### PR TITLE
CSS styles exported to an external, shared file

### DIFF
--- a/doc/en/readme.html
+++ b/doc/en/readme.html
@@ -4,19 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Vision Assistant Pro Documentation</title>
-<style>
-    body { font-family: "Segoe UI", Arial, sans-serif; line-height: 1.6; color: #333; max-width: 900px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
-    h1 { color: #2c3e50; border-bottom: 2px solid #2c3e50; padding-bottom: 10px; }
-    h2 { color: #34495e; margin-top: 30px; border-bottom: 1px solid #ddd; padding-bottom: 5px; }
-    h3 { color: #555; margin-top: 20px; }
-    code { background-color: #f0f0f0; padding: 2px 6px; border-radius: 4px; font-family: Consolas, monospace; color: #c7254e; }
-    table { width: 100%; border-collapse: collapse; margin-top: 15px; }
-    th, td { border: 1px solid #ddd; padding: 10px; text-align: left; vertical-align: top; }
-    th { background-color: #f8f9fa; color: #333; font-weight: bold; }
-    tr:nth-child(even) { background-color: #fcfcfc; }
-    .note { background-color: #e8f6f3; border-left: 5px solid #1abc9c; padding: 10px; margin: 15px 0; }
-    ul { margin: 0; padding-left: 20px; }
-</style>
+<link rel="stylesheet" href="../styles.css"/>
 </head>
 <body>
 

--- a/doc/styles.css
+++ b/doc/styles.css
@@ -1,0 +1,11 @@
+body { font-family: "Segoe UI", Arial, sans-serif; line-height: 1.6; color: #333; max-width: 900px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
+h1 { color: #2c3e50; border-bottom: 2px solid #2c3e50; padding-bottom: 10px; }
+h2 { color: #34495e; margin-top: 30px; border-bottom: 1px solid #ddd; padding-bottom: 5px; }
+h3 { color: #555; margin-top: 20px; }
+code { background-color: #f0f0f0; padding: 2px 6px; border-radius: 4px; font-family: Consolas, monospace; color: #c7254e; }
+table { width: 100%; border-collapse: collapse; margin-top: 15px; }
+th, td { border: 1px solid #ddd; padding: 10px; text-align: left; vertical-align: top; }
+th { background-color: #f8f9fa; color: #333; font-weight: bold; }
+tr:nth-child(even) { background-color: #fcfcfc; }
+.note { background-color: #e8f6f3; border-left: 5px solid #1abc9c; padding: 10px; margin: 15px 0; }
+ul { margin: 0; padding-left: 20px; }


### PR DESCRIPTION
Why repeat the styles in each `.html` file for different languages ​​when you can just export the styles to a separate `.css` file and plug it in.