### PR TITLE
Update pt_BR translations and donation copy

### DIFF
--- a/addon/locale/pt_BR/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_BR/LC_MESSAGES/nvda.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 'VisionAssistant' '4.5'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-02-09 15:25+0330\n"
+"POT-Creation-Date: 2026-02-16 17:43+0330\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Edilberto Fonseca <edilberto.fonseca@outlook.com>\n"
 "Language-Team: Edilberto Fonseca <edilberto.fonseca@outlook.com\n"
@@ -19,45 +19,62 @@ msgstr ""
 "X-Generator: Poedit 3.8\n"
 
 #. Translators: Label for the button to copy the TON cryptocurrency wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:17
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:18
 msgid "Copy TON Address"
 msgstr "Copiar endereço TON"
 
 #. Translators: Label for the button to copy the USDT (TRC20 network) wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:19
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:20
 msgid "Copy USDT (TRC20) Address"
 msgstr "Copiar endereço USDT (TRC20)"
 
+#. Translators: Label for the button to copy the support email address for gift cards.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:22
+msgid "Copy Support Email"
+msgstr "Copiar e-mail de suporte"
+
 #. Translators: Button to dismiss the donation dialog without taking any action.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:25
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:29
 msgid "Maybe Later"
 msgstr "Talvez mais tarde"
 
-#. Translators: Success message shown after a wallet address is copied to the clipboard.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:36
-msgid ""
-"Address copied to clipboard! If you'd like, you can now proceed to your "
-"wallet and donate any amount you can. Your support is greatly appreciated!"
-msgstr ""
-"Endereço copiado para a área de transferência! Se desejar, você pode agora "
-"acessar sua carteira e doar qualquer quantia que puder. Agradecemos "
-"imensamente o seu apoio!"
+#. Translators: Success message shown after an address or email is copied to the clipboard.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:40
+msgid "Copied to clipboard! Your support is greatly appreciated!"
+msgstr "Copiado para a área de transferência! Agradecemos muito o seu apoio!"
 
 #. Translators: Title for the success message box.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:38
-#: addon\globalPlugins\visionAssistant\__init__.py:2225
-#: addon\globalPlugins\visionAssistant\__init__.py:2273
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:42
+#: addon\globalPlugins\visionAssistant\__init__.py:2312
+#: addon\globalPlugins\visionAssistant\__init__.py:2360
 msgid "Success"
 msgstr "Sucesso"
 
 #. Translators: Title of the donation request dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:49
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
 #, python-brace-format
 msgid "Support the Future of {name}"
 msgstr "Apoie o futuro do {name}"
 
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
+#. Translators: The main message of the donation dialog.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:56
 #, python-brace-format
+#| msgid ""
+#| "{name} is a project born from a personal vision to bridge the gap between "
+#| "AI and true accessibility. The initial concept and many of the features "
+#| "you enjoy were created from my own ideas to solve real challenges and "
+#| "provide a new level of digital independence.\n"
+#| "\n"
+#| "I take great pride in thinking through every detail and turning both my "
+#| "own innovations and your valuable requests into reality. Ensuring this "
+#| "tool remains fast, stable, and constantly evolving is a continuous "
+#| "creative journey that I am passionate about pursuing.\n"
+#| "\n"
+#| "If this assistant has brought value to your daily life, your support is a "
+#| "wonderful way to show appreciation for the original work and the "
+#| "dedication behind it. It provides the extra motivation to keep the "
+#| "inspiration alive and ensures we can continue to push the boundaries "
+#| "together. Thank you for being part of this mission!"
 msgid ""
 "{name} is a project born from a personal vision to bridge the gap between AI "
 "and true accessibility. The initial concept and many of the features you "
@@ -69,29 +86,34 @@ msgid ""
 "remains fast, stable, and constantly evolving is a continuous creative "
 "journey that I am passionate about pursuing.\n"
 "\n"
+"Important Note: Due to international banking restrictions in my region, I am "
+"unable to use PayPal or Stripe. If you wish to support this project, you can "
+"donate via Cryptocurrency or by sending an Apple Gift Card (US region) to: "
+"{email}\n"
+"\n"
 "If this assistant has brought value to your daily life, your support is a "
 "wonderful way to show appreciation for the original work and the dedication "
-"behind it. It provides the extra motivation to keep the inspiration alive "
-"and ensures we can continue to push the boundaries together. Thank you for "
-"being part of this mission!"
+"behind it. Thank you for being part of this mission!"
 msgstr ""
-"{name} é um projeto que nasceu de uma visão pessoal para reduzir a distância "
-"entre a inteligência artificial e a acessibilidade de verdade. O conceito "
-"inicial e muitas das funcionalidades que você utiliza foram criados a partir "
-"das minhas próprias ideias, com o objetivo de resolver desafios reais e "
-"proporcionar um novo nível de independência digital.\n"
+"{name} é um projeto que nasce de uma visão pessoal para preencher a lacuna "
+"entre a IA e a verdadeira acessibilidade. O conceito inicial e muitos dos "
+"recursos que você gosta foram criados a partir de minhas próprias ideias "
+"para resolver desafios reais e fornecer um novo nível de independência "
+"digital.\n"
 "\n"
-"Tenho muito orgulho de pensar em cada detalhe e de transformar tanto as "
-"minhas próprias inovações quanto as suas valiosas sugestões em realidade. "
-"Garantir que esta ferramenta continue rápida, estável e em constante "
-"evolução é uma jornada criativa contínua, que sigo com muita dedicação e "
-"entusiasmo.\n"
+"Tenho muito orgulho de pensar em cada detalhe e transformar minhas próprias "
+"inovações e suas valiosas solicitações em realidade. Garantir que esta "
+"ferramenta permaneça rápida, estável e em constante evolução é uma jornada "
+"criativa contínua que adoro seguir.\n"
 "\n"
-"Se este assistente trouxe valor para o seu dia a dia, o seu apoio é uma "
-"excelente forma de demonstrar apreço pelo trabalho original e pela dedicação "
-"por trás dele. Esse apoio oferece motivação extra para manter a inspiração "
-"viva e garante que possamos continuar expandindo limites juntos. Obrigado "
-"por fazer parte desta missão!"
+"Observação importante: devido a restrições bancárias internacionais na minha "
+"região, não consigo usar PayPal ou Stripe. Se desejar apoiar este projeto, "
+"você pode doar via criptomoeda ou enviando um vale-presente da Apple (região "
+"dos EUA) para: {email}\n"
+"\n"
+"Se este assistente agregou valor ao seu dia a dia, seu apoio é uma ótima "
+"forma de demonstrar apreço pelo trabalho original e pela dedicação por trás "
+"dele. Obrigado por fazer parte desta missão!"
 
 #. Translators: Label for prompt name input field.
 #: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:20
@@ -101,173 +123,161 @@ msgstr "Nome:"
 #. Translators: Label for prompt text input field.
 #. Translators: Label above the prompt editor textarea.
 #: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:26
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:191
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:187
 msgid "Prompt Text:"
 msgstr "Texto do Prompt:"
 
-#. Translators: Helper text about custom prompt input capabilities.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:36
-msgid ""
-"Custom prompt text supports multiple lines and '|' in v2. Legacy versions "
-"may not import these prompts."
-msgstr ""
-"O texto personalizado do prompt suporta múltiplas linhas e o caractere "
-"'barra vertical' na versão v2. Versões legadas podem não importar esses "
-"prompts."
-
 #. Translators: Button label to open the variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:49
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:144
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:45
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:140
 msgid "Variables Guide"
 msgstr "Guia de Variáveis"
 
 #. Translators: Validation error for empty prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:66
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:62
 msgid "Name cannot be empty."
 msgstr "O nome não pode estar vazio."
 
 #. Translators: Title of validation warning dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:68
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:76
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:278
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:378
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:405
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:64
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:72
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:274
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:374
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:402
 msgid "Validation Error"
 msgstr "Erro de Validação"
 
 #. Translators: Validation error for empty prompt text.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:74
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:276
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:70
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:272
 msgid "Prompt text cannot be empty."
 msgstr "O texto do prompt não pode estar vazio."
 
 #. Translators: Title for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:97
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:93
 msgid "Prompt Variables Guide"
 msgstr "Guia de Variáveis do Prompt"
 
 #. Translators: Intro text for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:101
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:97
 msgid "Use these variables inside prompt text:"
 msgstr "Use estas variáveis dentro do texto do prompt:"
 
 #. Translators: Button to close chat dialog
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:112
-#: addon\globalPlugins\visionAssistant\__init__.py:1398
-#: addon\globalPlugins\visionAssistant\__init__.py:1934
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:108
+#: addon\globalPlugins\visionAssistant\__init__.py:1471
+#: addon\globalPlugins\visionAssistant\__init__.py:2015
 msgid "Close"
 msgstr "Fechar"
 
 #. Translators: Title for the prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:122
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:118
 msgid "Prompt Manager"
 msgstr "Gerenciador de Prompts"
 
 #. Translators: Notebook tab for built-in refine prompts.
 #. Translators: Label above the list of default prompt entries.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:134
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:168
-#| msgid "Custom Prompts"
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:130
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:164
 msgid "Default Prompts"
 msgstr "Prompts Padrão"
 
 #. Translators: Notebook tab for user-defined prompts.
 #. Translators: Label above the list of custom prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:136
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:223
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:132
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:219
 msgid "Custom Prompts"
 msgstr "Prompts Personalizados"
 
 #. Translators: Note explaining when prompt changes are persisted.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:148
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:144
 msgid "Changes are applied only when you press OK."
 msgstr "As alterações são aplicadas somente quando você pressionar OK."
 
 #. Translators: Button label to reset currently selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:180
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:176
 msgid "Reset Selected"
 msgstr "Redefinir Selecionado"
 
 #. Translators: Button label to reset all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:185
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:181
 msgid "Reset All"
 msgstr "Redefinir Tudo"
 
 #. Translators: Button label to apply current editor text to the selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:200
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:196
 msgid "Apply to Selected"
 msgstr "Aplicar ao Selecionados"
 
 #. Translators: Button label for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:228
 msgid "Add"
 msgstr "Adicionar"
 
 #. Translators: Button label for editing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:234
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:230
 msgid "Edit"
 msgstr "Editar"
 
 #. Translators: Button label for removing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:236
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
 msgid "Remove"
 msgstr "Remover"
 
 #. Translators: Button label for moving selected custom prompt up in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:247
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:243
 msgid "Move Up"
 msgstr "Mover para Cima"
 
 #. Translators: Button label for moving selected custom prompt down in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:249
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:245
 msgid "Move Down"
 msgstr "Mover para baixo"
 
 #. Translators: Label above the custom prompt preview area.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:258
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:254
 msgid "Prompt Preview:"
 msgstr "Visualização do Prompt:"
 
 #. Translators: Message shown after applying changes to the selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:301
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:297
 msgid "Selected prompt updated."
 msgstr "Prompt selecionado atualizado."
 
 #. Translators: Confirmation text before resetting all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:314
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:310
 msgid "Reset all default prompts to built-in values?"
 msgstr "Redefinir todos os prompts padrão para os valores integrados?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:316
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:312
 msgid "Confirm Reset"
 msgstr "Confirmar redefinição"
 
 #. Translators: Title of dialog for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:371
-#| msgid "Custom Prompts"
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:367
 msgid "Add Custom Prompt"
 msgstr "Adicionar Prompt Personalizado"
 
 #. Translators: Validation error for duplicate custom prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:376
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:403
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:372
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:400
 msgid "A custom prompt with this name already exists."
 msgstr "Já existe um prompt personalizado com esse nome."
 
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:394
-#| msgid "Custom Prompts"
+#. Translators: Title of the dialog for editing an existing custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:391
 msgid "Edit Custom Prompt"
 msgstr "Editar prompt personalizado"
 
 #. Translators: Confirmation text before deleting a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:418
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:415
 #, python-brace-format
 msgid "Remove custom prompt '{name}'?"
 msgstr "Remover o prompt personalizado '{name}'?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:420
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:417
 msgid "Confirm Remove"
 msgstr "Confirmar remoção"
 
@@ -303,478 +313,521 @@ msgstr "(Pré-visualização)"
 msgid "[Pro]"
 msgstr "[Prós]"
 
-#. Translators: Voice style description (e.g., Bright, Calm, Formal).
+#. Translators: Adjective describing a bright AI voice style.
 #: addon\globalPlugins\visionAssistant\__init__.py:84
-#: addon\globalPlugins\visionAssistant\__init__.py:93
+#: addon\globalPlugins\visionAssistant\__init__.py:102
 msgid "Bright"
 msgstr "Clara"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:85
-#: addon\globalPlugins\visionAssistant\__init__.py:102
+#. Translators: Adjective describing an upbeat AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:86
+#: addon\globalPlugins\visionAssistant\__init__.py:120
 msgid "Upbeat"
 msgstr "Otimista"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:86
-#: addon\globalPlugins\visionAssistant\__init__.py:101
+#. Translators: Adjective describing an informative AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:88
+#: addon\globalPlugins\visionAssistant\__init__.py:118
 msgid "Informative"
 msgstr "Informativa"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:87
+#. Translators: Adjective describing a firm AI voice style.
 #: addon\globalPlugins\visionAssistant\__init__.py:90
-#: addon\globalPlugins\visionAssistant\__init__.py:104
+#: addon\globalPlugins\visionAssistant\__init__.py:96
+#: addon\globalPlugins\visionAssistant\__init__.py:124
 msgid "Firm"
 msgstr "Firme"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:88
+#. Translators: Adjective describing an excitable AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:92
 msgid "Excitable"
 msgstr "Excitável"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:89
+#. Translators: Adjective describing a youthful AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:94
 msgid "Youthful"
 msgstr "Jovial"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:91
+#. Translators: Adjective describing a breezy AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:98
 msgid "Breezy"
 msgstr "Leve"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:92
-#: addon\globalPlugins\visionAssistant\__init__.py:96
+#. Translators: Adjective describing an easy-going AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:100
+#: addon\globalPlugins\visionAssistant\__init__.py:108
 msgid "Easy-going"
 msgstr "Descontraída"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:94
+#. Translators: Adjective describing a breathy AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:104
 msgid "Breathy"
 msgstr "Sussurrada"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:95
-#: addon\globalPlugins\visionAssistant\__init__.py:99
+#. Translators: Adjective describing a clear AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:106
+#: addon\globalPlugins\visionAssistant\__init__.py:114
 msgid "Clear"
 msgstr "Clara"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:97
-#: addon\globalPlugins\visionAssistant\__init__.py:98
+#. Translators: Adjective describing a smooth AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:110
+#: addon\globalPlugins\visionAssistant\__init__.py:112
 msgid "Smooth"
 msgstr "Suave"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:100
+#. Translators: Adjective describing a gravelly AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:116
 msgid "Gravelly"
 msgstr "Rascante"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:103
+#. Translators: Adjective describing a soft AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:122
 msgid "Soft"
 msgstr "Suave"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:105
+#. Translators: Adjective describing an even AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:126
 msgid "Even"
 msgstr "Uniforme"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:106
+#. Translators: Adjective describing a mature AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:128
 msgid "Mature"
 msgstr "Madura"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:107
+#. Translators: Adjective describing a forward AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:130
 msgid "Forward"
 msgstr "Confiante"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:108
+#. Translators: Adjective describing a friendly AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:132
 msgid "Friendly"
 msgstr "Amigável"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:109
+#. Translators: Adjective describing a casual AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:134
 msgid "Casual"
 msgstr "Casual"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:110
+#. Translators: Adjective describing a gentle AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:136
 msgid "Gentle"
 msgstr "Gentil"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:111
+#. Translators: Adjective describing a lively AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:138
 msgid "Lively"
 msgstr "Animada"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:112
+#. Translators: Adjective describing a knowledgeable AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:140
 msgid "Knowledgeable"
 msgstr "Conhecedora"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:113
+#. Translators: Adjective describing a warm AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:142
 msgid "Warm"
 msgstr "Acolhedora"
 
 #. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\__init__.py:134
+#: addon\globalPlugins\visionAssistant\__init__.py:163
 msgid "Chrome (Fast)"
 msgstr "Chrome (Rápido)"
 
 #. Translators: OCR Engine option (Slower but better formatting)
-#: addon\globalPlugins\visionAssistant\__init__.py:136
+#: addon\globalPlugins\visionAssistant\__init__.py:165
 msgid "Gemini (Formatted)"
 msgstr "Gemini (Formatado)"
 
+#. Translators: Section header for text refinement prompts in Prompt Manager.
 #. Translators: main message of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:203
-#: addon\globalPlugins\visionAssistant\__init__.py:209
-#: addon\globalPlugins\visionAssistant\__init__.py:215
-#: addon\globalPlugins\visionAssistant\__init__.py:221
-#: addon\globalPlugins\visionAssistant\__init__.py:2934
+#: addon\globalPlugins\visionAssistant\__init__.py:227
+#: addon\globalPlugins\visionAssistant\__init__.py:235
+#: addon\globalPlugins\visionAssistant\__init__.py:243
+#: addon\globalPlugins\visionAssistant\__init__.py:251
+#: addon\globalPlugins\visionAssistant\__init__.py:3022
 msgid "Refine"
 msgstr "Refinar"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:204
+#. Translators: Label for the text summarization prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:229
 msgid "Summarize"
 msgstr "Resumir"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:210
+#. Translators: Label for the grammar correction prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:237
 msgid "Fix Grammar"
 msgstr "Corrigir Gramática"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:216
+#. Translators: Label for the grammar correction and translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:245
 msgid "Fix Grammar & Translate"
 msgstr "Corrigir Gramática e Traduzir"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:222
+#. Translators: Label for the text explanation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:253
 msgid "Explain"
 msgstr "Explicar"
 
+#. Translators: Section header for translation-related prompts in Prompt Manager.
 #. Translators: Box title for translation options
-#: addon\globalPlugins\visionAssistant\__init__.py:227
-#: addon\globalPlugins\visionAssistant\__init__.py:233
-#: addon\globalPlugins\visionAssistant\__init__.py:1745
+#: addon\globalPlugins\visionAssistant\__init__.py:259
+#: addon\globalPlugins\visionAssistant\__init__.py:267
+#: addon\globalPlugins\visionAssistant\__init__.py:1824
 msgid "Translation"
 msgstr "Tradução"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:228
-#| msgid "Translation"
+#. Translators: Label for the smart translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:261
 msgid "Smart Translation"
 msgstr "Tradução Inteligente"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:234
-#| msgid "Translation"
+#. Translators: Label for the quick translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:269
 msgid "Quick Translation"
 msgstr "Tradução Rápida"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:239
-#: addon\globalPlugins\visionAssistant\__init__.py:333
-#| msgid "Docu&mentation"
+#. Translators: Section header for document-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:275
+#: addon\globalPlugins\visionAssistant\__init__.py:394
 msgid "Document"
 msgstr "Documento"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:240
-#| msgid "Docu&mentation"
+#. Translators: Label for the initial context prompt in document chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:277
 msgid "Document Chat Context"
 msgstr "Contexto do bate-papo do documento"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:245
-#: addon\globalPlugins\visionAssistant\__init__.py:275
-#: addon\globalPlugins\visionAssistant\__init__.py:281
-#: addon\globalPlugins\visionAssistant\__init__.py:352
+#. Translators: Section header for advanced/internal prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:283
+#: addon\globalPlugins\visionAssistant\__init__.py:320
+#: addon\globalPlugins\visionAssistant\__init__.py:329
+#: addon\globalPlugins\visionAssistant\__init__.py:418
 msgid "Advanced"
 msgstr "Avançado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:246
+#. Translators: Label for the AI's acknowledgement reply in document chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:285
 msgid "Document Chat Bootstrap Reply"
 msgstr "Resposta Inicial do Chat do Documento"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:251
-#: addon\globalPlugins\visionAssistant\__init__.py:263
+#. Translators: Section header for image analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:292
+#: addon\globalPlugins\visionAssistant\__init__.py:306
 msgid "Vision"
 msgstr "Visão"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:252
-#| msgid "Navigator Object"
+#. Translators: Label for the prompt used to analyze the current navigator object.
+#: addon\globalPlugins\visionAssistant\__init__.py:294
 msgid "Navigator Object Analysis"
 msgstr "Análise de objetos do navegador"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:264
-#| msgid "Full Screen"
+#. Translators: Label for the prompt used to analyze the entire screen.
+#: addon\globalPlugins\visionAssistant\__init__.py:308
 msgid "Full Screen Analysis"
 msgstr "Análise em tela cheia"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:276
+#. Translators: Label for the follow-up context in image analysis chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:322
 msgid "Vision Follow-up Context"
 msgstr "Contexto de Acompanhamento do Visão"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:282
+#. Translators: Label for the rule enforced during image analysis follow-up questions.
+#: addon\globalPlugins\visionAssistant\__init__.py:331
 msgid "Vision Follow-up Answer Rule"
 msgstr "Regra de Resposta para Acompanhamento do Visão"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:287
+#. Translators: Section header for video analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:338
 msgid "Video"
 msgstr "Vídeo"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:288
+#. Translators: Label for the video content analysis prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:340
 msgid "Video Analysis"
 msgstr "Análise de vídeo"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:297
-#: addon\globalPlugins\visionAssistant\__init__.py:303
-#| msgid "Save Audio"
+#. Translators: Section header for audio-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:350
+#: addon\globalPlugins\visionAssistant\__init__.py:358
 msgid "Audio"
 msgstr "Áudio"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:298
-#| msgid "Translation"
+#. Translators: Label for the audio file transcription prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:352
 msgid "Audio Transcription"
 msgstr "Transcrição de áudio"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:304
+#. Translators: Label for the smart voice dictation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:360
 msgid "Smart Dictation"
 msgstr "Ditado Inteligente"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:312
-#: addon\globalPlugins\visionAssistant\__init__.py:322
+#. Translators: Section header for OCR-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:369
+#: addon\globalPlugins\visionAssistant\__init__.py:381
 msgid "OCR"
 msgstr "OCR"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:313
+#. Translators: Label for the OCR prompt used for image text extraction.
+#: addon\globalPlugins\visionAssistant\__init__.py:371
 msgid "OCR Image Extraction"
 msgstr "Extração de imagem OCR"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:323
-#| msgid "Docu&mentation"
+#. Translators: Label for the OCR prompt used for document text extraction.
+#: addon\globalPlugins\visionAssistant\__init__.py:383
 msgid "OCR Document Extraction"
 msgstr "Extração de documentos OCR"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:334
-#| msgid "Document Reader"
+#. Translators: Label for the combined OCR and translation prompt for documents.
+#: addon\globalPlugins\visionAssistant\__init__.py:396
 msgid "Document OCR + Translate"
 msgstr "OCR de documentos mais tradução"
 
+#. Translators: Section header for CAPTCHA-related prompts in Prompt Manager.
 #. --- CAPTCHA Group ---
 #. Translators: Title of the settings group for CAPTCHA options
-#: addon\globalPlugins\visionAssistant\__init__.py:343
-#: addon\globalPlugins\visionAssistant\__init__.py:1635
+#: addon\globalPlugins\visionAssistant\__init__.py:406
+#: addon\globalPlugins\visionAssistant\__init__.py:1708
 msgid "CAPTCHA"
 msgstr "CAPTCHA"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:344
-#| msgid "CAPTCHA"
+#. Translators: Label for the CAPTCHA solving prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:408
 msgid "CAPTCHA Solver"
 msgstr "Resolvedor de CAPTCHA"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:353
+#. Translators: Label for the fallback prompt when only files are provided in Refine.
+#: addon\globalPlugins\visionAssistant\__init__.py:420
 msgid "Refine Files-Only Fallback"
 msgstr "Refinar Fallback Apenas para Arquivos"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:359
+#. Translators: Description and input type for the [selection] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:428
 msgid "Currently selected text"
 msgstr "Texto atualmente selecionado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:359
-#: addon\globalPlugins\visionAssistant\__init__.py:360
+#: addon\globalPlugins\visionAssistant\__init__.py:428
+#: addon\globalPlugins\visionAssistant\__init__.py:430
 msgid "Text"
 msgstr "Texto"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:360
-#| msgid "Clipboard empty."
+#. Translators: Description for the [clipboard] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:430
 msgid "Clipboard content"
 msgstr "Conteúdo da área de transferência"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:361
-#| msgid "Translates the selected text or navigator object."
+#. Translators: Description and input type for the [screen_obj] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:432
 msgid "Screenshot of the navigator object"
 msgstr "Captura de tela do objeto navegador"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:361
-#: addon\globalPlugins\visionAssistant\__init__.py:362
+#: addon\globalPlugins\visionAssistant\__init__.py:432
+#: addon\globalPlugins\visionAssistant\__init__.py:434
 msgid "Image"
 msgstr "Imagem"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:362
+#. Translators: Description for the [screen_full] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:434
 msgid "Screenshot of the entire screen"
 msgstr "Captura de tela da tela inteira"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:363
-#| msgid "Select Image/PDF/TIFF for OCR"
+#. Translators: Description and input type for the [file_ocr] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:436
 msgid "Select image/PDF/TIFF for text extraction"
 msgstr "Selecionar imagem/PDF/TIFF para extração de texto"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:363
+#: addon\globalPlugins\visionAssistant\__init__.py:436
 msgid "Image, PDF, TIFF"
 msgstr "Imagem, PDF, TIFF"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:364
-#| msgid "Select Document to Analyze"
+#. Translators: Description and input type for the [file_read] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:438
 msgid "Select document for reading"
 msgstr "Selecione o documento para leitura"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:364
+#: addon\globalPlugins\visionAssistant\__init__.py:438
 msgid "TXT, Code, PDF"
 msgstr "TXT, Code, PDF"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:365
-#| msgid "Select Audio File to Transcribe"
+#. Translators: Description and input type for the [file_audio] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:440
 msgid "Select audio file for analysis"
 msgstr "Selecione o arquivo de áudio para análise"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:365
+#: addon\globalPlugins\visionAssistant\__init__.py:440
 msgid "MP3, WAV, OGG"
 msgstr "MP3, WAV, OGG"
 
 #. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\__init__.py:614
+#: addon\globalPlugins\visionAssistant\__init__.py:687
 msgid "Custom: "
 msgstr "Personalizado: "
 
 #. Translators: Title of the error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:698
+#: addon\globalPlugins\visionAssistant\__init__.py:771
 #, python-brace-format
 msgid "{name} Error"
 msgstr "Erro em {name}"
 
 #. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\__init__.py:959
+#: addon\globalPlugins\visionAssistant\__init__.py:1034
 msgid "Error 400: Bad Request (Check API Key)"
 msgstr "Erro 400: Requisição inválida (verifique a chave de API)"
 
 #. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\__init__.py:961
+#: addon\globalPlugins\visionAssistant\__init__.py:1036
 msgid "Error 403: Forbidden (Check Region)"
 msgstr "Erro 403: Proibido (verifique a região)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1004
-#: addon\globalPlugins\visionAssistant\__init__.py:1129
+#: addon\globalPlugins\visionAssistant\__init__.py:1079
+#: addon\globalPlugins\visionAssistant\__init__.py:1200
 msgid "Error 429: Quota Exceeded (Try later)"
 msgstr "Erro 429: Cota Excedida (Tente mais tarde)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1007
-#: addon\globalPlugins\visionAssistant\__init__.py:1132
+#: addon\globalPlugins\visionAssistant\__init__.py:1082
+#: addon\globalPlugins\visionAssistant\__init__.py:1203
 #, python-brace-format
 msgid "Server Error {code}: {reason}"
 msgstr "Erro do Servidor {code}: {reason}"
 
 #. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:1017
+#: addon\globalPlugins\visionAssistant\__init__.py:1092
 msgid "No API Keys configured."
 msgstr "Nenhuma chave de API configurada."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1032
+#: addon\globalPlugins\visionAssistant\__init__.py:1107
 msgid "All API Keys failed (Quota/Server)."
 msgstr "Todas as chaves de API falharam (cota/servidor)."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1036
+#: addon\globalPlugins\visionAssistant\__init__.py:1111
 msgid "Unknown error occurred."
 msgstr "Ocorreu um erro desconhecido."
 
 #. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\__init__.py:1072
+#: addon\globalPlugins\visionAssistant\__init__.py:1143
 msgid "No API Keys."
 msgstr "Nenhuma chave de API."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1109
-#: addon\globalPlugins\visionAssistant\__init__.py:1831
-#: addon\globalPlugins\visionAssistant\__init__.py:3220
+#: addon\globalPlugins\visionAssistant\__init__.py:1180
+#: addon\globalPlugins\visionAssistant\__init__.py:1910
+#: addon\globalPlugins\visionAssistant\__init__.py:3308
 msgid "Upload failed."
 msgstr "Falha no envio."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1138
+#: addon\globalPlugins\visionAssistant\__init__.py:1209
 msgid "All keys failed."
 msgstr "Todas as chaves falharam."
 
 #. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1235
+#: addon\globalPlugins\visionAssistant\__init__.py:1306
 msgid "Update Available"
 msgstr "Atualização Disponível"
 
 #. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\__init__.py:1242
+#: addon\globalPlugins\visionAssistant\__init__.py:1313
 #, python-brace-format
 msgid "A new version ({version}) of {name} is available."
 msgstr "Uma nova versão ({version}) de {name} está disponível."
 
 #. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\__init__.py:1247
+#: addon\globalPlugins\visionAssistant\__init__.py:1318
 msgid "Changes:"
 msgstr "Mudanças:"
 
 #. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\__init__.py:1254
+#: addon\globalPlugins\visionAssistant\__init__.py:1325
 msgid "Download and Install?"
 msgstr "Baixar e instalar?"
 
 #. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\__init__.py:1259
+#: addon\globalPlugins\visionAssistant\__init__.py:1330
 msgid "&Yes"
 msgstr "&Sim"
 
 #. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\__init__.py:1261
+#: addon\globalPlugins\visionAssistant\__init__.py:1332
 msgid "&No"
 msgstr "&Não"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1302
+#. Translators: Error message when an update is found but the addon file is missing from GitHub.
+#: addon\globalPlugins\visionAssistant\__init__.py:1374
 msgid "Update found but no .nvda-addon file in release."
 msgstr "Atualização encontrada, mas nenhum arquivo .nvda-addon na release."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1305
+#. Translators: Status message informing the user they are already on the latest version.
+#: addon\globalPlugins\visionAssistant\__init__.py:1378
 msgid "You have the latest version."
 msgstr "Você já está usando a versão mais recente."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1309
+#: addon\globalPlugins\visionAssistant\__init__.py:1382
 #, python-brace-format
 msgid "Update check failed: {error}"
 msgstr "Falha ao verificar atualização: {error}"
 
 #. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\__init__.py:1328
+#: addon\globalPlugins\visionAssistant\__init__.py:1401
 msgid "Downloading update..."
 msgstr "Baixando atualização..."
 
 #. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1337
+#: addon\globalPlugins\visionAssistant\__init__.py:1410
 #, python-brace-format
 msgid "Download failed: {error}"
 msgstr "Falha no download: {error}"
 
 #. Translators: Label for the AI response text area in a chat dialog
 #. Translators: Label for AI Response Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1357
-#: addon\globalPlugins\visionAssistant\__init__.py:1599
+#: addon\globalPlugins\visionAssistant\__init__.py:1430
+#: addon\globalPlugins\visionAssistant\__init__.py:1672
 msgid "AI Response:"
 msgstr "Resposta da IA:"
 
 #. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1367
-#: addon\globalPlugins\visionAssistant\__init__.py:1455
-#: addon\globalPlugins\visionAssistant\__init__.py:1472
+#: addon\globalPlugins\visionAssistant\__init__.py:1440
+#: addon\globalPlugins\visionAssistant\__init__.py:1528
+#: addon\globalPlugins\visionAssistant\__init__.py:1545
 #, python-brace-format
 msgid "AI: {text}\n"
 msgstr "IA: {text}\n"
 
 #. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1378
+#: addon\globalPlugins\visionAssistant\__init__.py:1451
 msgid "Ask:"
 msgstr "Perguntar:"
 
 #. Translators: Button to send message in a chat dialog
 #. Translators: Button to send message
-#: addon\globalPlugins\visionAssistant\__init__.py:1388
-#: addon\globalPlugins\visionAssistant\__init__.py:1812
+#: addon\globalPlugins\visionAssistant\__init__.py:1461
+#: addon\globalPlugins\visionAssistant\__init__.py:1891
 msgid "Send"
 msgstr "Enviar"
 
 #. Translators: Button to view the content in a formatted HTML window
 #. Translators: Button to view formatted content
-#: addon\globalPlugins\visionAssistant\__init__.py:1390
-#: addon\globalPlugins\visionAssistant\__init__.py:1924
+#: addon\globalPlugins\visionAssistant\__init__.py:1463
+#: addon\globalPlugins\visionAssistant\__init__.py:2005
 msgid "View Formatted"
 msgstr "Ver formatado"
 
 #. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:1393
+#: addon\globalPlugins\visionAssistant\__init__.py:1466
 msgid "Save Content"
 msgstr "Salvar Conteúdo"
 
 #. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1396
+#: addon\globalPlugins\visionAssistant\__init__.py:1469
 msgid "Save Chat"
 msgstr "Salvar Chat"
 
 #. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1431
-#: addon\globalPlugins\visionAssistant\__init__.py:1470
+#: addon\globalPlugins\visionAssistant\__init__.py:1504
+#: addon\globalPlugins\visionAssistant\__init__.py:1543
 #, python-brace-format
 msgid ""
 "\n"
@@ -785,574 +838,577 @@ msgstr ""
 
 #. Translators: Message shown while processing in a chat dialog
 #. Translators: Message showing AI is thinking
-#: addon\globalPlugins\visionAssistant\__init__.py:1435
-#: addon\globalPlugins\visionAssistant\__init__.py:1847
+#: addon\globalPlugins\visionAssistant\__init__.py:1508
+#: addon\globalPlugins\visionAssistant\__init__.py:1926
 msgid "Thinking..."
 msgstr "Pensando..."
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:1492
+#: addon\globalPlugins\visionAssistant\__init__.py:1565
 msgid "Formatted Conversation"
 msgstr "Conversa formatada"
 
 #. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:1495
+#: addon\globalPlugins\visionAssistant\__init__.py:1568
 #, python-brace-format
 msgid "Error displaying content: {error}"
 msgstr "Erro ao exibir o conteúdo: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:1500
+#: addon\globalPlugins\visionAssistant\__init__.py:1573
 msgid "Save Chat Log"
 msgstr "Salvar Registro do Chat"
 
+#. Translators: Message shown on successful save of a file.
 #. Translators: Message on successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:1505
-#: addon\globalPlugins\visionAssistant\__init__.py:1519
+#: addon\globalPlugins\visionAssistant\__init__.py:1578
+#: addon\globalPlugins\visionAssistant\__init__.py:1592
 msgid "Saved."
 msgstr "Salvo."
 
 #. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1508
-#: addon\globalPlugins\visionAssistant\__init__.py:1522
+#: addon\globalPlugins\visionAssistant\__init__.py:1581
+#: addon\globalPlugins\visionAssistant\__init__.py:1595
 #, python-brace-format
 msgid "Save failed: {error}"
 msgstr "Falha ao salvar: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:1513
+#: addon\globalPlugins\visionAssistant\__init__.py:1586
 msgid "Save Result"
 msgstr "Salvar Resultado"
 
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\__init__.py:1530
+#: addon\globalPlugins\visionAssistant\__init__.py:1603
 msgid "Connection"
 msgstr "Conexão"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\__init__.py:1536
+#: addon\globalPlugins\visionAssistant\__init__.py:1609
 msgid "Gemini API Key (Separate multiple keys with comma or newline):"
 msgstr "Chave API Gemini (separe várias chaves com vírgula ou nova linha):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\__init__.py:1550
+#: addon\globalPlugins\visionAssistant\__init__.py:1623
 msgid "Show API Key"
 msgstr "Mostrar chave API"
 
 #. Translators: Label for Model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1556
+#: addon\globalPlugins\visionAssistant\__init__.py:1629
 msgid "AI Model:"
 msgstr "Modelo de IA:"
 
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:1564
+#: addon\globalPlugins\visionAssistant\__init__.py:1637
 msgid "Proxy URL:"
 msgstr "URL do Proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on NVDA startup
-#: addon\globalPlugins\visionAssistant\__init__.py:1568
+#: addon\globalPlugins\visionAssistant\__init__.py:1641
 msgid "Check for updates on startup"
 msgstr "Verificar atualizações na inicialização"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\__init__.py:1571
+#: addon\globalPlugins\visionAssistant\__init__.py:1644
 msgid "Clean Markdown in Chat"
 msgstr "Markdown Limpo no Chat"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:1574
+#: addon\globalPlugins\visionAssistant\__init__.py:1647
 msgid "Copy AI responses to clipboard"
 msgstr "Copiar respostas da IA para a área de transferência"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\__init__.py:1577
+#: addon\globalPlugins\visionAssistant\__init__.py:1650
 msgid "Direct Output (No Chat Window)"
 msgstr "Saída direta (sem janela de bate-papo)"
 
 #. --- Translation Languages Group ---
 #. Translators: Title of the settings group for translation languages configuration
-#: addon\globalPlugins\visionAssistant\__init__.py:1583
+#: addon\globalPlugins\visionAssistant\__init__.py:1656
 msgid "Translation Languages"
 msgstr "Idiomas da Tradução"
 
 #. Translators: Label for Source Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1589
+#: addon\globalPlugins\visionAssistant\__init__.py:1662
 msgid "Source:"
 msgstr "Origem:"
 
 #. Translators: Label for Target Language selection
 #. Translators: Label for target language
-#: addon\globalPlugins\visionAssistant\__init__.py:1594
-#: addon\globalPlugins\visionAssistant\__init__.py:1751
+#: addon\globalPlugins\visionAssistant\__init__.py:1667
+#: addon\globalPlugins\visionAssistant\__init__.py:1830
 msgid "Target:"
 msgstr "Destino:"
 
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\__init__.py:1604
+#: addon\globalPlugins\visionAssistant\__init__.py:1677
 msgid "Smart Swap"
 msgstr "Troca Inteligente"
 
 #. --- Document Reader Settings ---
 #. Translators: Title of settings group for Document Reader features
-#: addon\globalPlugins\visionAssistant\__init__.py:1610
+#. Translators: Title of the Document Reader window.
+#: addon\globalPlugins\visionAssistant\__init__.py:1683
+#: addon\globalPlugins\visionAssistant\__init__.py:1948
 msgid "Document Reader"
 msgstr "Leitor de documentos"
 
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1616
+#: addon\globalPlugins\visionAssistant\__init__.py:1689
 msgid "OCR Engine:"
 msgstr "Mecanismo de OCR:"
 
 #. Translators: Label for TTS Voice selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1625
+#: addon\globalPlugins\visionAssistant\__init__.py:1698
 msgid "TTS Voice:"
 msgstr "Voz TTS:"
 
 #. Translators: Label for CAPTCHA capture method selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1640
+#: addon\globalPlugins\visionAssistant\__init__.py:1713
 msgid "Capture Method:"
 msgstr "Método de Captura:"
 
 #. Translators: A choice for capture method. Captures only the specific object under the NVDA navigator cursor.
-#: addon\globalPlugins\visionAssistant\__init__.py:1642
+#: addon\globalPlugins\visionAssistant\__init__.py:1715
 msgid "Navigator Object"
 msgstr "Objeto do Navegador"
 
 #. Translators: A choice for capture method. Captures the entire visible screen area.
-#: addon\globalPlugins\visionAssistant\__init__.py:1644
+#: addon\globalPlugins\visionAssistant\__init__.py:1717
 msgid "Full Screen"
 msgstr "Tela Inteira"
 
 #. --- Prompt Manager Group ---
 #. Translators: Title of the settings group for prompt management
-#: addon\globalPlugins\visionAssistant\__init__.py:1654
-#| msgid "Custom Prompts"
+#: addon\globalPlugins\visionAssistant\__init__.py:1727
 msgid "Prompts"
 msgstr "Prompts"
 
 #. Translators: Description for the prompt manager button.
-#: addon\globalPlugins\visionAssistant\__init__.py:1659
-msgid "Manage default system prompts and custom refine prompts."
-msgstr ""
-"Gerenciar prompts padrão do sistema e prompts personalizados de refinamento."
+#: addon\globalPlugins\visionAssistant\__init__.py:1732
+msgid "Manage default and custom prompts."
+msgstr "Gerencie prompts padrão e personalizados."
 
 #. Translators: Button label to open prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:1661
+#: addon\globalPlugins\visionAssistant\__init__.py:1734
 msgid "Manage Prompts..."
 msgstr "Gerenciar Prompts..."
 
 #. Translators: Summary text for prompt counts in settings.
-#: addon\globalPlugins\visionAssistant\__init__.py:1671
+#: addon\globalPlugins\visionAssistant\__init__.py:1744
 #, python-brace-format
 msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
 msgstr "Prompts padrão: {defaultCount}, Prompts personalizados: {customCount}"
 
 #. Translators: Title of the PDF options dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1725
+#: addon\globalPlugins\visionAssistant\__init__.py:1804
 msgid "Options"
 msgstr "Opções"
 
 #. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:1728
+#: addon\globalPlugins\visionAssistant\__init__.py:1807
 #, python-brace-format
 msgid "Total Pages (All Files): {count}"
 msgstr "Total de páginas (todos os arquivos): {count}"
 
 #. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1731
+#: addon\globalPlugins\visionAssistant\__init__.py:1810
 msgid "Range"
 msgstr "Intervalo"
 
 #. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\__init__.py:1734
+#: addon\globalPlugins\visionAssistant\__init__.py:1813
 msgid "From:"
 msgstr "De:"
 
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\__init__.py:1738
+#: addon\globalPlugins\visionAssistant\__init__.py:1817
 msgid "To:"
 msgstr "Para:"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\__init__.py:1747
+#: addon\globalPlugins\visionAssistant\__init__.py:1826
 msgid "Translate Output"
 msgstr "Traduzir saída"
 
 #. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\__init__.py:1760
+#: addon\globalPlugins\visionAssistant\__init__.py:1839
 msgid "Start"
 msgstr "Começar"
 
 #. Translators: Button to cancel
-#: addon\globalPlugins\visionAssistant\__init__.py:1763
+#: addon\globalPlugins\visionAssistant\__init__.py:1842
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1788
+#: addon\globalPlugins\visionAssistant\__init__.py:1867
 msgid "Ask about Document"
 msgstr "Perguntar sobre o documento"
 
 #. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\__init__.py:1797
+#: addon\globalPlugins\visionAssistant\__init__.py:1876
 #, python-brace-format
 msgid "File: {name}"
 msgstr "Arquivo: {name}"
 
 #. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\__init__.py:1802
+#: addon\globalPlugins\visionAssistant\__init__.py:1881
 msgid "Uploading to Gemini...\n"
 msgstr "Enviando para o Gemini...\n"
 
 #. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\__init__.py:1806
+#: addon\globalPlugins\visionAssistant\__init__.py:1885
 msgid "Your Question:"
 msgstr "Sua pergunta:"
 
 #. Translators: Message when ready to chat
-#: addon\globalPlugins\visionAssistant\__init__.py:1837
+#: addon\globalPlugins\visionAssistant\__init__.py:1916
 msgid "Ready! Ask your questions.\n"
 msgstr "Pronto! Faça suas perguntas.\n"
 
 #. Translators: Initial status when the add-on is doing nothing
 #. Translators: Status message when the add-on is doing nothing
-#: addon\globalPlugins\visionAssistant\__init__.py:1857
-#: addon\globalPlugins\visionAssistant\__init__.py:2136
+#: addon\globalPlugins\visionAssistant\__init__.py:1936
 #: addon\globalPlugins\visionAssistant\__init__.py:2223
-#: addon\globalPlugins\visionAssistant\__init__.py:2227
-#: addon\globalPlugins\visionAssistant\__init__.py:2291
-#: addon\globalPlugins\visionAssistant\__init__.py:2488
-#: addon\globalPlugins\visionAssistant\__init__.py:3082
-#: addon\globalPlugins\visionAssistant\__init__.py:3198
-#: addon\globalPlugins\visionAssistant\__init__.py:3203
-#: addon\globalPlugins\visionAssistant\__init__.py:3219
-#: addon\globalPlugins\visionAssistant\__init__.py:3232
-#: addon\globalPlugins\visionAssistant\__init__.py:3241
+#: addon\globalPlugins\visionAssistant\__init__.py:2310
+#: addon\globalPlugins\visionAssistant\__init__.py:2314
+#: addon\globalPlugins\visionAssistant\__init__.py:2378
+#: addon\globalPlugins\visionAssistant\__init__.py:2576
+#: addon\globalPlugins\visionAssistant\__init__.py:3170
+#: addon\globalPlugins\visionAssistant\__init__.py:3286
+#: addon\globalPlugins\visionAssistant\__init__.py:3291
+#: addon\globalPlugins\visionAssistant\__init__.py:3307
+#: addon\globalPlugins\visionAssistant\__init__.py:3320
 #: addon\globalPlugins\visionAssistant\__init__.py:3329
-#: addon\globalPlugins\visionAssistant\__init__.py:3333
-#: addon\globalPlugins\visionAssistant\__init__.py:3397
-#: addon\globalPlugins\visionAssistant\__init__.py:3411
-#: addon\globalPlugins\visionAssistant\__init__.py:3415
-#: addon\globalPlugins\visionAssistant\__init__.py:3420
-#: addon\globalPlugins\visionAssistant\__init__.py:3506
-#: addon\globalPlugins\visionAssistant\__init__.py:3519
-#: addon\globalPlugins\visionAssistant\__init__.py:3523
-#: addon\globalPlugins\visionAssistant\__init__.py:3559
-#: addon\globalPlugins\visionAssistant\__init__.py:3569
+#: addon\globalPlugins\visionAssistant\__init__.py:3417
+#: addon\globalPlugins\visionAssistant\__init__.py:3421
+#: addon\globalPlugins\visionAssistant\__init__.py:3485
+#: addon\globalPlugins\visionAssistant\__init__.py:3499
+#: addon\globalPlugins\visionAssistant\__init__.py:3503
+#: addon\globalPlugins\visionAssistant\__init__.py:3508
+#: addon\globalPlugins\visionAssistant\__init__.py:3594
+#: addon\globalPlugins\visionAssistant\__init__.py:3607
+#: addon\globalPlugins\visionAssistant\__init__.py:3611
+#: addon\globalPlugins\visionAssistant\__init__.py:3647
+#: addon\globalPlugins\visionAssistant\__init__.py:3657
 msgid "Idle"
 msgstr "Ocioso"
 
 #. Translators: Spoken prefix for AI response
-#: addon\globalPlugins\visionAssistant\__init__.py:1864
+#: addon\globalPlugins\visionAssistant\__init__.py:1943
 msgid "AI: "
 msgstr "AI: "
 
 #. Translators: Initial status message
-#: addon\globalPlugins\visionAssistant\__init__.py:1887
+#: addon\globalPlugins\visionAssistant\__init__.py:1968
 msgid "Initializing..."
 msgstr "Inicializando..."
 
 #. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\__init__.py:1893
+#: addon\globalPlugins\visionAssistant\__init__.py:1974
 msgid "Previous (Ctrl+PageUp)"
 msgstr "Anterior (Ctrl+PageUp)"
 
 #. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\__init__.py:1897
+#: addon\globalPlugins\visionAssistant\__init__.py:1978
 msgid "Next (Ctrl+PageDown)"
 msgstr "Próximo (Ctrl+PageDown)"
 
 #. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\__init__.py:1901
+#: addon\globalPlugins\visionAssistant\__init__.py:1982
 msgid "Go to:"
 msgstr "Ir para:"
 
 #. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\__init__.py:1909
+#: addon\globalPlugins\visionAssistant\__init__.py:1990
 msgid "Ask AI (Alt+A)"
 msgstr "Pergunte à IA (Alt+A)"
 
 #. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\__init__.py:1914
+#: addon\globalPlugins\visionAssistant\__init__.py:1995
 msgid "Re-scan with Gemini (Alt+R)"
 msgstr "Reescanear com o Gemini (Alt+R)"
 
 #. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\__init__.py:1919
+#: addon\globalPlugins\visionAssistant\__init__.py:2000
 msgid "Generate Audio (Alt+G)"
 msgstr "Gerar áudio (Alt+G)"
 
 #. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\__init__.py:1929
+#: addon\globalPlugins\visionAssistant\__init__.py:2010
 msgid "Save (Alt+S)"
 msgstr "Salvar (Alt+S)"
 
 #. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\__init__.py:1968
+#: addon\globalPlugins\visionAssistant\__init__.py:2049
 #, python-brace-format
 msgid "Page {num} ready"
 msgstr "Página {num} pronta"
 
 #. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\__init__.py:1990
+#: addon\globalPlugins\visionAssistant\__init__.py:2071
 msgid "[OCR failed. Try Gemini Re-scan.]"
 msgstr "[OCR falhou. Experimente a nova varredura do Gemini.]"
 
 #. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1999
+#: addon\globalPlugins\visionAssistant\__init__.py:2080
 msgid "Error processing page."
 msgstr "Erro ao processar a página."
 
 #. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\__init__.py:2004
+#: addon\globalPlugins\visionAssistant\__init__.py:2085
 #, python-brace-format
 msgid "Page {current} of {total}"
 msgstr "Página {current} de {total}"
 
 #. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\__init__.py:2011
+#: addon\globalPlugins\visionAssistant\__init__.py:2092
 msgid "Processing in background..."
 msgstr "Processando em segundo plano..."
 
 #. Translators: Spoken message when switching pages
 #. Translators: Heading for each page in the formatted content view.
-#: addon\globalPlugins\visionAssistant\__init__.py:2022
-#: addon\globalPlugins\visionAssistant\__init__.py:2041
+#: addon\globalPlugins\visionAssistant\__init__.py:2103
+#: addon\globalPlugins\visionAssistant\__init__.py:2122
 #, python-brace-format
 msgid "Page {num}"
 msgstr "Página {num}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:2054
+#: addon\globalPlugins\visionAssistant\__init__.py:2135
 msgid "Formatted Content"
 msgstr "Conteúdo formatado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2060
-#: addon\globalPlugins\visionAssistant\__init__.py:2145
+#: addon\globalPlugins\visionAssistant\__init__.py:2141
 #: addon\globalPlugins\visionAssistant\__init__.py:2232
+#: addon\globalPlugins\visionAssistant\__init__.py:2319
 msgid "Please configure Gemini API Key."
 msgstr "Por favor, configure a chave de API do Gemini."
 
 #. Translators: Status reported when an error occurs
-#: addon\globalPlugins\visionAssistant\__init__.py:2060
-#: addon\globalPlugins\visionAssistant\__init__.py:2145
+#: addon\globalPlugins\visionAssistant\__init__.py:2141
 #: addon\globalPlugins\visionAssistant\__init__.py:2232
-#: addon\globalPlugins\visionAssistant\__init__.py:2600
-#: addon\globalPlugins\visionAssistant\__init__.py:2607
-#: addon\globalPlugins\visionAssistant\__init__.py:2676
+#: addon\globalPlugins\visionAssistant\__init__.py:2319
+#: addon\globalPlugins\visionAssistant\__init__.py:2688
+#: addon\globalPlugins\visionAssistant\__init__.py:2695
+#: addon\globalPlugins\visionAssistant\__init__.py:2764
 msgid "Error"
 msgstr "Erro"
 
 #. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\__init__.py:2064
+#: addon\globalPlugins\visionAssistant\__init__.py:2145
 msgid "Current Page"
 msgstr "Página atual"
 
 #. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2066
+#: addon\globalPlugins\visionAssistant\__init__.py:2147
 msgid "All Pages (In Range)"
 msgstr "Todas as páginas (dentro do intervalo)"
 
 #. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\__init__.py:2076
+#: addon\globalPlugins\visionAssistant\__init__.py:2157
 msgid "Scanning with Gemini..."
 msgstr "Escaneando com o Gemini..."
 
 #. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2092
+#: addon\globalPlugins\visionAssistant\__init__.py:2173
 msgid "Scan complete"
 msgstr "Varredura concluída"
 
 #. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\__init__.py:2100
+#: addon\globalPlugins\visionAssistant\__init__.py:2181
 msgid "Batch Processing Started"
 msgstr "Processamento em lote iniciado"
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:2111
+#: addon\globalPlugins\visionAssistant\__init__.py:2192
 msgid "Error creating temporary PDF."
 msgstr "Erro ao criar PDF temporário."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2119
+#: addon\globalPlugins\visionAssistant\__init__.py:2200
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2120
+#. Translators: Message reported when batch scan fails
+#: addon\globalPlugins\visionAssistant\__init__.py:2202
 #, python-brace-format
 msgid "Scan failed: {err}"
 msgstr "Falha na varredura: {err}"
 
 #. Translators: Message when batch scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2133
+#: addon\globalPlugins\visionAssistant\__init__.py:2220
 msgid "Batch Scan Complete"
 msgstr "Varredura em lote concluída"
 
 #. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\__init__.py:2149
+#: addon\globalPlugins\visionAssistant\__init__.py:2236
 msgid "Generate for Current Page"
 msgstr "Gerar para a página atual"
 
 #. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2151
+#: addon\globalPlugins\visionAssistant\__init__.py:2238
 msgid "Generate for All Pages (In Range)"
 msgstr "Gerar para todas as páginas (no intervalo)"
 
 #. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\__init__.py:2161
+#: addon\globalPlugins\visionAssistant\__init__.py:2248
 msgid "No text to read."
 msgstr "Nenhum texto para ler."
 
 #. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\__init__.py:2171
+#: addon\globalPlugins\visionAssistant\__init__.py:2258
 msgid "Gathering text for audio..."
 msgstr "Coletando texto para áudio..."
 
 #. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2181
+#: addon\globalPlugins\visionAssistant\__init__.py:2268
 msgid "Save Audio"
 msgstr "Salvar áudio"
 
 #. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2188
+#: addon\globalPlugins\visionAssistant\__init__.py:2275
 msgid "Generating Audio..."
 msgstr "Gerando áudio..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2204
+#: addon\globalPlugins\visionAssistant\__init__.py:2291
 msgid "lame.exe not found in lib folder."
 msgstr "lame.exe não encontrado na pasta lib."
 
 #. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:2222
+#: addon\globalPlugins\visionAssistant\__init__.py:2309
 msgid "Audio Saved"
 msgstr "Áudio salvo"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2225
+#: addon\globalPlugins\visionAssistant\__init__.py:2312
 msgid "Audio file generated and saved successfully."
 msgstr "Arquivo de áudio gerado e salvo com sucesso."
 
 #. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\__init__.py:2247
+#: addon\globalPlugins\visionAssistant\__init__.py:2334
 msgid "Save"
 msgstr "Salvar"
 
 #. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\__init__.py:2258
+#: addon\globalPlugins\visionAssistant\__init__.py:2345
 #, python-brace-format
 msgid "Saving Page {num}..."
 msgstr "Salvando página {num}..."
 
 #. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2271
+#: addon\globalPlugins\visionAssistant\__init__.py:2358
 msgid "Saved"
 msgstr "Salvo"
 
 #. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:2273
+#: addon\globalPlugins\visionAssistant\__init__.py:2360
 msgid "File saved successfully."
 msgstr "Arquivo salvo com sucesso."
 
 #. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:2308
+#: addon\globalPlugins\visionAssistant\__init__.py:2395
 msgid "&Document Reader..."
 msgstr "&Leitor de documentos..."
 
 #. Translators: Menu item for Audio Transcription
-#: addon\globalPlugins\visionAssistant\__init__.py:2312
+#: addon\globalPlugins\visionAssistant\__init__.py:2399
 msgid "Transcribe &Audio File..."
 msgstr "Transcrever arquivo de &áudio..."
 
 #. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:2316
+#: addon\globalPlugins\visionAssistant\__init__.py:2403
 msgid "Analyze &Video URL..."
 msgstr "Analisar URL de &vídeo..."
 
 #. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:2322
+#: addon\globalPlugins\visionAssistant\__init__.py:2409
 msgid "&Settings..."
 msgstr "&Configurações..."
 
 #. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:2326
+#: addon\globalPlugins\visionAssistant\__init__.py:2413
 msgid "Check for &Update"
 msgstr "Verificar &atualizações"
 
 #. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:2330
+#: addon\globalPlugins\visionAssistant\__init__.py:2417
 msgid "Docu&mentation"
 msgstr "Docu&mentação"
 
 #. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:2334
+#: addon\globalPlugins\visionAssistant\__init__.py:2421
 msgid "D&onate"
 msgstr "D&oar"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2338
+#. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
+#: addon\globalPlugins\visionAssistant\__init__.py:2426
 msgid "Vision Assistant"
 msgstr "Assistente de Visão"
 
 #. Translators: Standard title for opening a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2352
-#: addon\globalPlugins\visionAssistant\__init__.py:2494
-#: addon\globalPlugins\visionAssistant\__init__.py:2961
+#: addon\globalPlugins\visionAssistant\__init__.py:2440
+#: addon\globalPlugins\visionAssistant\__init__.py:2582
+#: addon\globalPlugins\visionAssistant\__init__.py:3049
 msgid "Open"
 msgstr "Abrir"
 
 #. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:2360
+#: addon\globalPlugins\visionAssistant\__init__.py:2448
 msgid "Supported Files"
 msgstr "Arquivos Suportados"
 
 #. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:2367
-#: addon\globalPlugins\visionAssistant\__init__.py:3144
+#: addon\globalPlugins\visionAssistant\__init__.py:2455
+#: addon\globalPlugins\visionAssistant\__init__.py:3232
 msgid "PyMuPDF library is missing."
 msgstr "A biblioteca PyMuPDF está ausente."
 
 #. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:2373
-#: addon\globalPlugins\visionAssistant\__init__.py:3150
+#: addon\globalPlugins\visionAssistant\__init__.py:2461
+#: addon\globalPlugins\visionAssistant\__init__.py:3238
 msgid "No readable pages found."
 msgstr "Nenhuma página legível encontrada."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2407
+#: addon\globalPlugins\visionAssistant\__init__.py:2495
 msgid "Activates the Command Layer for quick access to all features."
 msgstr "Ativa a Camada de Comandos para acesso rápido a todos os recursos."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2465
-#: addon\globalPlugins\visionAssistant\__init__.py:2776
+#: addon\globalPlugins\visionAssistant\__init__.py:2553
+#: addon\globalPlugins\visionAssistant\__init__.py:2864
 msgid "Translates the selected text or navigator object."
 msgstr "Traduz o texto selecionado ou objeto do navegador."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2466
-#: addon\globalPlugins\visionAssistant\__init__.py:3611
+#: addon\globalPlugins\visionAssistant\__init__.py:2554
+#: addon\globalPlugins\visionAssistant\__init__.py:3699
 msgid "Translates the text currently in the clipboard."
 msgstr "Traduz o texto atualmente na área de transferência."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2467
-#: addon\globalPlugins\visionAssistant\__init__.py:2905
+#: addon\globalPlugins\visionAssistant\__init__.py:2555
+#: addon\globalPlugins\visionAssistant\__init__.py:2993
 msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
 msgstr "Abre um menu para Explicar, Resumir ou Corrigir o texto selecionado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2468
-#: addon\globalPlugins\visionAssistant\__init__.py:3293
+#: addon\globalPlugins\visionAssistant\__init__.py:2556
+#: addon\globalPlugins\visionAssistant\__init__.py:3381
 msgid "Performs OCR and description on the entire screen."
 msgstr "Realiza OCR e descrição da tela inteira."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2469
-#: addon\globalPlugins\visionAssistant\__init__.py:3299
+#: addon\globalPlugins\visionAssistant\__init__.py:2557
+#: addon\globalPlugins\visionAssistant\__init__.py:3387
 msgid "Describes the current object (Navigator Object)."
 msgstr "Descreve o objeto atual (Objeto do Navegador)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2470
-#: addon\globalPlugins\visionAssistant\__init__.py:3244
+#: addon\globalPlugins\visionAssistant\__init__.py:2558
+#: addon\globalPlugins\visionAssistant\__init__.py:3332
 msgid ""
 "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
 msgstr ""
@@ -1360,243 +1416,241 @@ msgstr ""
 "(PDF/Imagens)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2471
-#: addon\globalPlugins\visionAssistant\__init__.py:3131
+#: addon\globalPlugins\visionAssistant\__init__.py:2559
+#: addon\globalPlugins\visionAssistant\__init__.py:3219
 msgid "Recognizes text from a selected image or PDF file."
 msgstr "Reconhece texto de uma imagem ou arquivo PDF selecionado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2472
-#: addon\globalPlugins\visionAssistant\__init__.py:3379
+#: addon\globalPlugins\visionAssistant\__init__.py:2560
+#: addon\globalPlugins\visionAssistant\__init__.py:3467
 msgid "Transcribes a selected audio file."
 msgstr "Transcreve um arquivo de áudio selecionado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2473
-#: addon\globalPlugins\visionAssistant\__init__.py:3423
+#: addon\globalPlugins\visionAssistant\__init__.py:2561
+#: addon\globalPlugins\visionAssistant\__init__.py:3511
 msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
 msgstr "Analisa uma URL de vídeo do YouTube, Instagram, Twitter ou TikTok."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2474
-#: addon\globalPlugins\visionAssistant\__init__.py:3526
+#: addon\globalPlugins\visionAssistant\__init__.py:2562
+#: addon\globalPlugins\visionAssistant\__init__.py:3614
 msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
 msgstr "Tenta resolver um CAPTCHA na tela ou no objeto do navegador."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2475
-#: addon\globalPlugins\visionAssistant\__init__.py:2683
+#: addon\globalPlugins\visionAssistant\__init__.py:2563
+#: addon\globalPlugins\visionAssistant\__init__.py:2771
 msgid "Records voice, transcribes it using AI, and types the result."
 msgstr "Grava a voz, a transcreve usando IA e digita o resultado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2476
-#: addon\globalPlugins\visionAssistant\__init__.py:2484
+#: addon\globalPlugins\visionAssistant\__init__.py:2564
+#: addon\globalPlugins\visionAssistant\__init__.py:2572
 msgid "Announces the current status of the add-on."
 msgstr "Anuncia o status atual do complemento."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2477
-#: addon\globalPlugins\visionAssistant\__init__.py:3580
+#: addon\globalPlugins\visionAssistant\__init__.py:2565
+#: addon\globalPlugins\visionAssistant\__init__.py:3668
 msgid "Checks for updates manually."
 msgstr "Verifica atualizações manualmente."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2478
+#: addon\globalPlugins\visionAssistant\__init__.py:2566
 msgid "Shows a list of available commands in the layer."
 msgstr "Mostra uma lista de comandos disponíveis na camada."
 
 #. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2481
+#: addon\globalPlugins\visionAssistant\__init__.py:2569
 #, python-brace-format
 msgid "{name} Help"
 msgstr "Ajuda do {name}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2566
+#: addon\globalPlugins\visionAssistant\__init__.py:2654
 #, python-brace-format
 msgid "Upload Connection Error: {reason}"
 msgstr "Erro de Conexão no Upload: {reason}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2572
+#: addon\globalPlugins\visionAssistant\__init__.py:2660
 #, python-brace-format
 msgid "Upload Server Error {code}: {reason}"
 msgstr "Erro do Servidor no Upload {code}: {reason}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2578
+#: addon\globalPlugins\visionAssistant\__init__.py:2666
 #, python-brace-format
 msgid "File Upload Error: {error}"
 msgstr "Erro no Upload do Arquivo: {error}"
 
 #. Translators: Error message when there's no content to send
-#: addon\globalPlugins\visionAssistant\__init__.py:2599
-#: addon\globalPlugins\visionAssistant\__init__.py:2606
-#| msgid "No text to read."
+#: addon\globalPlugins\visionAssistant\__init__.py:2687
+#: addon\globalPlugins\visionAssistant\__init__.py:2694
 msgid "Nothing to send."
 msgstr "Nada para enviar."
 
 #. Translators: Error message when AI refuses to answer due to safety guidelines
-#: addon\globalPlugins\visionAssistant\__init__.py:2652
+#: addon\globalPlugins\visionAssistant\__init__.py:2740
 msgid "Error: Response blocked by AI safety filters."
 msgstr "Erro: Resposta bloqueada por filtros de segurança de IA."
 
 #. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:2693
+#: addon\globalPlugins\visionAssistant\__init__.py:2781
 msgid "Listening..."
 msgstr "Ouvindo..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2697
+#: addon\globalPlugins\visionAssistant\__init__.py:2785
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Erro no Dispositivo de Áudio: {error}"
 
 #. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\__init__.py:2707
+#: addon\globalPlugins\visionAssistant\__init__.py:2795
 msgid "Typing..."
 msgstr "Digitando..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2712
+#: addon\globalPlugins\visionAssistant\__init__.py:2800
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Erro ao Salvar a Gravação: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\__init__.py:2727
-#: addon\globalPlugins\visionAssistant\__init__.py:2750
+#: addon\globalPlugins\visionAssistant\__init__.py:2815
+#: addon\globalPlugins\visionAssistant\__init__.py:2838
 msgid "No speech detected."
 msgstr "Nenhuma fala detectada."
 
 #. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2757
+#: addon\globalPlugins\visionAssistant\__init__.py:2845
 msgid "No speech recognized or Error."
 msgstr "Nenhuma fala reconhecida ou erro."
 
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2772
+#: addon\globalPlugins\visionAssistant\__init__.py:2860
 #, python-brace-format
 msgid "Typed: {text}"
 msgstr "Digitado: {text}"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2783
+#: addon\globalPlugins\visionAssistant\__init__.py:2871
 msgid "No text found."
 msgstr "Nenhum texto encontrado."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2788
+#: addon\globalPlugins\visionAssistant\__init__.py:2876
 msgid "Translating..."
 msgstr "Traduzindo..."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2822
+#: addon\globalPlugins\visionAssistant\__init__.py:2910
 #, python-brace-format
 msgid "Translated: {text}"
 msgstr "Traduzido: {text}"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2840
+#: addon\globalPlugins\visionAssistant\__init__.py:2928
 #, python-brace-format
-#| msgid "Translation"
 msgid "{name} - Translation"
 msgstr "{name} - Tradução"
 
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2932
+#: addon\globalPlugins\visionAssistant\__init__.py:3020
 msgid "Choose action:"
 msgstr "Escolha uma ação:"
 
 #. Translators: Message while processing request of the refine text command
-#: addon\globalPlugins\visionAssistant\__init__.py:2969
+#: addon\globalPlugins\visionAssistant\__init__.py:3057
 msgid "Processing..."
 msgstr "Processando..."
 
 #. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\__init__.py:3027
+#: addon\globalPlugins\visionAssistant\__init__.py:3115
 msgid "Uploading file..."
 msgstr "Enviando arquivo..."
 
 #. Translators: Message reported when executing the refine command
 #. Translators: Message reported when calling the audio transcription command
 #. Translators: Message reported when AI is analyzing the video
-#: addon\globalPlugins\visionAssistant\__init__.py:3077
-#: addon\globalPlugins\visionAssistant\__init__.py:3401
-#: addon\globalPlugins\visionAssistant\__init__.py:3503
+#: addon\globalPlugins\visionAssistant\__init__.py:3165
+#: addon\globalPlugins\visionAssistant\__init__.py:3489
+#: addon\globalPlugins\visionAssistant\__init__.py:3591
 msgid "Analyzing..."
 msgstr "Analisando..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3119
+#: addon\globalPlugins\visionAssistant\__init__.py:3207
 #, python-brace-format
 msgid "{name} - Refine Result"
 msgstr "{name} - Resultado Refinado"
 
 #. Translators: Message reported when calling the OCR file recognition command
-#: addon\globalPlugins\visionAssistant\__init__.py:3171
+#: addon\globalPlugins\visionAssistant\__init__.py:3259
 msgid "Uploading & Extracting..."
 msgstr "Enviando & Extraindo..."
 
 #. Translators: Error shown when OCR finds no text in the selected files
-#: addon\globalPlugins\visionAssistant\__init__.py:3200
-#: addon\globalPlugins\visionAssistant\__init__.py:3234
+#: addon\globalPlugins\visionAssistant\__init__.py:3288
+#: addon\globalPlugins\visionAssistant\__init__.py:3322
 msgid "No text detected in the selected file(s)."
 msgstr "Nenhum texto detectado no(s) arquivo(s) selecionado(s)."
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3211
+#: addon\globalPlugins\visionAssistant\__init__.py:3299
 msgid "Error creating PDF."
 msgstr "Erro ao criar PDF."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3281
+#: addon\globalPlugins\visionAssistant\__init__.py:3369
 #, python-brace-format
 msgid "{name} - Chat"
 msgstr "{name} - Chat"
 
 #. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\__init__.py:3309
+#: addon\globalPlugins\visionAssistant\__init__.py:3397
 msgid "Scanning..."
 msgstr "Escaneando..."
 
 #. Translators: Message reported when calling an image analysis command
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3314
-#: addon\globalPlugins\visionAssistant\__init__.py:3546
+#: addon\globalPlugins\visionAssistant\__init__.py:3402
+#: addon\globalPlugins\visionAssistant\__init__.py:3634
 msgid "Capture failed."
 msgstr "Falha na captura."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3367
+#: addon\globalPlugins\visionAssistant\__init__.py:3455
 #, python-brace-format
 msgid "{name} - Image Analysis"
 msgstr "{name} - Análise de Imagem"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\__init__.py:3391
+#: addon\globalPlugins\visionAssistant\__init__.py:3479
 msgid "Uploading..."
 msgstr "Enviando..."
 
 #. Translators: Generic error message when audio processing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3418
+#: addon\globalPlugins\visionAssistant\__init__.py:3506
 msgid "Error processing audio."
 msgstr "Erro ao processar áudio."
 
 #. Translators: Title for the video URL entry dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3430
+#: addon\globalPlugins\visionAssistant\__init__.py:3518
 msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 msgstr "Análise do YouTube / Instagram / Twitter / TikTok"
 
 #. Translators: Label for the text entry in video dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3432
+#: addon\globalPlugins\visionAssistant\__init__.py:3520
 msgid "Enter Video URL (YouTube/Instagram/Twitter/TikTok):"
 msgstr "Insira o URL do vídeo (YouTube/Instagram/Twitter/TikTok):"
 
 #. Translators: Error message when the URL is invalid
-#: addon\globalPlugins\visionAssistant\__init__.py:3447
-#: addon\globalPlugins\visionAssistant\__init__.py:3450
+#: addon\globalPlugins\visionAssistant\__init__.py:3535
+#: addon\globalPlugins\visionAssistant\__init__.py:3538
 msgid "Error: Invalid URL."
 msgstr "Erro: URL inválida."
 
 #. Translators: Error message when the platform is not supported
-#: addon\globalPlugins\visionAssistant\__init__.py:3460
+#: addon\globalPlugins\visionAssistant\__init__.py:3548
 msgid ""
 "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
 "are supported."
@@ -1605,90 +1659,91 @@ msgstr ""
 "são suportados."
 
 #. Translators: Message reported when processing video link
-#: addon\globalPlugins\visionAssistant\__init__.py:3464
+#: addon\globalPlugins\visionAssistant\__init__.py:3552
 msgid "Processing Video..."
 msgstr "Processando o vídeo..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3475
+#: addon\globalPlugins\visionAssistant\__init__.py:3563
 msgid "Error: Could not extract Instagram video."
 msgstr "Erro: Não foi possível extrair o vídeo do Instagram."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3478
+#: addon\globalPlugins\visionAssistant\__init__.py:3566
 msgid "Error: Could not extract Twitter video."
 msgstr "Erro: Não foi possível extrair o vídeo do Twitter."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3481
+#: addon\globalPlugins\visionAssistant\__init__.py:3569
 msgid "Error: Could not extract TikTok video."
 msgstr "Erro: Não foi possível extrair o vídeo do TikTok."
 
 #. Translators: Message reported when downloading video
-#: addon\globalPlugins\visionAssistant\__init__.py:3488
+#: addon\globalPlugins\visionAssistant\__init__.py:3576
 msgid "Downloading Video..."
 msgstr "Baixando o vídeo..."
 
 #. Translators: Error message when video download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3493
+#: addon\globalPlugins\visionAssistant\__init__.py:3581
 msgid "Error: Download failed."
 msgstr "Erro: Falha no download."
 
 #. Translators: Message reported when uploading video to AI
-#: addon\globalPlugins\visionAssistant\__init__.py:3497
+#: addon\globalPlugins\visionAssistant\__init__.py:3585
 msgid "Uploading to AI..."
 msgstr "Enviando para a IA..."
 
 #. Translators: Message reported when analyzing YouTube video
-#: addon\globalPlugins\visionAssistant\__init__.py:3515
+#: addon\globalPlugins\visionAssistant\__init__.py:3603
 msgid "Analyzing YouTube..."
 msgstr "Analisando o YouTube..."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3541
+#: addon\globalPlugins\visionAssistant\__init__.py:3629
 msgid "Solving..."
 msgstr "Resolvendo..."
 
 #. Translators: Message reported when AI cannot find any CAPTCHA in the image
-#: addon\globalPlugins\visionAssistant\__init__.py:3562
+#: addon\globalPlugins\visionAssistant\__init__.py:3650
 msgid "No CAPTCHA detected."
 msgstr "Nenhum CAPTCHA detectado."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3567
+#: addon\globalPlugins\visionAssistant\__init__.py:3655
 msgid "Failed."
 msgstr "Falhou."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3576
+#: addon\globalPlugins\visionAssistant\__init__.py:3664
 #, python-brace-format
 msgid "Captcha: {text}"
 msgstr "Captcha: {text}"
 
 #. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:3584
+#: addon\globalPlugins\visionAssistant\__init__.py:3672
 msgid "Checking for updates..."
 msgstr "Verificando atualizações..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:3617
+#: addon\globalPlugins\visionAssistant\__init__.py:3705
 msgid "Translating Clipboard..."
 msgstr "Traduzindo área de transferência..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:3622
+#: addon\globalPlugins\visionAssistant\__init__.py:3710
 msgid "Clipboard empty."
 msgstr "Área de transferência vazia."
 
 #. Translators: Message shown when settings dialog is already open
-#: addon\globalPlugins\visionAssistant\__init__.py:3630
+#: addon\globalPlugins\visionAssistant\__init__.py:3721
+#: addon\globalPlugins\visionAssistant\__init__.py:3731
 msgid "Settings dialog is already open."
 msgstr "A caixa de diálogo de configurações já está aberta."
 
 #. Translators: Message when opening documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:3634
+#: addon\globalPlugins\visionAssistant\__init__.py:3737
 msgid "Opening documentation..."
 msgstr "Abrindo a documentação..."
 
 #. Translators: Error when help file is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:3644
+#: addon\globalPlugins\visionAssistant\__init__.py:3747
 msgid "Documentation file not found."
 msgstr "Arquivo de documentação não encontrado."
 
@@ -1777,6 +1832,22 @@ msgstr ""
 "**Guia de Variáveis de Prompt:** Adicionado um guia integrado nos diálogos "
 "de prompt para ajudar os usuários a identificar e utilizar facilmente "
 "variáveis dinâmicas como [selection], [clipboard] e [screen_obj]."
+
+#~ msgid ""
+#~ "Address copied to clipboard! If you'd like, you can now proceed to your "
+#~ "wallet and donate any amount you can. Your support is greatly appreciated!"
+#~ msgstr ""
+#~ "Endereço copiado para a área de transferência! Se desejar, você pode "
+#~ "agora acessar sua carteira e doar qualquer quantia que puder. Agradecemos "
+#~ "imensamente o seu apoio!"
+
+#~ msgid ""
+#~ "Custom prompt text supports multiple lines and '|' in v2. Legacy versions "
+#~ "may not import these prompts."
+#~ msgstr ""
+#~ "O texto personalizado do prompt suporta múltiplas linhas e o caractere "
+#~ "'barra vertical' na versão v2. Versões legadas podem não importar esses "
+#~ "prompts."
 
 #~ msgid "Format: Name:Content"
 #~ msgstr "Formato: Nome:Conteúdo"

--- a/addon/locale/pt_PT/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_PT/LC_MESSAGES/nvda.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 'VisionAssistant' '4.5'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-02-09 15:25+0330\n"
+"POT-Creation-Date: 2026-02-16 17:43+0330\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Edilberto Fonseca <edilberto.fonseca@outlook.com>\n"
 "Language-Team: Edilberto Fonseca <edilberto.fonseca@outlook.com\n"
@@ -19,44 +19,45 @@ msgstr ""
 "X-Generator: Poedit 3.8\n"
 
 #. Translators: Label for the button to copy the TON cryptocurrency wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:17
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:18
 msgid "Copy TON Address"
 msgstr "Copiar endereço TON"
 
 #. Translators: Label for the button to copy the USDT (TRC20 network) wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:19
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:20
 msgid "Copy USDT (TRC20) Address"
 msgstr "Copiar endereço USDT (TRC20)"
 
+#. Translators: Label for the button to copy the support email address for gift cards.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:22
+msgid "Copy Support Email"
+msgstr "Copiar e-mail de suporte"
+
 #. Translators: Button to dismiss the donation dialog without taking any action.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:25
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:29
 msgid "Maybe Later"
 msgstr "Talvez mais tarde"
 
-#. Translators: Success message shown after a wallet address is copied to the clipboard.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:36
-msgid ""
-"Address copied to clipboard! If you'd like, you can now proceed to your "
-"wallet and donate any amount you can. Your support is greatly appreciated!"
-msgstr ""
-"Endereço copiado para a área de transferência! Se desejar, pode agora aceder "
-"à sua carteira e doar qualquer quantia que puder. Agradecemos imensamente o "
-"seu apoio!"
+#. Translators: Success message shown after an address or email is copied to the clipboard.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:40
+msgid "Copied to clipboard! Your support is greatly appreciated!"
+msgstr "Copiado para a área de transferência! Agradecemos imenso o seu apoio!"
 
 #. Translators: Title for the success message box.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:38
-#: addon\globalPlugins\visionAssistant\__init__.py:2225
-#: addon\globalPlugins\visionAssistant\__init__.py:2273
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:42
+#: addon\globalPlugins\visionAssistant\__init__.py:2312
+#: addon\globalPlugins\visionAssistant\__init__.py:2360
 msgid "Success"
 msgstr "Sucesso"
 
 #. Translators: Title of the donation request dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:49
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
 #, python-brace-format
 msgid "Support the Future of {name}"
 msgstr "Apoie o futuro do {name}"
 
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
+#. Translators: The main message of the donation dialog.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:56
 #, python-brace-format
 msgid ""
 "{name} is a project born from a personal vision to bridge the gap between AI "
@@ -69,11 +70,14 @@ msgid ""
 "remains fast, stable, and constantly evolving is a continuous creative "
 "journey that I am passionate about pursuing.\n"
 "\n"
+"Important Note: Due to international banking restrictions in my region, I am "
+"unable to use PayPal or Stripe. If you wish to support this project, you can "
+"donate via Cryptocurrency or by sending an Apple Gift Card (US region) to: "
+"{email}\n"
+"\n"
 "If this assistant has brought value to your daily life, your support is a "
 "wonderful way to show appreciation for the original work and the dedication "
-"behind it. It provides the extra motivation to keep the inspiration alive "
-"and ensures we can continue to push the boundaries together. Thank you for "
-"being part of this mission!"
+"behind it. Thank you for being part of this mission!"
 msgstr ""
 "{name} é um projeto que nasceu de uma visão pessoal para reduzir a distância "
 "entre a inteligência artificial e a acessibilidade real. O conceito inicial "
@@ -86,6 +90,11 @@ msgstr ""
 "Garantir que esta ferramenta continue rápida, estável e em constante "
 "evolução é uma jornada criativa contínua, que sigo com grande dedicação e "
 "entusiasmo.\n"
+"\n"
+"Observação importante: devido a restrições bancárias internacionais na minha "
+"região, não consigo usar PayPal ou Stripe. Se desejar apoiar este projeto, "
+"você pode doar via criptomoeda ou enviando um vale-presente da Apple (região "
+"dos EUA) para: {email}n\n"
 "\n"
 "Se este assistente trouxe valor ao seu dia a dia, o seu apoio é uma "
 "excelente forma de demonstrar apreço pelo trabalho original e pela dedicação "
@@ -101,172 +110,161 @@ msgstr "Nome:"
 #. Translators: Label for prompt text input field.
 #. Translators: Label above the prompt editor textarea.
 #: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:26
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:191
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:187
 msgid "Prompt Text:"
 msgstr "Texto do Prompt:"
 
-#. Translators: Helper text about custom prompt input capabilities.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:36
-msgid ""
-"Custom prompt text supports multiple lines and '|' in v2. Legacy versions "
-"may not import these prompts."
-msgstr ""
-"O texto do prompt personalizado suporta múltiplas linhas e o caracter 'barra "
-"vertical' na v2. As versões antigas podem não importar estes prompts."
-
 #. Translators: Button label to open the variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:49
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:144
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:45
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:140
 msgid "Variables Guide"
 msgstr "Guia de Variáveis"
 
 #. Translators: Validation error for empty prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:66
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:62
 msgid "Name cannot be empty."
 msgstr "O nome não pode estar vazio."
 
 #. Translators: Title of validation warning dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:68
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:76
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:278
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:378
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:405
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:64
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:72
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:274
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:374
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:402
 msgid "Validation Error"
 msgstr "Erro de validação"
 
 #. Translators: Validation error for empty prompt text.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:74
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:276
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:70
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:272
 msgid "Prompt text cannot be empty."
 msgstr "O texto do prompt não pode estar vazio."
 
 #. Translators: Title for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:97
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:93
 msgid "Prompt Variables Guide"
 msgstr "Guia de variáveis de prompt"
 
 #. Translators: Intro text for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:101
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:97
 msgid "Use these variables inside prompt text:"
 msgstr "Use estas variáveis dentro do texto do prompt:"
 
 #. Translators: Button to close chat dialog
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:112
-#: addon\globalPlugins\visionAssistant\__init__.py:1398
-#: addon\globalPlugins\visionAssistant\__init__.py:1934
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:108
+#: addon\globalPlugins\visionAssistant\__init__.py:1471
+#: addon\globalPlugins\visionAssistant\__init__.py:2015
 msgid "Close"
 msgstr "Fechar"
 
 #. Translators: Title for the prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:122
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:118
 msgid "Prompt Manager"
 msgstr "Gestor de Prompts"
 
 #. Translators: Notebook tab for built-in refine prompts.
 #. Translators: Label above the list of default prompt entries.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:134
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:168
-#| msgid "Custom Prompts"
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:130
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:164
 msgid "Default Prompts"
 msgstr "Prompts Predefinidos"
 
 #. Translators: Notebook tab for user-defined prompts.
 #. Translators: Label above the list of custom prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:136
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:223
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:132
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:219
 msgid "Custom Prompts"
 msgstr "Prompts Personalizados"
 
 #. Translators: Note explaining when prompt changes are persisted.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:148
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:144
 msgid "Changes are applied only when you press OK."
 msgstr "As alterações são aplicadas apenas quando premir OK."
 
 #. Translators: Button label to reset currently selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:180
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:176
 msgid "Reset Selected"
 msgstr "Reiniciar Selecionados"
 
 #. Translators: Button label to reset all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:185
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:181
 msgid "Reset All"
 msgstr "Reiniciar Tudo"
 
 #. Translators: Button label to apply current editor text to the selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:200
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:196
 msgid "Apply to Selected"
 msgstr "Aplicar aos selecionados"
 
 #. Translators: Button label for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:228
 msgid "Add"
 msgstr "Adicionar"
 
 #. Translators: Button label for editing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:234
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:230
 msgid "Edit"
 msgstr "Editar"
 
 #. Translators: Button label for removing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:236
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
 msgid "Remove"
 msgstr "Remover"
 
 #. Translators: Button label for moving selected custom prompt up in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:247
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:243
 msgid "Move Up"
 msgstr "Mover Para Cima"
 
 #. Translators: Button label for moving selected custom prompt down in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:249
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:245
 msgid "Move Down"
 msgstr "Mover para baixo"
 
 #. Translators: Label above the custom prompt preview area.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:258
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:254
 msgid "Prompt Preview:"
 msgstr "Pré-visualização do Prompt:"
 
 #. Translators: Message shown after applying changes to the selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:301
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:297
 msgid "Selected prompt updated."
 msgstr "Prompt selecionado atualizado."
 
 #. Translators: Confirmation text before resetting all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:314
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:310
 msgid "Reset all default prompts to built-in values?"
 msgstr "Repor todos os prompts predefinidos para os valores incorporados?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:316
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:312
 msgid "Confirm Reset"
 msgstr "Confirmar Reposição"
 
 #. Translators: Title of dialog for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:371
-#| msgid "Custom Prompts"
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:367
 msgid "Add Custom Prompt"
 msgstr "Adicionar Prompt Personalizado"
 
 #. Translators: Validation error for duplicate custom prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:376
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:403
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:372
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:400
 msgid "A custom prompt with this name already exists."
 msgstr "Já existe um prompt personalizado com este nome."
 
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:394
-#| msgid "Custom Prompts"
+#. Translators: Title of the dialog for editing an existing custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:391
 msgid "Edit Custom Prompt"
 msgstr "Editar Prompt Personalizado"
 
 #. Translators: Confirmation text before deleting a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:418
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:415
 #, python-brace-format
 msgid "Remove custom prompt '{name}'?"
 msgstr "Remover o prompt personalizado '{name}'?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:420
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:417
 msgid "Confirm Remove"
 msgstr "Confirmar Remoção"
 
@@ -302,480 +300,523 @@ msgstr "(Pré-visualização)"
 msgid "[Pro]"
 msgstr "[Prós]"
 
-#. Translators: Voice style description (e.g., Bright, Calm, Formal).
+#. Translators: Adjective describing a bright AI voice style.
 #: addon\globalPlugins\visionAssistant\__init__.py:84
-#: addon\globalPlugins\visionAssistant\__init__.py:93
+#: addon\globalPlugins\visionAssistant\__init__.py:102
 msgid "Bright"
 msgstr "Clara"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:85
-#: addon\globalPlugins\visionAssistant\__init__.py:102
+#. Translators: Adjective describing an upbeat AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:86
+#: addon\globalPlugins\visionAssistant\__init__.py:120
 msgid "Upbeat"
 msgstr "Otimista"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:86
-#: addon\globalPlugins\visionAssistant\__init__.py:101
+#. Translators: Adjective describing an informative AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:88
+#: addon\globalPlugins\visionAssistant\__init__.py:118
 msgid "Informative"
 msgstr "Informativa"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:87
+#. Translators: Adjective describing a firm AI voice style.
 #: addon\globalPlugins\visionAssistant\__init__.py:90
-#: addon\globalPlugins\visionAssistant\__init__.py:104
+#: addon\globalPlugins\visionAssistant\__init__.py:96
+#: addon\globalPlugins\visionAssistant\__init__.py:124
 msgid "Firm"
 msgstr "Firme"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:88
+#. Translators: Adjective describing an excitable AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:92
 msgid "Excitable"
 msgstr "Excitável"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:89
+#. Translators: Adjective describing a youthful AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:94
 msgid "Youthful"
 msgstr "Jovial"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:91
+#. Translators: Adjective describing a breezy AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:98
 msgid "Breezy"
 msgstr "Leve"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:92
-#: addon\globalPlugins\visionAssistant\__init__.py:96
+#. Translators: Adjective describing an easy-going AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:100
+#: addon\globalPlugins\visionAssistant\__init__.py:108
 msgid "Easy-going"
 msgstr "Descontraída"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:94
+#. Translators: Adjective describing a breathy AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:104
 msgid "Breathy"
 msgstr "Sussurrada"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:95
-#: addon\globalPlugins\visionAssistant\__init__.py:99
+#. Translators: Adjective describing a clear AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:106
+#: addon\globalPlugins\visionAssistant\__init__.py:114
 msgid "Clear"
 msgstr "Clara"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:97
-#: addon\globalPlugins\visionAssistant\__init__.py:98
+#. Translators: Adjective describing a smooth AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:110
+#: addon\globalPlugins\visionAssistant\__init__.py:112
 msgid "Smooth"
 msgstr "Suave"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:100
+#. Translators: Adjective describing a gravelly AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:116
 msgid "Gravelly"
 msgstr "Rascante"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:103
+#. Translators: Adjective describing a soft AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:122
 msgid "Soft"
 msgstr "Suave"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:105
+#. Translators: Adjective describing an even AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:126
 msgid "Even"
 msgstr "Uniforme"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:106
+#. Translators: Adjective describing a mature AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:128
 msgid "Mature"
 msgstr "Madura"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:107
+#. Translators: Adjective describing a forward AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:130
 msgid "Forward"
 msgstr "Confiante"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:108
+#. Translators: Adjective describing a friendly AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:132
 msgid "Friendly"
 msgstr "Amigável"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:109
+#. Translators: Adjective describing a casual AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:134
 msgid "Casual"
 msgstr "Casual"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:110
+#. Translators: Adjective describing a gentle AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:136
 msgid "Gentle"
 msgstr "Gentil"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:111
+#. Translators: Adjective describing a lively AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:138
 msgid "Lively"
 msgstr "Animada"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:112
+#. Translators: Adjective describing a knowledgeable AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:140
 msgid "Knowledgeable"
 msgstr "Conhecedora"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:113
+#. Translators: Adjective describing a warm AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:142
 msgid "Warm"
 msgstr "Acolhedora"
 
 #. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\__init__.py:134
+#: addon\globalPlugins\visionAssistant\__init__.py:163
 msgid "Chrome (Fast)"
 msgstr "Chrome (Rápido)"
 
 #. Translators: OCR Engine option (Slower but better formatting)
-#: addon\globalPlugins\visionAssistant\__init__.py:136
+#: addon\globalPlugins\visionAssistant\__init__.py:165
 msgid "Gemini (Formatted)"
 msgstr "Gemini (Formatado)"
 
+#. Translators: Section header for text refinement prompts in Prompt Manager.
 #. Translators: main message of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:203
-#: addon\globalPlugins\visionAssistant\__init__.py:209
-#: addon\globalPlugins\visionAssistant\__init__.py:215
-#: addon\globalPlugins\visionAssistant\__init__.py:221
-#: addon\globalPlugins\visionAssistant\__init__.py:2934
+#: addon\globalPlugins\visionAssistant\__init__.py:227
+#: addon\globalPlugins\visionAssistant\__init__.py:235
+#: addon\globalPlugins\visionAssistant\__init__.py:243
+#: addon\globalPlugins\visionAssistant\__init__.py:251
+#: addon\globalPlugins\visionAssistant\__init__.py:3022
 msgid "Refine"
 msgstr "Refinar"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:204
+#. Translators: Label for the text summarization prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:229
 msgid "Summarize"
 msgstr "Resumir"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:210
+#. Translators: Label for the grammar correction prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:237
 msgid "Fix Grammar"
 msgstr "Corrigir Gramática"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:216
+#. Translators: Label for the grammar correction and translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:245
 msgid "Fix Grammar & Translate"
 msgstr "Corrigir gramática e traduzir"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:222
+#. Translators: Label for the text explanation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:253
 msgid "Explain"
 msgstr "Explicar"
 
+#. Translators: Section header for translation-related prompts in Prompt Manager.
 #. Translators: Box title for translation options
-#: addon\globalPlugins\visionAssistant\__init__.py:227
-#: addon\globalPlugins\visionAssistant\__init__.py:233
-#: addon\globalPlugins\visionAssistant\__init__.py:1745
+#: addon\globalPlugins\visionAssistant\__init__.py:259
+#: addon\globalPlugins\visionAssistant\__init__.py:267
+#: addon\globalPlugins\visionAssistant\__init__.py:1824
 msgid "Translation"
 msgstr "Tradução"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:228
-#| msgid "Translation"
+#. Translators: Label for the smart translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:261
 msgid "Smart Translation"
 msgstr "Tradução Inteligente"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:234
-#| msgid "Translation"
+#. Translators: Label for the quick translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:269
 msgid "Quick Translation"
 msgstr "Tradução Rápida"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:239
-#: addon\globalPlugins\visionAssistant\__init__.py:333
-#| msgid "Docu&mentation"
+#. Translators: Section header for document-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:275
+#: addon\globalPlugins\visionAssistant\__init__.py:394
 msgid "Document"
 msgstr "Documento"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:240
-#| msgid "Docu&mentation"
+#. Translators: Label for the initial context prompt in document chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:277
 msgid "Document Chat Context"
 msgstr "Contexto do Chat de Documentos"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:245
-#: addon\globalPlugins\visionAssistant\__init__.py:275
-#: addon\globalPlugins\visionAssistant\__init__.py:281
-#: addon\globalPlugins\visionAssistant\__init__.py:352
+#. Translators: Section header for advanced/internal prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:283
+#: addon\globalPlugins\visionAssistant\__init__.py:320
+#: addon\globalPlugins\visionAssistant\__init__.py:329
+#: addon\globalPlugins\visionAssistant\__init__.py:418
 msgid "Advanced"
 msgstr "Avançado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:246
+#. Translators: Label for the AI's acknowledgement reply in document chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:285
 msgid "Document Chat Bootstrap Reply"
 msgstr "Resposta de Inicialização do Chat de Documentos"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:251
-#: addon\globalPlugins\visionAssistant\__init__.py:263
+#. Translators: Section header for image analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:292
+#: addon\globalPlugins\visionAssistant\__init__.py:306
 msgid "Vision"
 msgstr "Visão"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:252
-#| msgid "Navigator Object"
+#. Translators: Label for the prompt used to analyze the current navigator object.
+#: addon\globalPlugins\visionAssistant\__init__.py:294
 msgid "Navigator Object Analysis"
 msgstr "Análise de objetos do navegador"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:264
-#| msgid "Full Screen"
+#. Translators: Label for the prompt used to analyze the entire screen.
+#: addon\globalPlugins\visionAssistant\__init__.py:308
 msgid "Full Screen Analysis"
 msgstr "Análise de Ecrã Completo"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:276
+#. Translators: Label for the follow-up context in image analysis chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:322
 msgid "Vision Follow-up Context"
 msgstr "Contexto de Seguimento do Visão"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:282
+#. Translators: Label for the rule enforced during image analysis follow-up questions.
+#: addon\globalPlugins\visionAssistant\__init__.py:331
 msgid "Vision Follow-up Answer Rule"
 msgstr "Regra de Resposta de Seguimento do Visão"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:287
+#. Translators: Section header for video analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:338
 msgid "Video"
 msgstr "Vídeo"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:288
+#. Translators: Label for the video content analysis prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:340
 msgid "Video Analysis"
 msgstr "Análise de Vídeo"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:297
-#: addon\globalPlugins\visionAssistant\__init__.py:303
-#| msgid "Save Audio"
+#. Translators: Section header for audio-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:350
+#: addon\globalPlugins\visionAssistant\__init__.py:358
 msgid "Audio"
 msgstr "Áudio"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:298
-#| msgid "Translation"
+#. Translators: Label for the audio file transcription prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:352
 msgid "Audio Transcription"
 msgstr "Transcrição de Áudio"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:304
+#. Translators: Label for the smart voice dictation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:360
 msgid "Smart Dictation"
 msgstr "Ditado Inteligente"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:312
-#: addon\globalPlugins\visionAssistant\__init__.py:322
+#. Translators: Section header for OCR-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:369
+#: addon\globalPlugins\visionAssistant\__init__.py:381
 msgid "OCR"
 msgstr "OCR"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:313
+#. Translators: Label for the OCR prompt used for image text extraction.
+#: addon\globalPlugins\visionAssistant\__init__.py:371
 msgid "OCR Image Extraction"
 msgstr "Extração de Imagem OCR"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:323
-#| msgid "Docu&mentation"
+#. Translators: Label for the OCR prompt used for document text extraction.
+#: addon\globalPlugins\visionAssistant\__init__.py:383
 msgid "OCR Document Extraction"
 msgstr "Extração de Documentos por OCR"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:334
-#| msgid "Document Reader"
+#. Translators: Label for the combined OCR and translation prompt for documents.
+#: addon\globalPlugins\visionAssistant\__init__.py:396
 msgid "Document OCR + Translate"
 msgstr "OCR de documentos mais tradução"
 
+#. Translators: Section header for CAPTCHA-related prompts in Prompt Manager.
 #. --- CAPTCHA Group ---
 #. Translators: Title of the settings group for CAPTCHA options
-#: addon\globalPlugins\visionAssistant\__init__.py:343
-#: addon\globalPlugins\visionAssistant\__init__.py:1635
+#: addon\globalPlugins\visionAssistant\__init__.py:406
+#: addon\globalPlugins\visionAssistant\__init__.py:1708
 msgid "CAPTCHA"
 msgstr "CAPTCHA"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:344
-#| msgid "CAPTCHA"
+#. Translators: Label for the CAPTCHA solving prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:408
 msgid "CAPTCHA Solver"
 msgstr "Resolução de CAPTCHA"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:353
+#. Translators: Label for the fallback prompt when only files are provided in Refine.
+#: addon\globalPlugins\visionAssistant\__init__.py:420
 msgid "Refine Files-Only Fallback"
 msgstr "Aperfeiçoar Apenas Arquivos como Recurso Secundário"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:359
+#. Translators: Description and input type for the [selection] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:428
 msgid "Currently selected text"
 msgstr "Texto atualmente selecionado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:359
-#: addon\globalPlugins\visionAssistant\__init__.py:360
+#: addon\globalPlugins\visionAssistant\__init__.py:428
+#: addon\globalPlugins\visionAssistant\__init__.py:430
 msgid "Text"
 msgstr "Texto"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:360
-#| msgid "Clipboard empty."
+#. Translators: Description for the [clipboard] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:430
 msgid "Clipboard content"
 msgstr "Conteúdo da Área de Transferência"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:361
-#| msgid "Translates the selected text or navigator object."
+#. Translators: Description and input type for the [screen_obj] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:432
 msgid "Screenshot of the navigator object"
 msgstr "Captura de ecrã do objeto do navegador"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:361
-#: addon\globalPlugins\visionAssistant\__init__.py:362
+#: addon\globalPlugins\visionAssistant\__init__.py:432
+#: addon\globalPlugins\visionAssistant\__init__.py:434
 msgid "Image"
 msgstr "Imagem"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:362
+#. Translators: Description for the [screen_full] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:434
 msgid "Screenshot of the entire screen"
 msgstr "Captura de ecrã de todo o ecrã"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:363
-#| msgid "Select Image/PDF/TIFF for OCR"
+#. Translators: Description and input type for the [file_ocr] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:436
 msgid "Select image/PDF/TIFF for text extraction"
 msgstr "Selecionar imagem/PDF/TIFF para extração de texto"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:363
+#: addon\globalPlugins\visionAssistant\__init__.py:436
 msgid "Image, PDF, TIFF"
 msgstr "Imagem, PDF, TIFF"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:364
-#| msgid "Select Document to Analyze"
+#. Translators: Description and input type for the [file_read] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:438
 msgid "Select document for reading"
 msgstr "Selecionar documento para leitura"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:364
+#: addon\globalPlugins\visionAssistant\__init__.py:438
 msgid "TXT, Code, PDF"
 msgstr "TXT, Code, PDF"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:365
-#| msgid "Select Audio File to Transcribe"
+#. Translators: Description and input type for the [file_audio] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:440
 msgid "Select audio file for analysis"
 msgstr "Selecionar ficheiro de áudio para análise"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:365
+#: addon\globalPlugins\visionAssistant\__init__.py:440
 msgid "MP3, WAV, OGG"
 msgstr "MP3, WAV, OGG"
 
 #. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\__init__.py:614
+#: addon\globalPlugins\visionAssistant\__init__.py:687
 msgid "Custom: "
 msgstr "Personalizado: "
 
 #. Translators: Title of the error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:698
+#: addon\globalPlugins\visionAssistant\__init__.py:771
 #, python-brace-format
 msgid "{name} Error"
 msgstr "Erro em {name}"
 
 #. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\__init__.py:959
+#: addon\globalPlugins\visionAssistant\__init__.py:1034
 msgid "Error 400: Bad Request (Check API Key)"
 msgstr "Erro 400: Pedido inválido (verifique a chave da API)"
 
 #. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\__init__.py:961
+#: addon\globalPlugins\visionAssistant\__init__.py:1036
 msgid "Error 403: Forbidden (Check Region)"
 msgstr "Erro 403: Proibido (verifique a região)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1004
-#: addon\globalPlugins\visionAssistant\__init__.py:1129
+#: addon\globalPlugins\visionAssistant\__init__.py:1079
+#: addon\globalPlugins\visionAssistant\__init__.py:1200
 msgid "Error 429: Quota Exceeded (Try later)"
 msgstr "Erro 429: Cota Excedida (Tente mais tarde)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1007
-#: addon\globalPlugins\visionAssistant\__init__.py:1132
+#: addon\globalPlugins\visionAssistant\__init__.py:1082
+#: addon\globalPlugins\visionAssistant\__init__.py:1203
 #, python-brace-format
 msgid "Server Error {code}: {reason}"
 msgstr "Erro do Servidor {code}: {reason}"
 
 #. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:1017
+#: addon\globalPlugins\visionAssistant\__init__.py:1092
 msgid "No API Keys configured."
 msgstr "Nenhuma chave de API configurada."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1032
+#: addon\globalPlugins\visionAssistant\__init__.py:1107
 msgid "All API Keys failed (Quota/Server)."
 msgstr "Todas as chaves de API falharam (cota/servidor)."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1036
+#: addon\globalPlugins\visionAssistant\__init__.py:1111
 msgid "Unknown error occurred."
 msgstr "Ocorreu um erro desconhecido."
 
 #. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\__init__.py:1072
+#: addon\globalPlugins\visionAssistant\__init__.py:1143
 msgid "No API Keys."
 msgstr "Nenhuma chave de API."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1109
-#: addon\globalPlugins\visionAssistant\__init__.py:1831
-#: addon\globalPlugins\visionAssistant\__init__.py:3220
+#: addon\globalPlugins\visionAssistant\__init__.py:1180
+#: addon\globalPlugins\visionAssistant\__init__.py:1910
+#: addon\globalPlugins\visionAssistant\__init__.py:3308
 msgid "Upload failed."
 msgstr "Falha no envio."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1138
+#: addon\globalPlugins\visionAssistant\__init__.py:1209
 msgid "All keys failed."
 msgstr "Todas as chaves falharam."
 
 #. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1235
+#: addon\globalPlugins\visionAssistant\__init__.py:1306
 msgid "Update Available"
 msgstr "Actualização disponível"
 
 #. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\__init__.py:1242
+#: addon\globalPlugins\visionAssistant\__init__.py:1313
 #, python-brace-format
 msgid "A new version ({version}) of {name} is available."
 msgstr "Uma nova versão ({version}) de {name} está disponível."
 
 #. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\__init__.py:1247
+#: addon\globalPlugins\visionAssistant\__init__.py:1318
 msgid "Changes:"
 msgstr "Mudanças:"
 
 #. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\__init__.py:1254
+#: addon\globalPlugins\visionAssistant\__init__.py:1325
 msgid "Download and Install?"
 msgstr "Transferir e instalar?"
 
 #. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\__init__.py:1259
+#: addon\globalPlugins\visionAssistant\__init__.py:1330
 msgid "&Yes"
 msgstr "&Sim"
 
 #. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\__init__.py:1261
+#: addon\globalPlugins\visionAssistant\__init__.py:1332
 msgid "&No"
 msgstr "&Não"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1302
+#. Translators: Error message when an update is found but the addon file is missing from GitHub.
+#: addon\globalPlugins\visionAssistant\__init__.py:1374
 msgid "Update found but no .nvda-addon file in release."
 msgstr ""
 "Actualização encontrada, mas nenhum ficheiro .nvda-addon na versão "
 "disponibilizada."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1305
+#. Translators: Status message informing the user they are already on the latest version.
+#: addon\globalPlugins\visionAssistant\__init__.py:1378
 msgid "You have the latest version."
 msgstr "Já está a utilizar a versão mais recente."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1309
+#: addon\globalPlugins\visionAssistant\__init__.py:1382
 #, python-brace-format
 msgid "Update check failed: {error}"
 msgstr "Falha ao verificar a actualização: {error}"
 
 #. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\__init__.py:1328
+#: addon\globalPlugins\visionAssistant\__init__.py:1401
 msgid "Downloading update..."
 msgstr "A transferir a actualização…"
 
 #. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1337
+#: addon\globalPlugins\visionAssistant\__init__.py:1410
 #, python-brace-format
 msgid "Download failed: {error}"
 msgstr "Falha na transferência: {error}"
 
 #. Translators: Label for the AI response text area in a chat dialog
 #. Translators: Label for AI Response Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1357
-#: addon\globalPlugins\visionAssistant\__init__.py:1599
+#: addon\globalPlugins\visionAssistant\__init__.py:1430
+#: addon\globalPlugins\visionAssistant\__init__.py:1672
 msgid "AI Response:"
 msgstr "Resposta da IA:"
 
 #. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1367
-#: addon\globalPlugins\visionAssistant\__init__.py:1455
-#: addon\globalPlugins\visionAssistant\__init__.py:1472
+#: addon\globalPlugins\visionAssistant\__init__.py:1440
+#: addon\globalPlugins\visionAssistant\__init__.py:1528
+#: addon\globalPlugins\visionAssistant\__init__.py:1545
 #, python-brace-format
 msgid "AI: {text}\n"
 msgstr "IA: {text}\n"
 
 #. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1378
+#: addon\globalPlugins\visionAssistant\__init__.py:1451
 msgid "Ask:"
 msgstr "Perguntar:"
 
 #. Translators: Button to send message in a chat dialog
 #. Translators: Button to send message
-#: addon\globalPlugins\visionAssistant\__init__.py:1388
-#: addon\globalPlugins\visionAssistant\__init__.py:1812
+#: addon\globalPlugins\visionAssistant\__init__.py:1461
+#: addon\globalPlugins\visionAssistant\__init__.py:1891
 msgid "Send"
 msgstr "Enviar"
 
 #. Translators: Button to view the content in a formatted HTML window
 #. Translators: Button to view formatted content
-#: addon\globalPlugins\visionAssistant\__init__.py:1390
-#: addon\globalPlugins\visionAssistant\__init__.py:1924
+#: addon\globalPlugins\visionAssistant\__init__.py:1463
+#: addon\globalPlugins\visionAssistant\__init__.py:2005
 msgid "View Formatted"
 msgstr "Ver formatado"
 
 #. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:1393
+#: addon\globalPlugins\visionAssistant\__init__.py:1466
 msgid "Save Content"
 msgstr "Guardar conteúdo"
 
 #. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1396
+#: addon\globalPlugins\visionAssistant\__init__.py:1469
 msgid "Save Chat"
 msgstr "Guardar conversa"
 
 #. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1431
-#: addon\globalPlugins\visionAssistant\__init__.py:1470
+#: addon\globalPlugins\visionAssistant\__init__.py:1504
+#: addon\globalPlugins\visionAssistant\__init__.py:1543
 #, python-brace-format
 msgid ""
 "\n"
@@ -786,577 +827,579 @@ msgstr ""
 
 #. Translators: Message shown while processing in a chat dialog
 #. Translators: Message showing AI is thinking
-#: addon\globalPlugins\visionAssistant\__init__.py:1435
-#: addon\globalPlugins\visionAssistant\__init__.py:1847
+#: addon\globalPlugins\visionAssistant\__init__.py:1508
+#: addon\globalPlugins\visionAssistant\__init__.py:1926
 msgid "Thinking..."
 msgstr "Pensando..."
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:1492
+#: addon\globalPlugins\visionAssistant\__init__.py:1565
 msgid "Formatted Conversation"
 msgstr "Conversa formatada"
 
 #. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:1495
+#: addon\globalPlugins\visionAssistant\__init__.py:1568
 #, python-brace-format
 msgid "Error displaying content: {error}"
 msgstr "Erro ao apresentar o conteúdo: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:1500
+#: addon\globalPlugins\visionAssistant\__init__.py:1573
 msgid "Save Chat Log"
 msgstr "Guardar registo da conversa"
 
+#. Translators: Message shown on successful save of a file.
 #. Translators: Message on successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:1505
-#: addon\globalPlugins\visionAssistant\__init__.py:1519
+#: addon\globalPlugins\visionAssistant\__init__.py:1578
+#: addon\globalPlugins\visionAssistant\__init__.py:1592
 msgid "Saved."
 msgstr "Guardado."
 
 #. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1508
-#: addon\globalPlugins\visionAssistant\__init__.py:1522
+#: addon\globalPlugins\visionAssistant\__init__.py:1581
+#: addon\globalPlugins\visionAssistant\__init__.py:1595
 #, python-brace-format
 msgid "Save failed: {error}"
 msgstr "Falha ao guardar: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:1513
+#: addon\globalPlugins\visionAssistant\__init__.py:1586
 msgid "Save Result"
 msgstr "Guardar resultado"
 
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\__init__.py:1530
+#: addon\globalPlugins\visionAssistant\__init__.py:1603
 msgid "Connection"
 msgstr "Ligação"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\__init__.py:1536
+#: addon\globalPlugins\visionAssistant\__init__.py:1609
 msgid "Gemini API Key (Separate multiple keys with comma or newline):"
 msgstr ""
 "Chave da API Gemini (separe várias chaves com vírgula ou numa nova linha):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\__init__.py:1550
+#: addon\globalPlugins\visionAssistant\__init__.py:1623
 msgid "Show API Key"
 msgstr "Mostrar chave da API"
 
 #. Translators: Label for Model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1556
+#: addon\globalPlugins\visionAssistant\__init__.py:1629
 msgid "AI Model:"
 msgstr "Modelo de IA:"
 
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:1564
+#: addon\globalPlugins\visionAssistant\__init__.py:1637
 msgid "Proxy URL:"
 msgstr "URL do Proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on NVDA startup
-#: addon\globalPlugins\visionAssistant\__init__.py:1568
+#: addon\globalPlugins\visionAssistant\__init__.py:1641
 msgid "Check for updates on startup"
 msgstr "Verificar actualizações no arranque"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\__init__.py:1571
+#: addon\globalPlugins\visionAssistant\__init__.py:1644
 msgid "Clean Markdown in Chat"
 msgstr "Markdown limpo na conversa"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:1574
+#: addon\globalPlugins\visionAssistant\__init__.py:1647
 msgid "Copy AI responses to clipboard"
 msgstr "Copiar respostas da IA para a área de transferência"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\__init__.py:1577
+#: addon\globalPlugins\visionAssistant\__init__.py:1650
 msgid "Direct Output (No Chat Window)"
 msgstr "Saída directa (sem janela de conversação)"
 
 #. --- Translation Languages Group ---
 #. Translators: Title of the settings group for translation languages configuration
-#: addon\globalPlugins\visionAssistant\__init__.py:1583
+#: addon\globalPlugins\visionAssistant\__init__.py:1656
 msgid "Translation Languages"
 msgstr "Idiomas da Tradução"
 
 #. Translators: Label for Source Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1589
+#: addon\globalPlugins\visionAssistant\__init__.py:1662
 msgid "Source:"
 msgstr "Origem:"
 
 #. Translators: Label for Target Language selection
 #. Translators: Label for target language
-#: addon\globalPlugins\visionAssistant\__init__.py:1594
-#: addon\globalPlugins\visionAssistant\__init__.py:1751
+#: addon\globalPlugins\visionAssistant\__init__.py:1667
+#: addon\globalPlugins\visionAssistant\__init__.py:1830
 msgid "Target:"
 msgstr "Destino:"
 
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\__init__.py:1604
+#: addon\globalPlugins\visionAssistant\__init__.py:1677
 msgid "Smart Swap"
 msgstr "Substituição inteligente"
 
 #. --- Document Reader Settings ---
 #. Translators: Title of settings group for Document Reader features
-#: addon\globalPlugins\visionAssistant\__init__.py:1610
+#. Translators: Title of the Document Reader window.
+#: addon\globalPlugins\visionAssistant\__init__.py:1683
+#: addon\globalPlugins\visionAssistant\__init__.py:1948
 msgid "Document Reader"
 msgstr "Leitor de documentos"
 
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1616
+#: addon\globalPlugins\visionAssistant\__init__.py:1689
 msgid "OCR Engine:"
 msgstr "Motor de OCR:"
 
 #. Translators: Label for TTS Voice selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1625
+#: addon\globalPlugins\visionAssistant\__init__.py:1698
 msgid "TTS Voice:"
 msgstr "Voz TTS:"
 
 #. Translators: Label for CAPTCHA capture method selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1640
+#: addon\globalPlugins\visionAssistant\__init__.py:1713
 msgid "Capture Method:"
 msgstr "Método de Captura:"
 
 #. Translators: A choice for capture method. Captures only the specific object under the NVDA navigator cursor.
-#: addon\globalPlugins\visionAssistant\__init__.py:1642
+#: addon\globalPlugins\visionAssistant\__init__.py:1715
 msgid "Navigator Object"
 msgstr "Objeto do Navegador"
 
 #. Translators: A choice for capture method. Captures the entire visible screen area.
-#: addon\globalPlugins\visionAssistant\__init__.py:1644
+#: addon\globalPlugins\visionAssistant\__init__.py:1717
 msgid "Full Screen"
 msgstr "Ecrã inteiro"
 
 #. --- Prompt Manager Group ---
 #. Translators: Title of the settings group for prompt management
-#: addon\globalPlugins\visionAssistant\__init__.py:1654
-#| msgid "Custom Prompts"
+#: addon\globalPlugins\visionAssistant\__init__.py:1727
 msgid "Prompts"
 msgstr "Prompts"
 
 #. Translators: Description for the prompt manager button.
-#: addon\globalPlugins\visionAssistant\__init__.py:1659
-msgid "Manage default system prompts and custom refine prompts."
-msgstr ""
-"Gerir os prompts do sistema predefinidos e os prompts personalizados de "
-"aperfeiçoamento."
+#: addon\globalPlugins\visionAssistant\__init__.py:1732
+msgid "Manage default and custom prompts."
+msgstr "Gerencie prompts padrão e personalizados."
 
 #. Translators: Button label to open prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:1661
+#: addon\globalPlugins\visionAssistant\__init__.py:1734
 msgid "Manage Prompts..."
 msgstr "Gerir Prompts..."
 
 #. Translators: Summary text for prompt counts in settings.
-#: addon\globalPlugins\visionAssistant\__init__.py:1671
+#: addon\globalPlugins\visionAssistant\__init__.py:1744
 #, python-brace-format
 msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
 msgstr ""
 "Prompts predefinidos: {defaultCount}, Prompts personalizados: {customCount}"
 
 #. Translators: Title of the PDF options dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1725
+#: addon\globalPlugins\visionAssistant\__init__.py:1804
 msgid "Options"
 msgstr "Opções"
 
 #. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:1728
+#: addon\globalPlugins\visionAssistant\__init__.py:1807
 #, python-brace-format
 msgid "Total Pages (All Files): {count}"
 msgstr "Total de páginas (todos os ficheiros): {count}"
 
 #. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1731
+#: addon\globalPlugins\visionAssistant\__init__.py:1810
 msgid "Range"
 msgstr "Intervalo"
 
 #. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\__init__.py:1734
+#: addon\globalPlugins\visionAssistant\__init__.py:1813
 msgid "From:"
 msgstr "De:"
 
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\__init__.py:1738
+#: addon\globalPlugins\visionAssistant\__init__.py:1817
 msgid "To:"
 msgstr "Para:"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\__init__.py:1747
+#: addon\globalPlugins\visionAssistant\__init__.py:1826
 msgid "Translate Output"
 msgstr "Traduzir saída"
 
 #. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\__init__.py:1760
+#: addon\globalPlugins\visionAssistant\__init__.py:1839
 msgid "Start"
 msgstr "Iniciar"
 
 #. Translators: Button to cancel
-#: addon\globalPlugins\visionAssistant\__init__.py:1763
+#: addon\globalPlugins\visionAssistant\__init__.py:1842
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1788
+#: addon\globalPlugins\visionAssistant\__init__.py:1867
 msgid "Ask about Document"
 msgstr "Perguntar sobre o documento"
 
 #. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\__init__.py:1797
+#: addon\globalPlugins\visionAssistant\__init__.py:1876
 #, python-brace-format
 msgid "File: {name}"
 msgstr "Ficheiro: {name}"
 
 #. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\__init__.py:1802
+#: addon\globalPlugins\visionAssistant\__init__.py:1881
 msgid "Uploading to Gemini...\n"
 msgstr "A enviar para o Gemini…\n"
 
 #. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\__init__.py:1806
+#: addon\globalPlugins\visionAssistant\__init__.py:1885
 msgid "Your Question:"
 msgstr "A sua pergunta:"
 
 #. Translators: Message when ready to chat
-#: addon\globalPlugins\visionAssistant\__init__.py:1837
+#: addon\globalPlugins\visionAssistant\__init__.py:1916
 msgid "Ready! Ask your questions.\n"
 msgstr "Pronto! Faça as suas perguntas.\n"
 
 #. Translators: Initial status when the add-on is doing nothing
 #. Translators: Status message when the add-on is doing nothing
-#: addon\globalPlugins\visionAssistant\__init__.py:1857
-#: addon\globalPlugins\visionAssistant\__init__.py:2136
+#: addon\globalPlugins\visionAssistant\__init__.py:1936
 #: addon\globalPlugins\visionAssistant\__init__.py:2223
-#: addon\globalPlugins\visionAssistant\__init__.py:2227
-#: addon\globalPlugins\visionAssistant\__init__.py:2291
-#: addon\globalPlugins\visionAssistant\__init__.py:2488
-#: addon\globalPlugins\visionAssistant\__init__.py:3082
-#: addon\globalPlugins\visionAssistant\__init__.py:3198
-#: addon\globalPlugins\visionAssistant\__init__.py:3203
-#: addon\globalPlugins\visionAssistant\__init__.py:3219
-#: addon\globalPlugins\visionAssistant\__init__.py:3232
-#: addon\globalPlugins\visionAssistant\__init__.py:3241
+#: addon\globalPlugins\visionAssistant\__init__.py:2310
+#: addon\globalPlugins\visionAssistant\__init__.py:2314
+#: addon\globalPlugins\visionAssistant\__init__.py:2378
+#: addon\globalPlugins\visionAssistant\__init__.py:2576
+#: addon\globalPlugins\visionAssistant\__init__.py:3170
+#: addon\globalPlugins\visionAssistant\__init__.py:3286
+#: addon\globalPlugins\visionAssistant\__init__.py:3291
+#: addon\globalPlugins\visionAssistant\__init__.py:3307
+#: addon\globalPlugins\visionAssistant\__init__.py:3320
 #: addon\globalPlugins\visionAssistant\__init__.py:3329
-#: addon\globalPlugins\visionAssistant\__init__.py:3333
-#: addon\globalPlugins\visionAssistant\__init__.py:3397
-#: addon\globalPlugins\visionAssistant\__init__.py:3411
-#: addon\globalPlugins\visionAssistant\__init__.py:3415
-#: addon\globalPlugins\visionAssistant\__init__.py:3420
-#: addon\globalPlugins\visionAssistant\__init__.py:3506
-#: addon\globalPlugins\visionAssistant\__init__.py:3519
-#: addon\globalPlugins\visionAssistant\__init__.py:3523
-#: addon\globalPlugins\visionAssistant\__init__.py:3559
-#: addon\globalPlugins\visionAssistant\__init__.py:3569
+#: addon\globalPlugins\visionAssistant\__init__.py:3417
+#: addon\globalPlugins\visionAssistant\__init__.py:3421
+#: addon\globalPlugins\visionAssistant\__init__.py:3485
+#: addon\globalPlugins\visionAssistant\__init__.py:3499
+#: addon\globalPlugins\visionAssistant\__init__.py:3503
+#: addon\globalPlugins\visionAssistant\__init__.py:3508
+#: addon\globalPlugins\visionAssistant\__init__.py:3594
+#: addon\globalPlugins\visionAssistant\__init__.py:3607
+#: addon\globalPlugins\visionAssistant\__init__.py:3611
+#: addon\globalPlugins\visionAssistant\__init__.py:3647
+#: addon\globalPlugins\visionAssistant\__init__.py:3657
 msgid "Idle"
 msgstr "Inactivo"
 
 #. Translators: Spoken prefix for AI response
-#: addon\globalPlugins\visionAssistant\__init__.py:1864
+#: addon\globalPlugins\visionAssistant\__init__.py:1943
 msgid "AI: "
 msgstr "AI: "
 
 #. Translators: Initial status message
-#: addon\globalPlugins\visionAssistant\__init__.py:1887
+#: addon\globalPlugins\visionAssistant\__init__.py:1968
 msgid "Initializing..."
 msgstr "A iniciar…"
 
 #. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\__init__.py:1893
+#: addon\globalPlugins\visionAssistant\__init__.py:1974
 msgid "Previous (Ctrl+PageUp)"
 msgstr "Anterior (Ctrl+PageUp)"
 
 #. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\__init__.py:1897
+#: addon\globalPlugins\visionAssistant\__init__.py:1978
 msgid "Next (Ctrl+PageDown)"
 msgstr "Próximo (Ctrl+PageDown)"
 
 #. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\__init__.py:1901
+#: addon\globalPlugins\visionAssistant\__init__.py:1982
 msgid "Go to:"
 msgstr "Ir para:"
 
 #. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\__init__.py:1909
+#: addon\globalPlugins\visionAssistant\__init__.py:1990
 msgid "Ask AI (Alt+A)"
 msgstr "Pergunte à IA (Alt+A)"
 
 #. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\__init__.py:1914
+#: addon\globalPlugins\visionAssistant\__init__.py:1995
 msgid "Re-scan with Gemini (Alt+R)"
 msgstr "Reescanear com o Gemini (Alt+R)"
 
 #. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\__init__.py:1919
+#: addon\globalPlugins\visionAssistant\__init__.py:2000
 msgid "Generate Audio (Alt+G)"
 msgstr "Gerar áudio (Alt+G)"
 
 #. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\__init__.py:1929
+#: addon\globalPlugins\visionAssistant\__init__.py:2010
 msgid "Save (Alt+S)"
 msgstr "Guardar (Alt+S)"
 
 #. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\__init__.py:1968
+#: addon\globalPlugins\visionAssistant\__init__.py:2049
 #, python-brace-format
 msgid "Page {num} ready"
 msgstr "Página {num} pronta"
 
 #. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\__init__.py:1990
+#: addon\globalPlugins\visionAssistant\__init__.py:2071
 msgid "[OCR failed. Try Gemini Re-scan.]"
 msgstr "[OCR falhou. Experimente a nova digitalização do Gemini.]"
 
 #. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1999
+#: addon\globalPlugins\visionAssistant\__init__.py:2080
 msgid "Error processing page."
 msgstr "Erro ao processar a página."
 
 #. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\__init__.py:2004
+#: addon\globalPlugins\visionAssistant\__init__.py:2085
 #, python-brace-format
 msgid "Page {current} of {total}"
 msgstr "Página {current} de {total}"
 
 #. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\__init__.py:2011
+#: addon\globalPlugins\visionAssistant\__init__.py:2092
 msgid "Processing in background..."
 msgstr "A processar em segundo plano…"
 
 #. Translators: Spoken message when switching pages
 #. Translators: Heading for each page in the formatted content view.
-#: addon\globalPlugins\visionAssistant\__init__.py:2022
-#: addon\globalPlugins\visionAssistant\__init__.py:2041
+#: addon\globalPlugins\visionAssistant\__init__.py:2103
+#: addon\globalPlugins\visionAssistant\__init__.py:2122
 #, python-brace-format
 msgid "Page {num}"
 msgstr "Página {num}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:2054
+#: addon\globalPlugins\visionAssistant\__init__.py:2135
 msgid "Formatted Content"
 msgstr "Conteúdo formatado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2060
-#: addon\globalPlugins\visionAssistant\__init__.py:2145
+#: addon\globalPlugins\visionAssistant\__init__.py:2141
 #: addon\globalPlugins\visionAssistant\__init__.py:2232
+#: addon\globalPlugins\visionAssistant\__init__.py:2319
 msgid "Please configure Gemini API Key."
 msgstr "Por favor, configure a chave da API do Gemini."
 
 #. Translators: Status reported when an error occurs
-#: addon\globalPlugins\visionAssistant\__init__.py:2060
-#: addon\globalPlugins\visionAssistant\__init__.py:2145
+#: addon\globalPlugins\visionAssistant\__init__.py:2141
 #: addon\globalPlugins\visionAssistant\__init__.py:2232
-#: addon\globalPlugins\visionAssistant\__init__.py:2600
-#: addon\globalPlugins\visionAssistant\__init__.py:2607
-#: addon\globalPlugins\visionAssistant\__init__.py:2676
+#: addon\globalPlugins\visionAssistant\__init__.py:2319
+#: addon\globalPlugins\visionAssistant\__init__.py:2688
+#: addon\globalPlugins\visionAssistant\__init__.py:2695
+#: addon\globalPlugins\visionAssistant\__init__.py:2764
 msgid "Error"
 msgstr "Erro"
 
 #. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\__init__.py:2064
+#: addon\globalPlugins\visionAssistant\__init__.py:2145
 msgid "Current Page"
 msgstr "Página actual"
 
 #. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2066
+#: addon\globalPlugins\visionAssistant\__init__.py:2147
 msgid "All Pages (In Range)"
 msgstr "Todas as páginas (no intervalo especificado)"
 
 #. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\__init__.py:2076
+#: addon\globalPlugins\visionAssistant\__init__.py:2157
 msgid "Scanning with Gemini..."
 msgstr "A digitalizar com o Gemini…"
 
 #. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2092
+#: addon\globalPlugins\visionAssistant\__init__.py:2173
 msgid "Scan complete"
 msgstr "Digitalização concluída"
 
 #. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\__init__.py:2100
+#: addon\globalPlugins\visionAssistant\__init__.py:2181
 msgid "Batch Processing Started"
 msgstr "Processamento em lote iniciado"
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:2111
+#: addon\globalPlugins\visionAssistant\__init__.py:2192
 msgid "Error creating temporary PDF."
 msgstr "Erro ao criar o PDF temporário."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2119
+#: addon\globalPlugins\visionAssistant\__init__.py:2200
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2120
+#. Translators: Message reported when batch scan fails
+#: addon\globalPlugins\visionAssistant\__init__.py:2202
 #, python-brace-format
 msgid "Scan failed: {err}"
 msgstr "Falha na digitalização: {err}"
 
 #. Translators: Message when batch scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2133
+#: addon\globalPlugins\visionAssistant\__init__.py:2220
 msgid "Batch Scan Complete"
 msgstr "Digitalização em lote concluída"
 
 #. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\__init__.py:2149
+#: addon\globalPlugins\visionAssistant\__init__.py:2236
 msgid "Generate for Current Page"
 msgstr "Gerar para a página actual"
 
 #. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2151
+#: addon\globalPlugins\visionAssistant\__init__.py:2238
 msgid "Generate for All Pages (In Range)"
 msgstr "Gerar para todas as páginas (no intervalo)"
 
 #. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\__init__.py:2161
+#: addon\globalPlugins\visionAssistant\__init__.py:2248
 msgid "No text to read."
 msgstr "Nenhum texto para ler."
 
 #. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\__init__.py:2171
+#: addon\globalPlugins\visionAssistant\__init__.py:2258
 msgid "Gathering text for audio..."
 msgstr "A recolher texto para áudio…"
 
 #. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2181
+#: addon\globalPlugins\visionAssistant\__init__.py:2268
 msgid "Save Audio"
 msgstr "Guardar áudio"
 
 #. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2188
+#: addon\globalPlugins\visionAssistant\__init__.py:2275
 msgid "Generating Audio..."
 msgstr "A gerar áudio…"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2204
+#: addon\globalPlugins\visionAssistant\__init__.py:2291
 msgid "lame.exe not found in lib folder."
 msgstr "lame.exe não encontrado na pasta lib."
 
 #. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:2222
+#: addon\globalPlugins\visionAssistant\__init__.py:2309
 msgid "Audio Saved"
 msgstr "Áudio guardado"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2225
+#: addon\globalPlugins\visionAssistant\__init__.py:2312
 msgid "Audio file generated and saved successfully."
 msgstr "Ficheiro de áudio gerado e guardado com sucesso."
 
 #. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\__init__.py:2247
+#: addon\globalPlugins\visionAssistant\__init__.py:2334
 msgid "Save"
 msgstr "Guardar"
 
 #. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\__init__.py:2258
+#: addon\globalPlugins\visionAssistant\__init__.py:2345
 #, python-brace-format
 msgid "Saving Page {num}..."
 msgstr "A guardar a página {num}…"
 
 #. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2271
+#: addon\globalPlugins\visionAssistant\__init__.py:2358
 msgid "Saved"
 msgstr "Guardado"
 
 #. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:2273
+#: addon\globalPlugins\visionAssistant\__init__.py:2360
 msgid "File saved successfully."
 msgstr "Ficheiro guardado com sucesso."
 
 #. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:2308
+#: addon\globalPlugins\visionAssistant\__init__.py:2395
 msgid "&Document Reader..."
 msgstr "&Leitor de documentos..."
 
 #. Translators: Menu item for Audio Transcription
-#: addon\globalPlugins\visionAssistant\__init__.py:2312
+#: addon\globalPlugins\visionAssistant\__init__.py:2399
 msgid "Transcribe &Audio File..."
 msgstr "Transcrever ficheiro de &áudio…"
 
 #. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:2316
+#: addon\globalPlugins\visionAssistant\__init__.py:2403
 msgid "Analyze &Video URL..."
 msgstr "Analisar URL de &vídeo..."
 
 #. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:2322
+#: addon\globalPlugins\visionAssistant\__init__.py:2409
 msgid "&Settings..."
 msgstr "&Configurações..."
 
 #. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:2326
+#: addon\globalPlugins\visionAssistant\__init__.py:2413
 msgid "Check for &Update"
 msgstr "Verificar &atualizações"
 
 #. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:2330
+#: addon\globalPlugins\visionAssistant\__init__.py:2417
 msgid "Docu&mentation"
 msgstr "Docu&mentação"
 
 #. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:2334
+#: addon\globalPlugins\visionAssistant\__init__.py:2421
 msgid "D&onate"
 msgstr "D&oar"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2338
+#. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
+#: addon\globalPlugins\visionAssistant\__init__.py:2426
 msgid "Vision Assistant"
 msgstr "Assistente de Visão"
 
 #. Translators: Standard title for opening a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2352
-#: addon\globalPlugins\visionAssistant\__init__.py:2494
-#: addon\globalPlugins\visionAssistant\__init__.py:2961
+#: addon\globalPlugins\visionAssistant\__init__.py:2440
+#: addon\globalPlugins\visionAssistant\__init__.py:2582
+#: addon\globalPlugins\visionAssistant\__init__.py:3049
 msgid "Open"
 msgstr "Abrir"
 
 #. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:2360
+#: addon\globalPlugins\visionAssistant\__init__.py:2448
 msgid "Supported Files"
 msgstr "Ficheiros suportados"
 
 #. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:2367
-#: addon\globalPlugins\visionAssistant\__init__.py:3144
+#: addon\globalPlugins\visionAssistant\__init__.py:2455
+#: addon\globalPlugins\visionAssistant\__init__.py:3232
 msgid "PyMuPDF library is missing."
 msgstr "A biblioteca PyMuPDF está ausente."
 
 #. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:2373
-#: addon\globalPlugins\visionAssistant\__init__.py:3150
+#: addon\globalPlugins\visionAssistant\__init__.py:2461
+#: addon\globalPlugins\visionAssistant\__init__.py:3238
 msgid "No readable pages found."
 msgstr "Nenhuma página legível encontrada."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2407
+#: addon\globalPlugins\visionAssistant\__init__.py:2495
 msgid "Activates the Command Layer for quick access to all features."
 msgstr "Ativa a Camada de Comandos para acesso rápido a todos os recursos."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2465
-#: addon\globalPlugins\visionAssistant\__init__.py:2776
+#: addon\globalPlugins\visionAssistant\__init__.py:2553
+#: addon\globalPlugins\visionAssistant\__init__.py:2864
 msgid "Translates the selected text or navigator object."
 msgstr "Traduz o texto selecionado ou objeto do navegador."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2466
-#: addon\globalPlugins\visionAssistant\__init__.py:3611
+#: addon\globalPlugins\visionAssistant\__init__.py:2554
+#: addon\globalPlugins\visionAssistant\__init__.py:3699
 msgid "Translates the text currently in the clipboard."
 msgstr "Traduz o texto atualmente na área de transferência."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2467
-#: addon\globalPlugins\visionAssistant\__init__.py:2905
+#: addon\globalPlugins\visionAssistant\__init__.py:2555
+#: addon\globalPlugins\visionAssistant\__init__.py:2993
 msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
 msgstr "Abre um menu para Explicar, Resumir ou Corrigir o texto selecionado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2468
-#: addon\globalPlugins\visionAssistant\__init__.py:3293
+#: addon\globalPlugins\visionAssistant\__init__.py:2556
+#: addon\globalPlugins\visionAssistant\__init__.py:3381
 msgid "Performs OCR and description on the entire screen."
 msgstr "Realiza OCR e descreve o ecrã inteiro."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2469
-#: addon\globalPlugins\visionAssistant\__init__.py:3299
+#: addon\globalPlugins\visionAssistant\__init__.py:2557
+#: addon\globalPlugins\visionAssistant\__init__.py:3387
 msgid "Describes the current object (Navigator Object)."
 msgstr "Descreve o objeto atual (Objeto do Navegador)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2470
-#: addon\globalPlugins\visionAssistant\__init__.py:3244
+#: addon\globalPlugins\visionAssistant\__init__.py:2558
+#: addon\globalPlugins\visionAssistant\__init__.py:3332
 msgid ""
 "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
 msgstr ""
@@ -1364,243 +1407,241 @@ msgstr ""
 "(PDF/Imagens)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2471
-#: addon\globalPlugins\visionAssistant\__init__.py:3131
+#: addon\globalPlugins\visionAssistant\__init__.py:2559
+#: addon\globalPlugins\visionAssistant\__init__.py:3219
 msgid "Recognizes text from a selected image or PDF file."
 msgstr "Reconhece texto de uma imagem ou de um ficheiro PDF selecionado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2472
-#: addon\globalPlugins\visionAssistant\__init__.py:3379
+#: addon\globalPlugins\visionAssistant\__init__.py:2560
+#: addon\globalPlugins\visionAssistant\__init__.py:3467
 msgid "Transcribes a selected audio file."
 msgstr "Transcreve um ficheiro de áudio selecionado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2473
-#: addon\globalPlugins\visionAssistant\__init__.py:3423
+#: addon\globalPlugins\visionAssistant\__init__.py:2561
+#: addon\globalPlugins\visionAssistant\__init__.py:3511
 msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
 msgstr "Analisa uma URL de vídeo do YouTube, Instagram, Twitter ou TikTok."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2474
-#: addon\globalPlugins\visionAssistant\__init__.py:3526
+#: addon\globalPlugins\visionAssistant\__init__.py:2562
+#: addon\globalPlugins\visionAssistant\__init__.py:3614
 msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
 msgstr "Tenta resolver um CAPTCHA no ecrã ou no objeto do navegador."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2475
-#: addon\globalPlugins\visionAssistant\__init__.py:2683
+#: addon\globalPlugins\visionAssistant\__init__.py:2563
+#: addon\globalPlugins\visionAssistant\__init__.py:2771
 msgid "Records voice, transcribes it using AI, and types the result."
 msgstr "Grava a voz, a transcreve usando IA e digita o resultado."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2476
-#: addon\globalPlugins\visionAssistant\__init__.py:2484
+#: addon\globalPlugins\visionAssistant\__init__.py:2564
+#: addon\globalPlugins\visionAssistant\__init__.py:2572
 msgid "Announces the current status of the add-on."
 msgstr "Anuncia o status atual do complemento."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2477
-#: addon\globalPlugins\visionAssistant\__init__.py:3580
+#: addon\globalPlugins\visionAssistant\__init__.py:2565
+#: addon\globalPlugins\visionAssistant\__init__.py:3668
 msgid "Checks for updates manually."
 msgstr "Verifica atualizações manualmente."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2478
+#: addon\globalPlugins\visionAssistant\__init__.py:2566
 msgid "Shows a list of available commands in the layer."
 msgstr "Mostra uma lista de comandos disponíveis na camada."
 
 #. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2481
+#: addon\globalPlugins\visionAssistant\__init__.py:2569
 #, python-brace-format
 msgid "{name} Help"
 msgstr "Ajuda do {name}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2566
+#: addon\globalPlugins\visionAssistant\__init__.py:2654
 #, python-brace-format
 msgid "Upload Connection Error: {reason}"
 msgstr "Erro de Conexão no Upload: {reason}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2572
+#: addon\globalPlugins\visionAssistant\__init__.py:2660
 #, python-brace-format
 msgid "Upload Server Error {code}: {reason}"
 msgstr "Erro do Servidor no Upload {code}: {reason}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2578
+#: addon\globalPlugins\visionAssistant\__init__.py:2666
 #, python-brace-format
 msgid "File Upload Error: {error}"
 msgstr "Erro no envio do ficheiro: {error}"
 
 #. Translators: Error message when there's no content to send
-#: addon\globalPlugins\visionAssistant\__init__.py:2599
-#: addon\globalPlugins\visionAssistant\__init__.py:2606
-#| msgid "No text to read."
+#: addon\globalPlugins\visionAssistant\__init__.py:2687
+#: addon\globalPlugins\visionAssistant\__init__.py:2694
 msgid "Nothing to send."
 msgstr "Nada para enviar."
 
 #. Translators: Error message when AI refuses to answer due to safety guidelines
-#: addon\globalPlugins\visionAssistant\__init__.py:2652
+#: addon\globalPlugins\visionAssistant\__init__.py:2740
 msgid "Error: Response blocked by AI safety filters."
 msgstr "Erro: Resposta bloqueada por filtros de segurança de IA."
 
 #. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:2693
+#: addon\globalPlugins\visionAssistant\__init__.py:2781
 msgid "Listening..."
 msgstr "A ouvir…"
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2697
+#: addon\globalPlugins\visionAssistant\__init__.py:2785
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Erro no Dispositivo de Áudio: {error}"
 
 #. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\__init__.py:2707
+#: addon\globalPlugins\visionAssistant\__init__.py:2795
 msgid "Typing..."
 msgstr "Digitando..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2712
+#: addon\globalPlugins\visionAssistant\__init__.py:2800
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Erro ao guardar a gravação: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\__init__.py:2727
-#: addon\globalPlugins\visionAssistant\__init__.py:2750
+#: addon\globalPlugins\visionAssistant\__init__.py:2815
+#: addon\globalPlugins\visionAssistant\__init__.py:2838
 msgid "No speech detected."
 msgstr "Nenhuma fala detetada."
 
 #. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2757
+#: addon\globalPlugins\visionAssistant\__init__.py:2845
 msgid "No speech recognized or Error."
 msgstr "Nenhuma fala reconhecida ou ocorreu um erro."
 
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2772
+#: addon\globalPlugins\visionAssistant\__init__.py:2860
 #, python-brace-format
 msgid "Typed: {text}"
 msgstr "Digitado: {text}"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2783
+#: addon\globalPlugins\visionAssistant\__init__.py:2871
 msgid "No text found."
 msgstr "Nenhum texto encontrado."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2788
+#: addon\globalPlugins\visionAssistant\__init__.py:2876
 msgid "Translating..."
 msgstr "A traduzir…"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2822
+#: addon\globalPlugins\visionAssistant\__init__.py:2910
 #, python-brace-format
 msgid "Translated: {text}"
 msgstr "Traduzido: {text}"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2840
+#: addon\globalPlugins\visionAssistant\__init__.py:2928
 #, python-brace-format
-#| msgid "Translation"
 msgid "{name} - Translation"
 msgstr "{name} - Tradução"
 
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2932
+#: addon\globalPlugins\visionAssistant\__init__.py:3020
 msgid "Choose action:"
 msgstr "Escolha uma ação:"
 
 #. Translators: Message while processing request of the refine text command
-#: addon\globalPlugins\visionAssistant\__init__.py:2969
+#: addon\globalPlugins\visionAssistant\__init__.py:3057
 msgid "Processing..."
 msgstr "Processando..."
 
 #. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\__init__.py:3027
+#: addon\globalPlugins\visionAssistant\__init__.py:3115
 msgid "Uploading file..."
 msgstr "A enviar ficheiro…"
 
 #. Translators: Message reported when executing the refine command
 #. Translators: Message reported when calling the audio transcription command
 #. Translators: Message reported when AI is analyzing the video
-#: addon\globalPlugins\visionAssistant\__init__.py:3077
-#: addon\globalPlugins\visionAssistant\__init__.py:3401
-#: addon\globalPlugins\visionAssistant\__init__.py:3503
+#: addon\globalPlugins\visionAssistant\__init__.py:3165
+#: addon\globalPlugins\visionAssistant\__init__.py:3489
+#: addon\globalPlugins\visionAssistant\__init__.py:3591
 msgid "Analyzing..."
 msgstr "A analisar…"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3119
+#: addon\globalPlugins\visionAssistant\__init__.py:3207
 #, python-brace-format
 msgid "{name} - Refine Result"
 msgstr "{name} - Resultado Refinado"
 
 #. Translators: Message reported when calling the OCR file recognition command
-#: addon\globalPlugins\visionAssistant\__init__.py:3171
+#: addon\globalPlugins\visionAssistant\__init__.py:3259
 msgid "Uploading & Extracting..."
 msgstr "A enviar e a extrair…"
 
 #. Translators: Error shown when OCR finds no text in the selected files
-#: addon\globalPlugins\visionAssistant\__init__.py:3200
-#: addon\globalPlugins\visionAssistant\__init__.py:3234
+#: addon\globalPlugins\visionAssistant\__init__.py:3288
+#: addon\globalPlugins\visionAssistant\__init__.py:3322
 msgid "No text detected in the selected file(s)."
 msgstr "Nenhum texto detectado no(s) ficheiro(s) selecionado(s)."
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3211
+#: addon\globalPlugins\visionAssistant\__init__.py:3299
 msgid "Error creating PDF."
 msgstr "Erro ao criar PDF."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3281
+#: addon\globalPlugins\visionAssistant\__init__.py:3369
 #, python-brace-format
 msgid "{name} - Chat"
 msgstr "{name} - Chat"
 
 #. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\__init__.py:3309
+#: addon\globalPlugins\visionAssistant\__init__.py:3397
 msgid "Scanning..."
 msgstr "Digitalizando..."
 
 #. Translators: Message reported when calling an image analysis command
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3314
-#: addon\globalPlugins\visionAssistant\__init__.py:3546
+#: addon\globalPlugins\visionAssistant\__init__.py:3402
+#: addon\globalPlugins\visionAssistant\__init__.py:3634
 msgid "Capture failed."
 msgstr "Falha na captura."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3367
+#: addon\globalPlugins\visionAssistant\__init__.py:3455
 #, python-brace-format
 msgid "{name} - Image Analysis"
 msgstr "{name} - Análise de Imagem"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\__init__.py:3391
+#: addon\globalPlugins\visionAssistant\__init__.py:3479
 msgid "Uploading..."
 msgstr "Enviando..."
 
 #. Translators: Generic error message when audio processing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3418
+#: addon\globalPlugins\visionAssistant\__init__.py:3506
 msgid "Error processing audio."
 msgstr "Erro ao processar áudio."
 
 #. Translators: Title for the video URL entry dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3430
+#: addon\globalPlugins\visionAssistant\__init__.py:3518
 msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 msgstr "Análise do YouTube / Instagram / Twitter / TikTok"
 
 #. Translators: Label for the text entry in video dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3432
+#: addon\globalPlugins\visionAssistant\__init__.py:3520
 msgid "Enter Video URL (YouTube/Instagram/Twitter/TikTok):"
 msgstr "Insira o URL do vídeo (YouTube/Instagram/Twitter/TikTok):"
 
 #. Translators: Error message when the URL is invalid
-#: addon\globalPlugins\visionAssistant\__init__.py:3447
-#: addon\globalPlugins\visionAssistant\__init__.py:3450
+#: addon\globalPlugins\visionAssistant\__init__.py:3535
+#: addon\globalPlugins\visionAssistant\__init__.py:3538
 msgid "Error: Invalid URL."
 msgstr "Erro: URL inválida."
 
 #. Translators: Error message when the platform is not supported
-#: addon\globalPlugins\visionAssistant\__init__.py:3460
+#: addon\globalPlugins\visionAssistant\__init__.py:3548
 msgid ""
 "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
 "are supported."
@@ -1609,90 +1650,91 @@ msgstr ""
 "são suportados."
 
 #. Translators: Message reported when processing video link
-#: addon\globalPlugins\visionAssistant\__init__.py:3464
+#: addon\globalPlugins\visionAssistant\__init__.py:3552
 msgid "Processing Video..."
 msgstr "A processar o vídeo..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3475
+#: addon\globalPlugins\visionAssistant\__init__.py:3563
 msgid "Error: Could not extract Instagram video."
 msgstr "Erro: Não foi possível extrair o vídeo do Instagram."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3478
+#: addon\globalPlugins\visionAssistant\__init__.py:3566
 msgid "Error: Could not extract Twitter video."
 msgstr "Erro: Não foi possível extrair o vídeo do Twitter."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3481
+#: addon\globalPlugins\visionAssistant\__init__.py:3569
 msgid "Error: Could not extract TikTok video."
 msgstr "Não foi possível obter o vídeo do TikTok."
 
 #. Translators: Message reported when downloading video
-#: addon\globalPlugins\visionAssistant\__init__.py:3488
+#: addon\globalPlugins\visionAssistant\__init__.py:3576
 msgid "Downloading Video..."
 msgstr "A baixar o vídeo..."
 
 #. Translators: Error message when video download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3493
+#: addon\globalPlugins\visionAssistant\__init__.py:3581
 msgid "Error: Download failed."
 msgstr "Erro: Falha no descarregamento."
 
 #. Translators: Message reported when uploading video to AI
-#: addon\globalPlugins\visionAssistant\__init__.py:3497
+#: addon\globalPlugins\visionAssistant\__init__.py:3585
 msgid "Uploading to AI..."
 msgstr "Carregando para a IA..."
 
 #. Translators: Message reported when analyzing YouTube video
-#: addon\globalPlugins\visionAssistant\__init__.py:3515
+#: addon\globalPlugins\visionAssistant\__init__.py:3603
 msgid "Analyzing YouTube..."
 msgstr "A analisar o YouTube..."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3541
+#: addon\globalPlugins\visionAssistant\__init__.py:3629
 msgid "Solving..."
 msgstr "A resolver..."
 
 #. Translators: Message reported when AI cannot find any CAPTCHA in the image
-#: addon\globalPlugins\visionAssistant\__init__.py:3562
+#: addon\globalPlugins\visionAssistant\__init__.py:3650
 msgid "No CAPTCHA detected."
 msgstr "Nenhum CAPTCHA detetado."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3567
+#: addon\globalPlugins\visionAssistant\__init__.py:3655
 msgid "Failed."
 msgstr "Falhou."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3576
+#: addon\globalPlugins\visionAssistant\__init__.py:3664
 #, python-brace-format
 msgid "Captcha: {text}"
 msgstr "Captcha: {text}"
 
 #. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:3584
+#: addon\globalPlugins\visionAssistant\__init__.py:3672
 msgid "Checking for updates..."
 msgstr "Verificando actualizações..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:3617
+#: addon\globalPlugins\visionAssistant\__init__.py:3705
 msgid "Translating Clipboard..."
 msgstr "Traduzindo área de transferência..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:3622
+#: addon\globalPlugins\visionAssistant\__init__.py:3710
 msgid "Clipboard empty."
 msgstr "Área de transferência vazia."
 
 #. Translators: Message shown when settings dialog is already open
-#: addon\globalPlugins\visionAssistant\__init__.py:3630
+#: addon\globalPlugins\visionAssistant\__init__.py:3721
+#: addon\globalPlugins\visionAssistant\__init__.py:3731
 msgid "Settings dialog is already open."
 msgstr "A caixa de diálogo de configurações já está aberta."
 
 #. Translators: Message when opening documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:3634
+#: addon\globalPlugins\visionAssistant\__init__.py:3737
 msgid "Opening documentation..."
 msgstr "A abrir a documentação..."
 
 #. Translators: Error when help file is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:3644
+#: addon\globalPlugins\visionAssistant\__init__.py:3747
 msgid "Documentation file not found."
 msgstr "Ficheiro de documentação não encontrado."
 
@@ -1780,6 +1822,22 @@ msgstr ""
 "**Guia de Variáveis de Prompt:** Adicionado um guia incorporado nos diálogos "
 "de prompts para ajudar os utilizadores a identificar e usar facilmente "
 "variáveis dinâmicas como [selection], [clipboard] e [screen_obj]."
+
+#~ msgid ""
+#~ "Address copied to clipboard! If you'd like, you can now proceed to your "
+#~ "wallet and donate any amount you can. Your support is greatly appreciated!"
+#~ msgstr ""
+#~ "Endereço copiado para a área de transferência! Se desejar, pode agora "
+#~ "aceder à sua carteira e doar qualquer quantia que puder. Agradecemos "
+#~ "imensamente o seu apoio!"
+
+#~ msgid ""
+#~ "Custom prompt text supports multiple lines and '|' in v2. Legacy versions "
+#~ "may not import these prompts."
+#~ msgstr ""
+#~ "O texto do prompt personalizado suporta múltiplas linhas e o caracter "
+#~ "'barra vertical' na v2. As versões antigas podem não importar estes "
+#~ "prompts."
 
 #~ msgid "Format: Name:Content"
 #~ msgstr "Formato: Nome:Conteúdo"


### PR DESCRIPTION
Refresh Brazilian Portuguese translation file: bump POT date, adjust message line references, add "Copy Support Email" string, simplify clipboard success message, and expand donation dialog text (notes about banking restrictions and gift card/crypto support). Miscellaneous wording and translator comment updates across prompt/voice/UI strings.