### PR TITLE
Prompt manager fixes

### DIFF
--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -1649,7 +1649,7 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
         promptsSizer = wx.StaticBoxSizer(promptsBox, wx.VERTICAL)
         pHelper = gui.guiHelper.BoxSizerHelper(promptsBox, sizer=promptsSizer)
         # Translators: Description for the prompt manager button.
-        pHelper.addItem(wx.StaticText(promptsBox, label=_("Manage default system prompts and custom refine prompts.")))
+        pHelper.addItem(wx.StaticText(promptsBox, label=_("Manage default and custom prompts.")))
         # Translators: Button label to open prompt manager dialog.
         self.managePromptsBtn = wx.Button(promptsBox, label=_("Manage Prompts..."))
         self.managePromptsBtn.Bind(wx.EVT_BUTTON, self.onManagePrompts)

--- a/addon/globalPlugins/visionAssistant/prompt_manager_dialog.py
+++ b/addon/globalPlugins/visionAssistant/prompt_manager_dialog.py
@@ -32,10 +32,6 @@ class PromptItemDialog(wx.Dialog):
         )
         main_sizer.Add(self.prompt_ctrl, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
-        # Translators: Helper text about custom prompt input capabilities.
-        hint = wx.StaticText(self, label=_("Custom prompt text supports multiple lines and '|' in v2. Legacy versions may not import these prompts."))
-        main_sizer.Add(hint, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
-
         button_sizer = wx.StdDialogButtonSizer()
         ok_btn = wx.Button(self, wx.ID_OK)
         ok_btn.SetDefault()


### PR DESCRIPTION
- Added an `internal: True` flag to built-in prompts that should not be user-editable in Prompt Manager.
- Updated `get_configured_default_prompts()` to exclude prompts marked as internal from the Default Prompts list shown in Prompt Manager.
- Removed redundant advanced key sorting logic and simplified sorting to `display_label` only.
- Simplified Settings description text:
  - from: "Manage default system prompts and custom refine prompts."
  - to: "Manage default and custom prompts."
- Removed the custom prompt hint text from the prompt item dialog.