### PR TITLE
fix(translation): Respect direct output setting

### DIFF
--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -955,6 +955,8 @@ class VisionQADialog(wx.Dialog):
             wx.CallLater(300, ui.message, display_text)
 
     def onAsk(self, event):
+        if not self.inputArea:
+            return
         question = self.inputArea.Value
         if not question.strip(): return
         # Translators: Format for displaying User message in a chat dialog
@@ -2308,11 +2310,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             wx.CallAfter(self._announce_translation, clean_res)
 
     def _announce_translation(self, text):
-        if self._handle_direct_output(text):
-            return
+        if config.conf["VisionAssistant"]["copy_to_clipboard"] and not config.conf["VisionAssistant"]["skip_chat_dialog"]:
+            api.copyToClip(text)
         # Translators: Message reported when calling translation command
         msg = _("Translated: {text}").format(text=text)
-        self.current_status = msg
+        self.report_status(msg)
+        if self._handle_direct_output(text):
+            return
         wx.CallAfter(self._open_translation_dialog, text)
 
     def _open_translation_dialog(self, text):


### PR DESCRIPTION
## Summary
- Respect the "Direct Output (no chat window)" setting for translation output.
- When direct output is off, show the translation in a read-only dialog instead of speaking it automatically.

## Repro steps
1. Go to Settings > Vision Assistant Pro.
2. Uncheck "Direct Output (no chat window)".
3. Use Smart Translator (NVDA+Shift+V → T).

## Expected
- The translation appears in the chat window/dialog.
- It should not be spoken automatically unless direct output is enabled.

## Actual
- Translation is always spoken via TTS.
- No chat window appears even when direct output is unchecked.

## Impact
- Long translations are hard to review or navigate without a text window.

## How to test
1. Toggle "Direct Output (no chat window)" on/off.
2. When OFF: translation opens a read-only dialog (no auto-speech).
3. When ON: translation is spoken via TTS.

Closes #99