### PR TITLE
Fixes .pot file generation

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -30,7 +30,7 @@ Features:
     addon_licenseURL="https://www.gnu.org/licenses/gpl-2.0.html",
 )
 
-pythonSources: list[str] = []
+pythonSources: list[str] = ["addon/globalPlugins/visionAssistant/*.py"]
 i18nSources = pythonSources + ["buildVars.py"]
 excludedFiles: list[str] = []
 


### PR DESCRIPTION
Add `addon/globalPlugins/.../*.py to `pythonSources` file list.
This is required to extract all strings from `.py` to `.pot`.