### PR TITLE
Remove unused class

### DIFF
--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -328,44 +328,6 @@ class VisionQADialog(wx.Dialog):
                 show_error_dialog(msg)
         fd.Destroy()
 
-class ResultDialog(wx.Dialog):
-    def __init__(self, parent, title, content):
-        super().__init__(parent, title=title, size=(600, 400), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        clean_content = clean_markdown(content)
-        self.text_ctrl = wx.TextCtrl(self, value=clean_content, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH)
-        sizer.Add(self.text_ctrl, 1, wx.EXPAND | wx.ALL, 10)
-        
-        btn_sizer = wx.StdDialogButtonSizer()
-        # Translators: Button to save content
-        self.saveBtn = wx.Button(self, label=_("Save to File"))
-        self.saveBtn.Bind(wx.EVT_BUTTON, self.onSave)
-        
-        # Translators: Close button label
-        closeBtn = wx.Button(self, wx.ID_OK, label=_("Close"))
-        
-        btn_sizer.AddButton(self.saveBtn)
-        btn_sizer.AddButton(closeBtn)
-        btn_sizer.Realize()
-        sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
-        self.SetSizer(sizer)
-        self.Centre()
-
-    def onSave(self, event):
-        # Translators: Save dialog title
-        fd = wx.FileDialog(self, _("Save Result"), wildcard="Text files (*.txt)|*.txt", style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
-        if fd.ShowModal() == wx.ID_OK:
-            path = fd.GetPath()
-            try:
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(self.text_ctrl.GetValue())
-                # Translators: Message on successful save
-                ui.message(_("Saved."))
-            except Exception as e:
-                msg = _("Save failed: {error}").format(error=e)
-                show_error_dialog(msg)
-        fd.Destroy()
-
 class SettingsPanel(gui.settingsDialogs.SettingsPanel):
     title = ADDON_NAME
     def makeSettings(self, settingsSizer):


### PR DESCRIPTION
Removed class `ResultDialog` which is unused.

This class contains translatable strings, so keeping this unused code adds more work for translators for nothing (as mentioned in #16).

If you plan to use this code in the future instead, feel free to discard this PR. But in this case, I'd recommend:
* To check translators comments in this class; I have not modified them in my previous PR since this was unused code and thus could not provide context
* If possible use object model design to avoid implementing twice the same things: `VisionQADialog` is quite similar so there would probably code to factorize in a base class.
