### PR TITLE
Update Vietnamese docs and translations

### DIFF
--- a/addon/doc/vi/readme.md
+++ b/addon/doc/vi/readme.md
@@ -1,191 +1,228 @@
 # Tài liệu hướng dẫn Vision Assistant Pro
 
-**Vision Assistant Pro** là trợ lý AI đa năng nâng cao dành cho NVDA. Add-on này tận dụng các mô hình Gemini của Google để cung cấp các khả năng đọc màn hình thông minh, dịch thuật, soạn thảo bằng giọng nói và phân tích tài liệu.
+**Vision Assistant Pro** là một trợ lý AI đa phương thức, nâng cao dành cho NVDA. Nó tận dụng các mô hình Gemini của Google để cung cấp khả năng đọc màn hình thông minh, dịch thuật, đọc chính tả bằng giọng nói và phân tích tài liệu.
 
-*Add-on này được phát hành cho cộng đồng nhằm vinh danh Ngày Quốc tế Người khuyết tật.*
+*Add-on này được phát hành cho cộng đồng nhằm tôn vinh Ngày Quốc tế Người khuyết tật.*
 
 ## 1. Thiết lập & Cấu hình
 
-Truy cập **Menu NVDA > Tùy chọn > Cài đặt > Vision Assistant Pro**.
+Đi tới **Menu NVDA > Tùy chọn > Cài đặt > Vision Assistant Pro**.
 
-* **Khóa API:** Bắt buộc. Bạn có thể nhập nhiều khóa (phân tách bằng dấu phẩy hoặc xuống dòng). Trợ lý sẽ tự động luân chuyển giữa các khóa nếu một khóa hết hạn mức (quota).
-* **Mô hình AI:** Chọn giữa các mô hình **Flash** (Nhanh nhất/Miễn phí), **Lite**, hoặc **Pro** (Trí tuệ cao).
-* **Proxy URL:** Không bắt buộc. Sử dụng nếu Google bị chặn ở khu vực của bạn. Đây phải là một địa chỉ web đóng vai trò làm cầu nối tới API Gemini.
-* **Công cụ OCR:** Chọn giữa **Chrome (Nhanh)** để có kết quả nhanh chóng hoặc **Gemini (Có định dạng)** để giữ nguyên bố cục và nhận dạng bảng biểu tốt hơn.
-* **Giọng đọc TTS:** Chọn kiểu giọng đọc ưu thích để tạo tệp âm thanh từ các trang tài liệu.
-* **Hoán đổi thông minh:** Tự động hoán đổi ngôn ngữ nếu văn bản nguồn khớp với ngôn ngữ đích.
-* **Kết quả trực tiếp:** Bỏ qua cửa sổ chat và thông báo phản hồi của AI trực tiếp bằng giọng nói.
-* **Tích hợp bộ nhớ tạm:** Tự động sao chép phản hồi của AI vào bộ nhớ tạm.
+* **Khóa API (API Key):** Bắt buộc. Bạn có thể nhập nhiều khóa (phân tách bằng dấu phẩy hoặc xuống dòng). Trợ lý sẽ tự động luân phiên giữa các khóa nếu đạt đến giới hạn hạn ngạch.
+* **Mô hình AI:** Chọn giữa các mô hình **Flash** (Nhanh nhất/Miễn phí), **Lite**, hoặc **Pro** (Trí thông minh cao).
+* **URL Proxy:** Tùy chọn. Sử dụng thiết lập này nếu Google bị chặn ở khu vực của bạn. Đây phải là một địa chỉ web hoạt động như một cầu nối với Gemini API.
+* **Công cụ OCR:** Chọn giữa **Chrome (Fast)** để có kết quả nhanh hoặc **Gemini (Formatted)** để giữ nguyên bố cục và nhận dạng bảng tốt hơn.
+* **Giọng nói TTS:** Chọn kiểu giọng nói ưa thích để tạo tệp âm thanh từ các trang tài liệu.
+* **Chuyển đổi thông minh (Smart Swap):** Tự động chuyển đổi ngôn ngữ nếu văn bản nguồn khớp với ngôn ngữ đích.
+* **Đầu ra trực tiếp (Direct Output):** Bỏ qua cửa sổ trò chuyện và đọc thẳng phản hồi của AI qua giọng nói. **Lưu ý:** Ngay cả trong chế độ này, bạn có thể nhấn **Space** trong lớp lệnh để mở lại kết quả cuối cùng trong một hộp thoại trò chuyện.
+* **Tích hợp Clipboard:** Tự động sao chép phản hồi của AI vào clipboard.
 
 ## 2. Lớp lệnh & Phím tắt
 
-Để tránh xung đột phím tắt, add-on này sử dụng một **Lớp lệnh**.
+Để ngăn ngừa xung đột bàn phím, add-on này sử dụng một **Lớp lệnh (Command Layer)**.
 
-1. Nhấn **NVDA + Shift + V** (Phím chính) để kích hoạt lớp lệnh (bạn sẽ nghe thấy một tiếng bíp).
-2. Thả các phím, sau đó nhấn một trong các phím đơn sau:
+1. Nhấn **NVDA + Shift + V** (Phím chính) để kích hoạt lớp lệnh (bạn sẽ nghe thấy tiếng bíp).
+2. Nhả các phím, sau đó nhấn một trong các phím đơn sau:
 
 | Phím | Chức năng | Mô tả |
 | --- | --- | --- |
-| **T** | Trình dịch thông minh | Dịch văn bản dưới con trỏ điều hướng hoặc đoạn đang chọn. |
-| **Shift + T** | Dịch bộ nhớ tạm | Dịch nội dung hiện có trong bộ nhớ tạm. |
-| **R** | Tinh chỉnh văn bản | Tóm tắt, Sửa ngữ pháp, Giải thích hoặc chạy **Lệnh tùy chỉnh**. |
-| **V** | Mô tả đối tượng | Mô tả đối tượng điều hướng hiện tại. |
-| **O** | Mô tả toàn màn hình | Phân tích bố cục và nội dung của toàn bộ màn hình. |
-| **Shift + V** | Phân tích video trực tuyến | Phân tích video **YouTube**, **Instagram**, hoặc **Twitter (X)** qua đường dẫn. |
-| **D** | Trình đọc tài liệu | Trình đọc nâng cao cho PDF và hình ảnh với khả năng chọn phạm vi trang. |
-| **F** | Nhận diện tệp (OCR) | Nhận diện văn bản trực tiếp từ các tệp hình ảnh, PDF hoặc TIFF được chọn. |
-| **A** | Phiên âm âm thanh | Phiên âm các tệp MP3, WAV hoặc OGG thành văn bản. |
-| **C** | Giải CAPTCHA | Chụp và giải CAPTCHA trên màn hình hoặc đối tượng điều hướng. |
-| **S** | Soạn thảo thông minh | Chuyển đổi giọng nói thành văn bản. Nhấn để bắt đầu ghi âm, nhấn lần nữa để dừng/nhập văn bản. |
-| **L** | Báo cáo trạng thái | Thông báo tiến trình hiện tại (ví dụ: "Đang quét...", "Đang chờ"). |
-| **U** | Kiểm tra cập nhật | Kiểm tra phiên bản mới nhất của add-on trên GitHub thủ công. |
+| **T** | Dịch thông minh | Dịch văn bản dưới con trỏ navigator hoặc vùng đang chọn. |
+| **Shift + T** | Dịch Clipboard | Dịch nội dung hiện có trong clipboard. |
+| **R** | Tinh chỉnh văn bản | Tóm tắt, Sửa ngữ pháp, Giải thích hoặc chạy các **Prompt tùy chỉnh**. |
+| **V** | Thị giác đối tượng | Mô tả đối tượng navigator hiện tại. |
+| **O** | Thị giác toàn màn hình | Phân tích toàn bộ bố cục và nội dung màn hình. |
+| **Shift + V** | Phân tích Video trực tuyến | Phân tích video trên **YouTube**, **Instagram**, **TikTok**, hoặc **Twitter (X)**. |
+| **D** | Trình đọc tài liệu | Trình đọc nâng cao cho PDF và hình ảnh với tùy chọn chọn phạm vi trang. |
+| **F** | OCR Tệp | Nhận dạng văn bản trực tiếp từ các tệp hình ảnh, PDF hoặc TIFF được chọn. |
+| **A** | Chuyển biên âm thanh | Chuyển biên các tệp MP3, WAV hoặc OGG thành văn bản. |
+| **C** | Giải CAPTCHA | Chụp và giải mã CAPTCHA trên màn hình hoặc đối tượng navigator. |
+| **S** | Đọc chính tả thông minh | Chuyển đổi giọng nói thành văn bản. Nhấn để bắt đầu ghi âm, nhấn lần nữa để dừng/gõ văn bản. |
+| **L** | Thông báo trạng thái | Thông báo tiến trình hiện tại (ví dụ: "Đang quét...", "Nhàn rỗi"). |
+| **U** | Kiểm tra cập nhật | Kiểm tra thủ công trên GitHub để tìm phiên bản mới nhất của add-on. |
+| **Space** | Gọi lại kết quả cuối | Hiển thị phản hồi cuối cùng của AI trong hộp thoại trò chuyện để xem lại hoặc hỏi tiếp. |
 | **H** | Trợ giúp lệnh | Hiển thị danh sách tất cả các phím tắt có sẵn trong lớp lệnh. |
 
-### 2.1 Phím tắt trong Trình đọc tài liệu (Bên trong trình xem)
+### 2.1 Phím tắt Trình đọc tài liệu (Bên trong Trình xem)
 
-Khi một tài liệu được mở thông qua lệnh **D**:
+Khi một tài liệu được mở qua lệnh **D**:
 
-* **Ctrl + PageDown:** Chuyển sang trang tiếp theo (thông báo số trang).
-* **Ctrl + PageUp:** Chuyển về trang trước (thông báo số trang).
-* **Alt + A:** Mở hộp thoại chat để đặt câu hỏi về tài liệu.
+* **Ctrl + PageDown:** Chuyển đến trang tiếp theo (thông báo số trang).
+* **Ctrl + PageUp:** Chuyển đến trang trước đó (thông báo số trang).
+* **Alt + A:** Mở hộp thoại trò chuyện để đặt câu hỏi về tài liệu.
 * **Alt + R:** Buộc quét lại trang hiện tại hoặc tất cả các trang bằng công cụ Gemini.
 * **Alt + G:** Tạo và lưu tệp âm thanh chất lượng cao (WAV) từ nội dung.
-* **Alt + S / Ctrl + S:** Lưu văn bản đã trích xuất dưới dạng tệp TXT hoặc HTML.
+* **Alt + S / Ctrl + S:** Lưu văn bản được trích xuất dưới dạng tệp TXT hoặc HTML.
 
-## 3. Lệnh tùy chỉnh & Biến
+## 3. Prompt tùy chỉnh & Biến
 
-Bạn có thể tạo các lệnh AI tùy chỉnh mạnh mẽ trong phần Cài đặt bằng định dạng: `Tên:Nội dung lệnh` (phân tách nhiều lệnh bằng dấu `|` hoặc xuống dòng).
+Mở **Cài đặt > Prompts > Manage Prompts...** để cấu hình các prompt hệ thống và tùy chỉnh.
 
-### Các biến hỗ trợ
+* **Thẻ Default Prompts:** chỉnh sửa các prompt có sẵn. Bạn có thể đặt lại một prompt duy nhất hoặc đặt lại tất cả về mặc định.
+* **Thẻ Custom Prompts:** thêm, sửa, xóa và sắp xếp lại các prompt tùy chỉnh.
+* **Nút Variables Guide:** mở cửa sổ trợ giúp với tất cả các biến và loại đầu vào được hỗ trợ.
+
+### Các biến có sẵn
 
 | Biến | Mô tả | Loại đầu vào |
 | --- | --- | --- |
-| `[selection]` | Văn bản đang được chọn | Văn bản |
-| `[clipboard]` | Nội dung bộ nhớ tạm | Văn bản |
-| `[screen_obj]` | Chụp ảnh đối tượng điều hướng | Hình ảnh |
-| `[screen_full]` | Chụp ảnh toàn màn hình | Hình ảnh |
-| `[file_ocr]` | Chọn tệp ảnh/PDF để trích xuất văn bản | Hình ảnh, PDF, TIFF |
+| `[selection]` | Văn bản hiện đang được chọn | Text |
+| `[clipboard]` | Nội dung clipboard | Text |
+| `[screen_obj]` | Ảnh chụp màn hình của đối tượng navigator | Image |
+| `[screen_full]` | Ảnh chụp toàn bộ màn hình | Image |
+| `[file_ocr]` | Chọn tệp hình ảnh/PDF để trích xuất văn bản | Image, PDF, TIFF |
 | `[file_read]` | Chọn tài liệu để đọc | TXT, Code, PDF |
 | `[file_audio]` | Chọn tệp âm thanh để phân tích | MP3, WAV, OGG |
 
-### Ví dụ về Lệnh tùy chỉnh
+### Ví dụ về Prompt tùy chỉnh
 
-* **OCR nhanh:** `OCR của tôi:[file_ocr]`
-* **Dịch hình ảnh:** `Dịch ảnh:Trích xuất văn bản từ hình ảnh này và dịch sang tiếng Anh. [file_ocr]`
-* **Phân tích âm thanh:** `Tóm tắt âm thanh:Nghe bản ghi này và tóm tắt các điểm chính. [file_audio]`
-* **Gỡ lỗi mã nguồn:** `Gỡ lỗi:Tìm lỗi trong đoạn mã này và giải thích chúng: [selection]`
+* **OCR Nhanh:** `My OCR:[file_ocr]`
+* **Dịch hình ảnh:** `Translate Img:Extract text from this image and translate to English. [file_ocr]`
+* **Phân tích âm thanh:** `Summarize Audio:Listen to this recording and summarize the main points. [file_audio]`
+* **Tìm lỗi mã nguồn (Code Debugger):** `Debug:Find bugs in this code and explain them: [selection]`
 
 ---
 
-**Lưu ý:** Cần có kết nối internet để sử dụng tất cả các tính năng AI. Các tài liệu nhiều trang và tệp TIFF được xử lý tự động.
+**Lưu ý:** Cần có kết nối internet đang hoạt động cho tất cả các tính năng AI. Tài liệu nhiều trang và tệp TIFF được xử lý tự động.
 
-## Các thay đổi trong 4.0.1
+## 4. Hỗ trợ & Cộng đồng
 
-* **Trình đọc tài liệu nâng cao:** Trình xem mới mạnh mẽ cho PDF và hình ảnh với khả năng chọn phạm vi trang, xử lý trong nền và điều hướng `Ctrl+PageUp/Down` mượt mà.
-* **Trình đơn phụ mới trong Tools:** Thêm một trình đơn phụ "Vision Assistant" riêng biệt trong menu Công cụ của NVDA để truy cập nhanh hơn vào các tính năng chính, cài đặt và tài liệu hướng dẫn.
-* **Tùy biến linh hoạt:** Giờ đây bạn có thể chọn công cụ OCR và giọng đọc TTS ưa thích trực tiếp từ bảng cài đặt.
-* **Hỗ trợ nhiều khóa API:** Thêm hỗ trợ cho nhiều khóa API Gemini. Bạn có thể nhập mỗi dòng một khóa hoặc phân tách bằng dấu phẩy trong cài đặt.
-* **Công cụ OCR thay thế:** Giới thiệu một công cụ OCR mới để đảm bảo nhận diện văn bản đáng tin cậy ngay cả khi đạt giới hạn hạn mức API Gemini.
-* **Luân chuyển khóa API thông minh:** Tự động chuyển sang và ghi nhớ khóa API hoạt động nhanh nhất để vượt qua giới hạn hạn mức.
-* **Tài liệu sang MP3/WAV:** Tích hợp khả năng tạo và lưu tệp âm thanh chất lượng cao ở cả định dạng MP3 (128kbps) và WAV trực tiếp trong trình đọc.
-* **Hỗ trợ Instagram Stories:** Thêm khả năng mô tả và phân tích Instagram Stories bằng đường dẫn của chúng.
-* **Hỗ trợ TikTok:** Giới thiệu hỗ trợ cho video TikTok, cho phép mô tả hình ảnh đầy đủ và phiên âm âm thanh của các clip.
-* **Thiết kế lại hộp thoại cập nhật:** Giao diện hỗ trợ tiếp cận mới với khung văn bản có thể cuộn để đọc rõ ràng các thay đổi phiên bản trước khi cài đặt.
-* **Trạng thái & UX hợp nhất:** Tiêu chuẩn hóa các hộp thoại tệp trong toàn bộ add-on và cải tiến lệnh 'L' để báo cáo tiến độ theo thời gian thực.
+Cập nhật những tin tức, tính năng và bản phát hành mới nhất:
 
-## Các thay đổi trong 3.6.0
+* **Kênh Telegram:** [t.me/VisionAssistantPro](https://t.me/VisionAssistantPro)
+* **GitHub Issues:** Dành cho báo cáo lỗi và yêu cầu tính năng.
 
-* **Hệ thống trợ giúp:** Thêm lệnh trợ giúp (`H`) trong Lớp lệnh để cung cấp danh sách tất cả các phím tắt và chức năng của chúng một cách dễ dàng.
-* **Phân tích video trực tuyến:** Mở rộng hỗ trợ bao gồm cả video trên **Twitter (X)**. Đồng thời cải thiện khả năng phát hiện đường dẫn và độ ổn định để có trải nghiệm đáng tin cậy hơn.
-* **Đóng góp dự án:** Thêm hộp thoại ủng hộ (donation) tùy chọn cho những người dùng muốn hỗ trợ các bản cập nhật trong tương lai và sự phát triển liên tục của dự án.
+## Những thay đổi trong phiên bản 4.6
 
-## Các thay đổi trong 3.5.0
+* **Gọi lại kết quả tương tác:** Đã thêm phím **Space** vào lớp lệnh, cho phép người dùng mở lại ngay lập tức phản hồi cuối cùng của AI trong cửa sổ trò chuyện để đặt câu hỏi tiếp theo, ngay cả khi chế độ "Direct Output" đang hoạt động.
+* **Cộng đồng Telegram:** Đã thêm liên kết "Official Telegram Channel" vào menu Tools của NVDA, cung cấp một cách nhanh chóng để cập nhật những tin tức, tính năng và bản phát hành mới nhất.
+* **Tăng cường độ ổn định của phản hồi:** Tối ưu hóa logic cốt lõi cho các tính năng Dịch thuật, OCR và Thị giác để đảm bảo hiệu suất đáng tin cậy hơn và trải nghiệm mượt mà hơn khi sử dụng đầu ra giọng nói trực tiếp.
+* **Cải thiện hướng dẫn giao diện:** Đã cập nhật các mô tả cài đặt và tài liệu hướng dẫn để giải thích rõ hơn về hệ thống gọi lại mới và cách thức hoạt động của nó cùng với các cài đặt đầu ra trực tiếp.
 
-* **Lớp lệnh:** Giới thiệu hệ thống Lớp lệnh (mặc định: `NVDA+Shift+V`) để nhóm các phím tắt dưới một phím chính duy nhất. Ví dụ, thay vì nhấn `NVDA+Control+Shift+T` để dịch, giờ đây bạn nhấn `NVDA+Shift+V` sau đó nhấn `T`.
-* **Phân tích video trực tuyến:** Thêm tính năng mới để phân tích video YouTube và Instagram trực tiếp bằng cách cung cấp đường dẫn.
+## Những thay đổi trong phiên bản 4.5
 
-## Các thay đổi trong 3.1.0
+* **Trình quản lý Prompt nâng cao:** Giới thiệu một hộp thoại quản lý chuyên dụng trong cài đặt để tùy chỉnh các prompt hệ thống mặc định và quản lý các prompt do người dùng xác định với hỗ trợ đầy đủ cho việc thêm, sửa, sắp xếp lại và xem trước.
+* **Hỗ trợ Proxy toàn diện:** Đã giải quyết các sự cố kết nối mạng bằng cách đảm bảo rằng các cài đặt proxy do người dùng định cấu hình được áp dụng nghiêm ngặt cho tất cả các yêu cầu API, bao gồm dịch thuật, OCR và tạo giọng nói.
+* **Di chuyển dữ liệu tự động:** Tích hợp hệ thống di chuyển thông minh để tự động nâng cấp các cấu hình prompt cũ sang định dạng v2 JSON mạnh mẽ trong lần chạy đầu tiên mà không làm mất dữ liệu.
+* **Cập nhật khả năng tương thích (2025.1):** Đặt phiên bản NVDA yêu cầu tối thiểu thành 2025.1 do sự phụ thuộc thư viện trong các tính năng nâng cao như Trình đọc tài liệu để đảm bảo hiệu suất ổn định.
+* **Tối ưu hóa giao diện cài đặt:** Sắp xếp hợp lý giao diện cài đặt bằng cách tổ chức lại việc quản lý prompt thành một hộp thoại riêng biệt, mang lại trải nghiệm người dùng rõ ràng và dễ tiếp cận hơn.
+* **Hướng dẫn về biến Prompt:** Đã thêm hướng dẫn tích hợp trong các hộp thoại prompt để giúp người dùng dễ dàng xác định và sử dụng các biến động như `[selection]`, `[clipboard]`, và `[screen_obj]`.
 
-* **Chế độ kết quả trực tiếp:** Thêm tùy chọn để bỏ qua hộp thoại chat và nghe phản hồi của AI trực tiếp qua giọng nói để có trải nghiệm nhanh hơn và liền mạch hơn.
-* **Tích hợp bộ nhớ tạm:** Thêm cài đặt mới để tự động sao chép phản hồi AI vào bộ nhớ tạm.
+## Những thay đổi trong phiên bản 4.0.3
 
-## Các thay đổi trong 3.0
+* **Tăng cường độ ổn định mạng:** Đã thêm cơ chế thử lại tự động để xử lý tốt hơn các kết nối internet không ổn định và lỗi máy chủ tạm thời, đảm bảo phản hồi AI đáng tin cậy hơn.
+* **Hộp thoại dịch trực quan:** Giới thiệu một cửa sổ dành riêng cho kết quả dịch. Người dùng giờ đây có thể dễ dàng điều hướng và đọc các bản dịch dài theo từng dòng, tương tự như kết quả OCR.
+* **Chế độ xem định dạng tổng hợp:** Tính năng "View Formatted" trong Trình đọc tài liệu hiện hiển thị tất cả các trang đã xử lý trong một cửa sổ duy nhất, được tổ chức với các tiêu đề trang rõ ràng.
+* **Tối ưu hóa quy trình OCR:** Tự động bỏ qua việc chọn phạm vi trang đối với các tài liệu chỉ có một trang, giúp quá trình nhận dạng diễn ra nhanh chóng và liền mạch hơn.
+* **Cải thiện độ ổn định API:** Chuyển sang phương thức xác thực dựa trên header mạnh mẽ hơn, giải quyết các lỗi "All API Keys failed" tiềm ẩn do xung đột khi luân phiên khóa.
+* **Sửa lỗi:** Đã giải quyết một số sự cố treo có thể xảy ra, bao gồm sự cố trong quá trình tắt add-on và lỗi tiêu điểm trong hộp thoại trò chuyện.
 
-* **Ngôn ngữ mới:** Thêm bản dịch tiếng **Ba Tư** và tiếng **Việt**.
-* **Mở rộng mô hình AI:** Sắp xếp lại danh sách lựa chọn mô hình với các tiền tố rõ ràng (`[Free]`, `[Pro]`, `[Auto]`) để giúp người dùng phân biệt giữa các mô hình miễn phí và các mô hình giới hạn hạn mức (trả phí). Thêm hỗ trợ cho **Gemini 3.0 Pro** và **Gemini 2.0 Flash Lite**.
-* **Độ ổn định của soạn thảo:** Cải thiện đáng kể độ ổn định của Soạn thảo thông minh. Thêm kiểm tra an toàn để bỏ qua các đoạn âm thanh ngắn hơn 1 giây, ngăn chặn AI "ảo giác" và các lỗi trống.
-* **Xử lý tệp:** Khắc phục lỗi tải lên các tệp có tên không phải tiếng Anh bị thất bại.
-* **Tối ưu hóa câu lệnh:** Cải thiện logic Dịch thuật và cấu trúc kết quả Thị giác (Vision).
+## Những thay đổi trong phiên bản 4.0.1
 
-## Các thay đổi trong 2.9
+* **Trình đọc tài liệu nâng cao:** Một trình xem mới, mạnh mẽ dành cho PDF và hình ảnh với khả năng chọn phạm vi trang, xử lý nền và điều hướng liền mạch bằng `Ctrl+PageUp/Down`.
+* **Menu con Tools mới:** Đã thêm một menu con "Vision Assistant" chuyên dụng bên dưới menu Tools của NVDA để truy cập nhanh hơn vào các tính năng cốt lõi, cài đặt và tài liệu hướng dẫn.
+* **Tùy chỉnh linh hoạt:** Giờ đây, bạn có thể chọn công cụ OCR và giọng nói TTS ưa thích trực tiếp từ bảng cài đặt.
+* **Hỗ trợ nhiều khóa API:** Đã thêm hỗ trợ cho nhiều khóa API Gemini. Bạn có thể nhập một khóa trên mỗi dòng hoặc phân tách chúng bằng dấu phẩy trong cài đặt.
+* **Công cụ OCR thay thế:** Giới thiệu một công cụ OCR mới để đảm bảo nhận dạng văn bản đáng tin cậy ngay cả khi đạt đến giới hạn hạn ngạch của Gemini API.
+* **Luân phiên Khóa API thông minh:** Tự động chuyển sang và ghi nhớ khóa API hoạt động nhanh nhất để vượt qua giới hạn hạn ngạch.
+* **Tài liệu sang MP3/WAV:** Tích hợp khả năng tạo và lưu các tệp âm thanh chất lượng cao ở cả định dạng MP3 (128kbps) và WAV trực tiếp trong trình đọc.
+* **Hỗ trợ Instagram Stories:** Đã thêm khả năng mô tả và phân tích Instagram Stories bằng URL của chúng.
+* **Hỗ trợ TikTok:** Giới thiệu hỗ trợ cho các video TikTok, cho phép mô tả hình ảnh đầy đủ và chuyển biên âm thanh của các đoạn clip.
+* **Hộp thoại cập nhật được thiết kế lại:** Cung cấp một giao diện mới, dễ tiếp cận với hộp văn bản có thể cuộn để đọc rõ các thay đổi của phiên bản trước khi cài đặt.
+* **Trạng thái & UX thống nhất:** Chuẩn hóa các hộp thoại tệp trên toàn bộ add-on và cải tiến lệnh 'L' để báo cáo tiến trình theo thời gian thực.
 
-* **Thêm bản dịch tiếng Pháp và tiếng Thổ Nhĩ Kỳ.**
-* **Xem có định dạng:** Thêm nút "Xem bản có định dạng" trong hộp thoại chat để xem cuộc hội thoại với định dạng chuẩn (Tiêu đề, Chữ đậm, Mã nguồn) trong một cửa sổ duyệt văn bản tiêu chuẩn.
-* **Cài đặt Markdown:** Thêm tùy chọn mới "Làm sạch Markdown trong Chat" trong Cài đặt. Bỏ chọn mục này cho phép người dùng thấy cú pháp Markdown thô (ví dụ: `**`, `#`) trong cửa sổ chat.
-* **Quản lý hộp thoại:** Khắc phục lỗi các cửa sổ "Tinh chỉnh văn bản" hoặc cửa sổ chat mở ra nhiều lần hoặc không thể tập trung chính xác.
-* **Cải tiến UX:** Tiêu chuẩn hóa tiêu đề các hộp thoại tệp thành "Mở" và loại bỏ các thông báo giọng nói dư thừa (ví dụ: "Đang mở trình đơn...") để có trải nghiệm mượt mà hơn.
+## Những thay đổi trong phiên bản 3.6.0
 
-## Các thay đổi trong 2.8
+* **Hệ thống trợ giúp:** Đã thêm lệnh trợ giúp (`H`) trong Lớp lệnh để cung cấp một danh sách dễ truy cập gồm tất cả các phím tắt và chức năng của chúng.
+* **Phân tích Video trực tuyến:** Mở rộng hỗ trợ để bao gồm các video trên **Twitter (X)**. Đồng thời cải thiện khả năng phát hiện URL và độ ổn định để có trải nghiệm đáng tin cậy hơn.
+* **Đóng góp cho dự án:** Đã thêm hộp thoại quyên góp tùy chọn cho những người dùng muốn ủng hộ các bản cập nhật trong tương lai và sự phát triển liên tục của dự án.
 
-* Thêm bản dịch tiếng Ý.
-* **Báo cáo trạng thái:** Thêm lệnh mới (NVDA+Control+Shift+I) để thông báo trạng thái hiện tại của add-on (ví dụ: "Đang tải lên...", "Đang phân tích...").
-* **Xuất HTML:** Nút "Lưu nội dung" trong các hộp thoại kết quả giờ đây lưu kết quả dưới dạng tệp HTML có định dạng, giữ nguyên các kiểu như tiêu đề và chữ đậm.
-* **Giao diện Cài đặt:** Cải thiện bố cục bảng Cài đặt với các nhóm có thể tiếp cận tốt hơn.
-* **Mô hình mới:** Thêm hỗ trợ cho gemini-flash-latest và gemini-flash-lite-latest.
-* **Ngôn ngữ:** Thêm tiếng Nepal vào danh sách các ngôn ngữ được hỗ trợ.
-* **Logic trình đơn Tinh chỉnh:** Khắc phục một lỗi nghiêm trọng khiến các lệnh "Tinh chỉnh văn bản" thất bại nếu ngôn ngữ giao diện NVDA không phải là tiếng Anh.
-* **Soạn thảo:** Cải thiện khả năng phát hiện sự im lặng để ngăn kết quả văn bản không chính xác khi không có tiếng nói đầu vào.
-* **Cài đặt cập nhật:** Mục "Kiểm tra cập nhật khi khởi động" hiện bị tắt theo mặc định để tuân thủ các chính sách của Cửa hàng Add-on.
-* Làm sạch mã nguồn.
+## Những thay đổi trong phiên bản 3.5.0
 
-## Các thay đổi trong 2.7
+* **Lớp lệnh:** Giới thiệu hệ thống Lớp lệnh (mặc định: `NVDA+Shift+V`) để nhóm các phím tắt dưới một phím chính duy nhất. Ví dụ: thay vì nhấn `NVDA+Control+Shift+T` để dịch, giờ đây bạn nhấn `NVDA+Shift+V` theo sau là `T`.
+* **Phân tích Video trực tuyến:** Đã thêm tính năng mới để phân tích trực tiếp các video trên YouTube và Instagram bằng cách cung cấp URL.
 
-* Di chuyển cấu trúc dự án sang Mẫu Add-on chính thức của NV Access để tuân thủ tốt hơn các tiêu chuẩn.
-* Triển khai logic tự động thử lại cho các lỗi HTTP 429 (Giới hạn hạn mức) để đảm bảo độ tin cậy khi lưu lượng truy cập cao.
-* Tối ưu hóa các câu lệnh dịch thuật để có độ chính xác cao hơn và xử lý logic "Hoán đổi thông minh" tốt hơn.
-* Cập nhật bản dịch tiếng Nga.
+## Những thay đổi trong phiên bản 3.1.0
 
-## Các thay đổi trong 2.6
+* **Chế độ Đầu ra trực tiếp:** Đã thêm tùy chọn để bỏ qua hộp thoại trò chuyện và nghe thẳng các phản hồi của AI qua giọng nói để có trải nghiệm nhanh chóng và liền mạch hơn.
+* **Tích hợp Clipboard:** Đã thêm một cài đặt mới để tự động sao chép các phản hồi của AI vào clipboard.
 
-* Thêm hỗ trợ bản dịch tiếng Nga (Cảm ơn nvda-ru).
-* Cập nhật các thông báo lỗi để cung cấp phản hồi mô tả chi tiết hơn về kết nối.
+## Những thay đổi trong phiên bản 3.0
+
+* **Ngôn ngữ mới:** Đã thêm bản dịch tiếng **Ba Tư** và tiếng **Việt**.
+* **Mở rộng mô hình AI:** Tổ chức lại danh sách chọn mô hình với các tiền tố rõ ràng (`[Free]`, `[Pro]`, `[Auto]`) để giúp người dùng phân biệt giữa các mô hình miễn phí và giới hạn tốc độ (trả phí). Đã thêm hỗ trợ cho **Gemini 3.0 Pro** và **Gemini 2.0 Flash Lite**.
+* **Độ ổn định khi Đọc chính tả:** Cải thiện đáng kể độ ổn định của tính năng Đọc chính tả thông minh. Đã thêm kiểm tra an toàn để bỏ qua các đoạn âm thanh ngắn hơn 1 giây, ngăn chặn hiện tượng AI "ảo giác" và các lỗi trống.
+* **Xử lý tệp:** Đã sửa lỗi tải lên các tệp có tên không phải tiếng Anh bị thất bại.
+* **Tối ưu hóa Prompt:** Cải thiện logic Dịch thuật và cấu trúc lại kết quả của Thị giác.
+
+## Những thay đổi trong phiên bản 2.9
+
+* **Đã thêm bản dịch tiếng Pháp và tiếng Thổ Nhĩ Kỳ.**
+* **Chế độ xem định dạng:** Đã thêm nút "View Formatted" trong các hộp thoại trò chuyện để xem cuộc hội thoại với định dạng chuẩn (Tiêu đề, In đậm, Code) trong một cửa sổ có thể duyệt qua tiêu chuẩn.
+* **Cài đặt Markdown:** Đã thêm tùy chọn mới "Clean Markdown in Chat" trong phần Cài đặt. Bỏ chọn tùy chọn này cho phép người dùng xem cú pháp Markdown gốc (ví dụ: `**`, `#`) trong cửa sổ trò chuyện.
+* **Quản lý hộp thoại:** Đã sửa sự cố trong đó cửa sổ "Refine Text" hoặc cửa sổ trò chuyện sẽ mở nhiều lần hoặc không lấy được tiêu điểm chính xác.
+* **Cải tiến UX:** Chuẩn hóa các tiêu đề hộp thoại tệp thành "Open" và loại bỏ các thông báo giọng nói dư thừa (ví dụ: "Opening menu...") để có trải nghiệm mượt mà hơn.
+
+## Những thay đổi trong phiên bản 2.8
+
+* Đã thêm bản dịch tiếng Ý.
+* **Thông báo trạng thái:** Đã thêm một lệnh mới (NVDA+Control+Shift+I) để thông báo trạng thái hiện tại của add-on (ví dụ: "Uploading...", "Analyzing...").
+* **Xuất HTML:** Nút "Save Content" trong các hộp thoại kết quả hiện lưu đầu ra dưới dạng tệp HTML được định dạng, giữ nguyên các kiểu như tiêu đề và chữ in đậm.
+* **Giao diện Cài đặt:** Cải thiện bố cục bảng Cài đặt với các nhóm dễ tiếp cận hơn.
+* **Các mô hình mới:** Đã thêm hỗ trợ cho gemini-flash-latest và gemini-flash-lite-latest.
+* **Ngôn ngữ:** Đã thêm tiếng Nepal vào các ngôn ngữ được hỗ trợ.
+* **Logic menu Refine:** Đã sửa một lỗi nghiêm trọng khiến các lệnh "Refine Text" bị lỗi nếu ngôn ngữ giao diện NVDA không phải là tiếng Anh.
+* **Đọc chính tả:** Cải thiện tính năng phát hiện khoảng lặng để ngăn chặn đầu ra văn bản không chính xác khi không có giọng nói được nhập vào.
+* **Cài đặt cập nhật:** Tính năng "Check for updates on startup" hiện bị tắt theo mặc định để tuân thủ các chính sách của Add-on Store.
+* Dọn dẹp mã nguồn.
+
+## Những thay đổi trong phiên bản 2.7
+
+* Chuyển đổi cấu trúc dự án sang Mẫu Add-on chính thức của NV Access để tuân thủ các tiêu chuẩn tốt hơn.
+* Đã triển khai logic thử lại tự động cho các lỗi HTTP 429 (Rate Limit) để đảm bảo độ tin cậy trong thời gian lưu lượng truy cập cao.
+* Tối ưu hóa các prompt dịch thuật để có độ chính xác cao hơn và xử lý logic "Smart Swap" tốt hơn.
+* Đã cập nhật bản dịch tiếng Nga.
+
+## Những thay đổi trong phiên bản 2.6
+
+* Đã thêm hỗ trợ bản dịch tiếng Nga (Cảm ơn nvda-ru).
+* Cập nhật các thông báo lỗi để cung cấp phản hồi mang tính mô tả cao hơn về vấn đề kết nối.
 * Thay đổi ngôn ngữ đích mặc định thành tiếng Anh.
 
-## Các thay đổi trong 2.5
+## Những thay đổi trong phiên bản 2.5
 
-* Thêm lệnh Nhận diện tệp (OCR) gốc (NVDA+Control+Shift+F).
-* Thêm nút "Lưu cuộc trò chuyện" vào các hộp thoại kết quả.
-* Triển khai hỗ trợ bản địa hóa đầy đủ (i18n).
-* Di chuyển phản hồi âm thanh sang mô-đun âm báo gốc của NVDA.
-* Chuyển sang sử dụng Gemini File API để xử lý các tệp PDF và âm thanh tốt hơn.
-* Khắc phục lỗi crash khi dịch văn bản có chứa dấu ngoặc nhọn.
+* Đã thêm lệnh Native File OCR (NVDA+Control+Shift+F).
+* Đã thêm nút "Save Chat" vào các hộp thoại kết quả.
+* Đã triển khai hỗ trợ bản địa hóa đầy đủ (i18n).
+* Đã chuyển các phản hồi âm thanh sang mô-đun tones gốc của NVDA.
+* Chuyển sang sử dụng Gemini File API để xử lý tốt hơn các tệp PDF và âm thanh.
+* Đã sửa lỗi treo khi dịch văn bản có chứa dấu ngoặc nhọn.
 
-## Các thay đổi trong 2.1.1
+## Những thay đổi trong phiên bản 2.1.1
 
-* Khắc phục lỗi biến [file_ocr] hoạt động không chính xác trong các Lệnh tùy chỉnh.
+* Đã sửa sự cố trong đó biến `[file_ocr]` không hoạt động bình thường trong Custom Prompts.
 
-## Các thay đổi trong 2.1
+## Những thay đổi trong phiên bản 2.1
 
-* Tiêu chuẩn hóa tất cả các phím tắt sử dụng tổ hợp NVDA+Control+Shift để loại bỏ các xung đột với bố cục Laptop của NVDA và các phím nóng hệ thống.
+* Chuẩn hóa tất cả các phím tắt để sử dụng NVDA+Control+Shift nhằm loại bỏ xung đột với bố cục Bàn phím Laptop của NVDA và các phím nóng hệ thống.
 
-## Các thay đổi trong 2.0
+## Những thay đổi trong phiên bản 2.0
 
-* Triển khai hệ thống Tự động cập nhật tích hợp.
-* Thêm Bộ nhớ tạm dịch thông minh để truy xuất tức thì các văn bản đã dịch trước đó.
-* Thêm Bộ nhớ hội thoại để tinh chỉnh kết quả theo ngữ cảnh trong các hộp thoại chat.
-* Thêm lệnh Dịch bộ nhớ tạm riêng biệt (NVDA+Control+Shift+Y).
-* Tối ưu hóa các câu lệnh AI để ép buộc nghiêm ngặt kết quả đầu ra theo ngôn ngữ đích.
-* Khắc phục lỗi crash do các ký tự đặc biệt trong văn bản đầu vào.
+* Đã triển khai hệ thống Tự động cập nhật tích hợp sẵn.
+* Đã thêm Bộ nhớ đệm Dịch thông minh để truy xuất tức thì các văn bản đã dịch trước đó.
+* Đã thêm Bộ nhớ hội thoại để tinh chỉnh kết quả theo ngữ cảnh trong các hộp thoại trò chuyện.
+* Đã thêm Lệnh dịch Clipboard chuyên dụng (NVDA+Control+Shift+Y).
+* Tối ưu hóa các prompt AI để thực thi nghiêm ngặt đầu ra ngôn ngữ đích.
+* Đã sửa lỗi treo do các ký tự đặc biệt trong văn bản đầu vào.
 
-## Các thay đổi trong 1.5
+## Những thay đổi trong phiên bản 1.5
 
-* Thêm hỗ trợ cho hơn 20 ngôn ngữ mới.
-* Triển khai Hộp thoại tinh chỉnh tương tác cho các câu hỏi tiếp nối.
-* Thêm tính năng Soạn thảo thông minh gốc.
-* Thêm danh mục "Vision Assistant" vào hộp thoại Cử chỉ nhập liệu của NVDA.
-* Khắc phục các lỗi COMError trong các ứng dụng cụ thể như Firefox và Word.
-* Thêm cơ chế tự động thử lại cho các lỗi máy chủ.
+* Đã thêm hỗ trợ cho hơn 20 ngôn ngữ mới.
+* Đã triển khai Hộp thoại Tinh chỉnh Tương tác cho các câu hỏi tiếp theo.
+* Đã thêm tính năng Đọc chính tả thông minh gốc.
+* Đã thêm danh mục "Vision Assistant" vào hộp thoại Input Gestures của NVDA.
+* Đã sửa các lỗi treo COMError trong một số ứng dụng cụ thể như Firefox và Word.
+* Đã thêm cơ chế tự động thử lại đối với các lỗi máy chủ.
 
-## Các thay đổi trong 1.0
+## Những thay đổi trong phiên bản 1.0
 
-* Phiên bản phát hành đầu tiên.
+* Phát hành lần đầu.

--- a/addon/locale/vi/LC_MESSAGES/nvda.po
+++ b/addon/locale/vi/LC_MESSAGES/nvda.po
@@ -1,15 +1,17 @@
-# Vision Assistant Pro Translation File.
-# Copyright (C) 2026
-# This file is distributed under the same license as the VisionAssistant package.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the 'VisionAssistant' package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: VisionAssistant 4.0.0\n"
+"Project-Id-Version: 'VisionAssistant' '4.6'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-01-26 16:50+0330\n"
-"PO-Revision-Date: 2026-01-27 10:05+0700\n"
-"Last-Translator: Gemini\n"
-"Language-Team: Vietnamese\n"
+"POT-Creation-Date: 2026-02-20 13:33+0330\n"
+"PO-Revision-Date: 2026-02-21 17:37+0700\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,42 +19,45 @@ msgstr ""
 "X-Generator: Poedit 3.6\n"
 
 #. Translators: Label for the button to copy the TON cryptocurrency wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:17
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:18
 msgid "Copy TON Address"
-msgstr "Sao chép địa chỉ ví TON"
+msgstr "Sao chép địa chỉ TON"
 
 #. Translators: Label for the button to copy the USDT (TRC20 network) wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:19
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:20
 msgid "Copy USDT (TRC20) Address"
 msgstr "Sao chép địa chỉ USDT (TRC20)"
 
+#. Translators: Label for the button to copy the support email address for gift cards.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:22
+msgid "Copy Support Email"
+msgstr "Sao chép email hỗ trợ"
+
 #. Translators: Button to dismiss the donation dialog without taking any action.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:25
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:29
 msgid "Maybe Later"
 msgstr "Để sau"
 
-#. Translators: Success message shown after a wallet address is copied to the clipboard.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:36
-msgid ""
-"Address copied to clipboard! If you'd like, you can now proceed to your "
-"wallet and donate any amount you can. Your support is greatly appreciated!"
-msgstr ""
-"Địa chỉ đã được sao chép vào bộ nhớ tạm! Nếu muốn, bạn có thể truy cập ví "
-"của mình và ủng hộ bất kỳ số tiền nào. Sự giúp đỡ của bạn là niềm khích lệ "
-"rất lớn!"
+#. Translators: Success message shown after an address or email is copied to the clipboard.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:40
+msgid "Copied to clipboard! Your support is greatly appreciated!"
+msgstr "Đã sao chép vào clipboard! Rất trân trọng sự ủng hộ của bạn!"
 
 #. Translators: Title for the success message box.
-#: addon\globalPlugins\visionAssistant\__init__.py:2221 addon\globalPlugins\visionAssistant\__init__.py:2269 addon\globalPlugins\visionAssistant\donate_dialog.py:38
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:42
+#: addon\globalPlugins\visionAssistant\__init__.py:2346
+#: addon\globalPlugins\visionAssistant\__init__.py:2394
 msgid "Success"
 msgstr "Thành công"
 
 #. Translators: Title of the donation request dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:49
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
 #, python-brace-format
 msgid "Support the Future of {name}"
 msgstr "Ủng hộ tương lai của {name}"
 
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
+#. Translators: The main message of the donation dialog.
+#: addon\globalPlugins\visionAssistant\donate_dialog.py:56
 #, python-brace-format
 msgid ""
 "{name} is a project born from a personal vision to bridge the gap between AI "
@@ -65,296 +70,802 @@ msgid ""
 "remains fast, stable, and constantly evolving is a continuous creative "
 "journey that I am passionate about pursuing.\n"
 "\n"
+"Important Note: Due to international banking restrictions in my region, I am "
+"unable to use PayPal or Stripe. If you wish to support this project, you can "
+"donate via Cryptocurrency or by sending an Apple Gift Card (US region) to: "
+"{email}\n"
+"\n"
 "If this assistant has brought value to your daily life, your support is a "
 "wonderful way to show appreciation for the original work and the dedication "
-"behind it. It provides the extra motivation to keep the inspiration alive "
-"and ensures we can continue to push the boundaries together. Thank you for "
-"being part of this mission!"
+"behind it. Thank you for being part of this mission!"
 msgstr ""
-"{name} là một dự án ra đời từ mong muốn cá nhân nhằm xóa nhòa khoảng cách "
-"giữa AI và khả năng tiếp cận thực tế. Ý tưởng ban đầu cũng như nhiều tính "
-"năng bạn đang sử dụng được hình thành từ tâm huyết của tôi để giải quyết các "
-"thách thức thực tế, mang lại sự độc lập mới trong môi trường kỹ thuật số.\n"
+"Dự án {name} ra đời từ tầm nhìn cá nhân nhằm thu hẹp khoảng cách giữa AI "
+"và khả năng tiếp cận thực sự. Ý tưởng ban đầu và nhiều tính năng bạn "
+"đang sử dụng được tạo ra từ chính những ý tưởng của tôi để giải quyết những "
+"thách thức thực tế và mang lại một mức độ độc lập kỹ thuật số mới.\n"
 "\n"
-"Tôi luôn nỗ lực trau chuốt từng chi tiết và biến những cải tiến của bản thân "
-"cũng như những yêu cầu quý báu của bạn thành hiện thực. Việc duy trì công cụ "
-"này luôn nhanh chóng, ổn định và không ngừng phát triển là một hành trình "
-"sáng tạo mà tôi luôn theo đuổi.\n"
+"Tôi rất tự hào khi suy nghĩ thấu đáo từng chi tiết và biến cả những "
+"đổi mới của riêng mình cũng như những yêu cầu quý giá của bạn thành hiện thực. "
+"Đảm bảo công cụ này luôn nhanh chóng, ổn định và không ngừng phát triển là "
+"một hành trình sáng tạo không ngừng mà tôi đam mê theo đuổi.\n"
 "\n"
-"Nếu trợ lý này mang lại giá trị cho cuộc sống của bạn, sự ủng hộ của bạn là "
-"cách tuyệt vời để ghi nhận nỗ lực sáng tạo và tâm huyết đằng sau nó. Đây "
-"cũng là động lực to lớn để giữ vững nguồn cảm hứng và cùng nhau phá vỡ những "
-"rào cản. Cảm ơn bạn đã đồng hành!"
+"Lưu ý quan trọng: Do những hạn chế về ngân hàng quốc tế tại khu vực của tôi, "
+"tôi không thể sử dụng PayPal hoặc Stripe. Nếu bạn muốn ủng hộ dự án này, bạn có thể "
+"quyên góp qua Tiền điện tử hoặc bằng cách gửi Apple Gift Card (khu vực Mỹ) tới: "
+"{email}\n"
+"\n"
+"Nếu trợ lý này mang lại giá trị cho cuộc sống hàng ngày của bạn, sự ủng hộ của bạn là "
+"một cách tuyệt vời để thể hiện sự trân trọng đối với công trình ban đầu và sự cống hiến "
+"đằng sau nó. Cảm ơn bạn đã là một phần của sứ mệnh này!"
+
+#. Translators: Label for prompt name input field.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:22
+msgid "Name:"
+msgstr "Tên:"
+
+#. Translators: Label for prompt text input field.
+#. Translators: Label above the prompt editor textarea.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:28
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:189
+msgid "Prompt Text:"
+msgstr "Văn bản prompt:"
+
+#. Translators: Button label to open the variables help dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:47
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:142
+msgid "Variables Guide"
+msgstr "Hướng dẫn về biến"
+
+#. Translators: Validation error for empty prompt name.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:64
+msgid "Name cannot be empty."
+msgstr "Tên không được để trống."
+
+#. Translators: Title of validation warning dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:66
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:74
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:362
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:473
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:501
+msgid "Validation Error"
+msgstr "Lỗi xác thực"
+
+#. Translators: Validation error for empty prompt text.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:72
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:360
+msgid "Prompt text cannot be empty."
+msgstr "Văn bản prompt không được để trống."
+
+#. Translators: Title for the prompt variables help dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:95
+msgid "Prompt Variables Guide"
+msgstr "Hướng dẫn về biến prompt"
+
+#. Translators: Intro text for the prompt variables help dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:99
+msgid "Use these variables inside prompt text:"
+msgstr "Sử dụng các biến này bên trong văn bản prompt:"
+
+#. Translators: Button to close chat dialog
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:110
+#: addon\globalPlugins\visionAssistant\__init__.py:1505
+#: addon\globalPlugins\visionAssistant\__init__.py:2049
+msgid "Close"
+msgstr "Đóng"
+
+#. Translators: Title for the prompt manager dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:120
+msgid "Prompt Manager"
+msgstr "Quản lý prompt"
+
+#. Translators: Notebook tab for built-in refine prompts.
+#. Translators: Label above the list of default prompt entries.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:132
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:166
+msgid "Default Prompts"
+msgstr "Prompt mặc định"
+
+#. Translators: Notebook tab for user-defined prompts.
+#. Translators: Label above the list of custom prompts.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:134
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:221
+msgid "Custom Prompts"
+msgstr "Prompt tùy chỉnh"
+
+#. Translators: Note explaining when prompt changes are persisted.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:146
+msgid "Changes are applied only when you press OK."
+msgstr "Các thay đổi chỉ được áp dụng khi bạn nhấn OK."
+
+#. Translators: Button label to reset currently selected default prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:178
+msgid "Reset Selected"
+msgstr "Đặt lại mục đã chọn"
+
+#. Translators: Button label to reset all default prompts.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:183
+msgid "Reset All"
+msgstr "Đặt lại tất cả"
+
+#. Translators: Button label to apply current editor text to the selected default prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:198
+msgid "Apply to Selected"
+msgstr "Áp dụng cho mục đã chọn"
+
+#. Translators: Button label for adding a custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:230
+msgid "Add"
+msgstr "Thêm"
+
+#. Translators: Button label for editing a custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
+msgid "Edit"
+msgstr "Sửa"
+
+#. Translators: Button label for removing a custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:234
+msgid "Remove"
+msgstr "Xóa"
+
+#. Translators: Button label for moving selected custom prompt up in the list.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:245
+msgid "Move Up"
+msgstr "Di chuyển lên"
+
+#. Translators: Button label for moving selected custom prompt down in the list.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:247
+msgid "Move Down"
+msgstr "Di chuyển xuống"
+
+#. Translators: Label above the custom prompt preview area.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:256
+msgid "Prompt Preview:"
+msgstr "Xem trước prompt:"
+
+#. Translators: Validation message shown when required text is missing in a guarded prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:318
+#, python-brace-format
+msgid ""
+"This prompt is used by {feature}. To save it, add the required text below:"
+msgstr "Prompt này được sử dụng bởi {feature}. Để lưu lại, hãy thêm văn bản bắt buộc bên dưới:"
+
+#. Translators: Guidance shown after listing missing required text.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:324
+msgid "Add these items exactly as written, then try again."
+msgstr "Thêm các mục này chính xác như đã viết, sau đó thử lại."
+
+#. Translators: Title of validation warning dialog for guarded prompt checks.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:326
+msgid "Required Text Missing"
+msgstr "Thiếu văn bản bắt buộc"
+
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:338
+#, python-brace-format
+msgid ""
+"You are editing a prompt used by {feature}.\n"
+"\n"
+"If this prompt is changed, this feature may not work correctly.\n"
+"\n"
+"Do you understand the risk and want to save anyway?"
+msgstr ""
+"Bạn đang chỉnh sửa một prompt được sử dụng bởi {feature}.\n"
+"\n"
+"Nếu prompt này bị thay đổi, tính năng này có thể không hoạt động chính xác.\n"
+"\n"
+"Bạn có hiểu rủi ro và vẫn muốn lưu không?"
+
+#. Translators: Title of confirmation dialog shown before saving guarded prompts.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:341
+msgid "Confirm"
+msgstr "Xác nhận"
+
+#. Translators: Confirm button label for guarded prompt save confirmation.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:345
+msgid "Yes, Save Anyway"
+msgstr "Có, vẫn lưu"
+
+#. Translators: Cancel button label for guarded prompt save confirmation.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:347
+msgid "No, Go Back"
+msgstr "Không, quay lại"
+
+#. Translators: Message shown after applying changes to the selected default prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:396
+msgid "Selected prompt updated."
+msgstr "Đã cập nhật prompt được chọn."
+
+#. Translators: Confirmation text before resetting all default prompts.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:409
+msgid "Reset all default prompts to built-in values?"
+msgstr "Đặt lại tất cả prompt mặc định về giá trị gốc?"
+
+#. Translators: Title of confirmation dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:411
+msgid "Confirm Reset"
+msgstr "Xác nhận đặt lại"
+
+#. Translators: Title of dialog for adding a custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:466
+msgid "Add Custom Prompt"
+msgstr "Thêm prompt tùy chỉnh"
+
+#. Translators: Validation error for duplicate custom prompt name.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:471
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:499
+msgid "A custom prompt with this name already exists."
+msgstr "Một prompt tùy chỉnh với tên này đã tồn tại."
+
+#. Translators: Title of the dialog for editing an existing custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:490
+msgid "Edit Custom Prompt"
+msgstr "Chỉnh sửa prompt tùy chỉnh"
+
+#. Translators: Confirmation text before deleting a custom prompt.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:514
+#, python-brace-format
+msgid "Remove custom prompt '{name}'?"
+msgstr "Xóa prompt tùy chỉnh '{name}'?"
+
+#. Translators: Title of confirmation dialog.
+#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:516
+msgid "Confirm Remove"
+msgstr "Xác nhận xóa"
 
 #. --- 1. Recommended (Auto-Updating) ---
 #. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest version.
-#: addon\globalPlugins\visionAssistant\__init__.py:67 addon\globalPlugins\visionAssistant\__init__.py:68
+#: addon\globalPlugins\visionAssistant\__init__.py:67
+#: addon\globalPlugins\visionAssistant\__init__.py:68
 msgid "[Auto]"
 msgstr "[Tự động]"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:67 addon\globalPlugins\visionAssistant\__init__.py:68
+#: addon\globalPlugins\visionAssistant\__init__.py:67
+#: addon\globalPlugins\visionAssistant\__init__.py:68
 msgid "(Latest)"
 msgstr "(Mới nhất)"
 
 #. --- 2. Current Standard (Free & Fast) ---
 #. Translators: AI Model info. [Free] = Generous usage limits. (Preview) = Experimental or early-access version.
-#: addon\globalPlugins\visionAssistant\__init__.py:72 addon\globalPlugins\visionAssistant\__init__.py:73 addon\globalPlugins\visionAssistant\__init__.py:74
+#: addon\globalPlugins\visionAssistant\__init__.py:72
+#: addon\globalPlugins\visionAssistant\__init__.py:73
+#: addon\globalPlugins\visionAssistant\__init__.py:74
 msgid "[Free]"
 msgstr "[Miễn phí]"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:72 addon\globalPlugins\visionAssistant\__init__.py:78
+#: addon\globalPlugins\visionAssistant\__init__.py:72
+#: addon\globalPlugins\visionAssistant\__init__.py:78
 msgid "(Preview)"
-msgstr "(Thử nghiệm)"
+msgstr "(Bản xem trước)"
 
 #. --- 3. High Intelligence (Paid/Pro/Preview) ---
 #. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview) = Experimental version.
-#: addon\globalPlugins\visionAssistant\__init__.py:78 addon\globalPlugins\visionAssistant\__init__.py:79
+#: addon\globalPlugins\visionAssistant\__init__.py:78
+#: addon\globalPlugins\visionAssistant\__init__.py:79
 msgid "[Pro]"
 msgstr "[Pro]"
 
-#. Translators: Voice style description (e.g., Bright, Calm, Formal).
-#: addon\globalPlugins\visionAssistant\__init__.py:84 addon\globalPlugins\visionAssistant\__init__.py:93
+#. Translators: Adjective describing a bright AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:84
+#: addon\globalPlugins\visionAssistant\__init__.py:102
 msgid "Bright"
-msgstr "Tươi sáng"
+msgstr "Sáng sủa"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:85 addon\globalPlugins\visionAssistant\__init__.py:102
+#. Translators: Adjective describing an upbeat AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:86
+#: addon\globalPlugins\visionAssistant\__init__.py:120
 msgid "Upbeat"
-msgstr "Sôi nổi"
+msgstr "Vui vẻ"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:86 addon\globalPlugins\visionAssistant\__init__.py:101
+#. Translators: Adjective describing an informative AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:88
+#: addon\globalPlugins\visionAssistant\__init__.py:118
 msgid "Informative"
 msgstr "Nhiều thông tin"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:87 addon\globalPlugins\visionAssistant\__init__.py:90 addon\globalPlugins\visionAssistant\__init__.py:104
+#. Translators: Adjective describing a firm AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:90
+#: addon\globalPlugins\visionAssistant\__init__.py:96
+#: addon\globalPlugins\visionAssistant\__init__.py:124
 msgid "Firm"
-msgstr "Mạnh mẽ"
+msgstr "Quả quyết"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:88
+#. Translators: Adjective describing an excitable AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:92
 msgid "Excitable"
-msgstr "Hào hứng"
+msgstr "Sôi nổi"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:89
+#. Translators: Adjective describing a youthful AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:94
 msgid "Youthful"
 msgstr "Trẻ trung"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:91
+#. Translators: Adjective describing a breezy AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:98
 msgid "Breezy"
-msgstr "Phóng khoáng"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:92 addon\globalPlugins\visionAssistant\__init__.py:96
-msgid "Easy-going"
 msgstr "Thoải mái"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:94
-msgid "Breathy"
-msgstr "Hơi mỏng"
+#. Translators: Adjective describing an easy-going AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:100
+#: addon\globalPlugins\visionAssistant\__init__.py:108
+msgid "Easy-going"
+msgstr "Dễ tính"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:95 addon\globalPlugins\visionAssistant\__init__.py:99
+#. Translators: Adjective describing a breathy AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:104
+msgid "Breathy"
+msgstr "Nhẹ nhàng"
+
+#. Translators: Adjective describing a clear AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:106
+#: addon\globalPlugins\visionAssistant\__init__.py:114
 msgid "Clear"
 msgstr "Rõ ràng"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:97 addon\globalPlugins\visionAssistant\__init__.py:98
+#. Translators: Adjective describing a smooth AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:110
+#: addon\globalPlugins\visionAssistant\__init__.py:112
 msgid "Smooth"
 msgstr "Mượt mà"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:100
+#. Translators: Adjective describing a gravelly AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:116
 msgid "Gravelly"
-msgstr "Trầm khàn"
+msgstr "Khàn"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:103
+#. Translators: Adjective describing a soft AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:122
 msgid "Soft"
-msgstr "Nhẹ nhàng"
+msgstr "Mềm mại"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:105
+#. Translators: Adjective describing an even AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:126
 msgid "Even"
-msgstr "Điềm tĩnh"
+msgstr "Đều đặn"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:106
+#. Translators: Adjective describing a mature AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:128
 msgid "Mature"
 msgstr "Trưởng thành"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:107
+#. Translators: Adjective describing a forward AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:130
 msgid "Forward"
-msgstr "Quyết đoán"
+msgstr "Thẳng thắn"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:108
+#. Translators: Adjective describing a friendly AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:132
 msgid "Friendly"
 msgstr "Thân thiện"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:109
+#. Translators: Adjective describing a casual AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:134
 msgid "Casual"
-msgstr "Tự nhiên"
+msgstr "Bình thường"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:110
+#. Translators: Adjective describing a gentle AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:136
 msgid "Gentle"
 msgstr "Dịu dàng"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:111
+#. Translators: Adjective describing a lively AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:138
 msgid "Lively"
-msgstr "Sinh động"
+msgstr "Sống động"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:112
+#. Translators: Adjective describing a knowledgeable AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:140
 msgid "Knowledgeable"
-msgstr "Thông thái"
+msgstr "Uyên bác"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:113
+#. Translators: Adjective describing a warm AI voice style.
+#: addon\globalPlugins\visionAssistant\__init__.py:142
 msgid "Warm"
 msgstr "Ấm áp"
 
 #. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\__init__.py:134
+#: addon\globalPlugins\visionAssistant\__init__.py:163
 msgid "Chrome (Fast)"
 msgstr "Chrome (Nhanh)"
 
 #. Translators: OCR Engine option (Slower but better formatting)
-#: addon\globalPlugins\visionAssistant\__init__.py:136
+#: addon\globalPlugins\visionAssistant\__init__.py:165
 msgid "Gemini (Formatted)"
-msgstr "Gemini (Có định dạng)"
+msgstr "Gemini (Được định dạng)"
+
+#. Translators: Section header for text refinement prompts in Prompt Manager.
+#. Translators: main message of the Refine dialog
+#: addon\globalPlugins\visionAssistant\__init__.py:205
+#: addon\globalPlugins\visionAssistant\__init__.py:213
+#: addon\globalPlugins\visionAssistant\__init__.py:221
+#: addon\globalPlugins\visionAssistant\__init__.py:229
+#: addon\globalPlugins\visionAssistant\__init__.py:3055
+msgid "Refine"
+msgstr "Tinh chỉnh"
+
+#. Translators: Label for the text summarization prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:207
+msgid "Summarize"
+msgstr "Tóm tắt"
+
+#. Translators: Label for the grammar correction prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:215
+msgid "Fix Grammar"
+msgstr "Sửa ngữ pháp"
+
+#. Translators: Label for the grammar correction and translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:223
+msgid "Fix Grammar & Translate"
+msgstr "Sửa ngữ pháp & Dịch"
+
+#. Translators: Label for the text explanation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:231
+msgid "Explain"
+msgstr "Giải thích"
+
+#. Translators: Section header for translation-related prompts in Prompt Manager.
+#. Translators: Box title for translation options
+#: addon\globalPlugins\visionAssistant\__init__.py:237
+#: addon\globalPlugins\visionAssistant\__init__.py:249
+#: addon\globalPlugins\visionAssistant\__init__.py:1858
+msgid "Translation"
+msgstr "Dịch thuật"
+
+#. Translators: Label for the smart translation prompt.
+#. Translators: Feature name used in guarded prompt warnings for smart translation.
+#: addon\globalPlugins\visionAssistant\__init__.py:239
+#: addon\globalPlugins\visionAssistant\__init__.py:242
+msgid "Smart Translation"
+msgstr "Dịch thông minh"
+
+#. Translators: Label for the quick translation prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:251
+msgid "Quick Translation"
+msgstr "Dịch nhanh"
+
+#. Translators: Section header for document-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:257
+#: addon\globalPlugins\visionAssistant\__init__.py:384
+msgid "Document"
+msgstr "Tài liệu"
+
+#. Translators: Label for the initial context prompt in document chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:259
+msgid "Document Chat Context"
+msgstr "Ngữ cảnh trò chuyện tài liệu"
+
+#. Translators: Section header for advanced/internal prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:265
+#: addon\globalPlugins\visionAssistant\__init__.py:302
+#: addon\globalPlugins\visionAssistant\__init__.py:311
+#: addon\globalPlugins\visionAssistant\__init__.py:411
+msgid "Advanced"
+msgstr "Nâng cao"
+
+#. Translators: Label for the AI's acknowledgement reply in document chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:267
+msgid "Document Chat Bootstrap Reply"
+msgstr "Phản hồi khởi động trò chuyện tài liệu"
+
+#. Translators: Section header for image analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:274
+#: addon\globalPlugins\visionAssistant\__init__.py:288
+msgid "Vision"
+msgstr "Thị giác"
+
+#. Translators: Label for the prompt used to analyze the current navigator object.
+#: addon\globalPlugins\visionAssistant\__init__.py:276
+msgid "Navigator Object Analysis"
+msgstr "Phân tích đối tượng Navigator"
+
+#. Translators: Label for the prompt used to analyze the entire screen.
+#: addon\globalPlugins\visionAssistant\__init__.py:290
+msgid "Full Screen Analysis"
+msgstr "Phân tích toàn màn hình"
+
+#. Translators: Label for the follow-up context in image analysis chat.
+#: addon\globalPlugins\visionAssistant\__init__.py:304
+msgid "Vision Follow-up Context"
+msgstr "Ngữ cảnh tiếp theo của thị giác"
+
+#. Translators: Label for the rule enforced during image analysis follow-up questions.
+#: addon\globalPlugins\visionAssistant\__init__.py:313
+msgid "Vision Follow-up Answer Rule"
+msgstr "Quy tắc trả lời tiếp theo của thị giác"
+
+#. Translators: Section header for video analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:320
+msgid "Video"
+msgstr "Video"
+
+#. Translators: Label for the video content analysis prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:322
+msgid "Video Analysis"
+msgstr "Phân tích Video"
+
+#. Translators: Section header for audio-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:332
+#: addon\globalPlugins\visionAssistant\__init__.py:340
+msgid "Audio"
+msgstr "Âm thanh"
+
+#. Translators: Label for the audio file transcription prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:334
+msgid "Audio Transcription"
+msgstr "Chuyển biên âm thanh"
+
+#. Translators: Label for the smart voice dictation prompt.
+#. Translators: Feature name used in guarded prompt warnings for smart dictation.
+#: addon\globalPlugins\visionAssistant\__init__.py:342
+#: addon\globalPlugins\visionAssistant\__init__.py:345
+msgid "Smart Dictation"
+msgstr "Đọc chính tả thông minh"
+
+#. Translators: Section header for OCR-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:355
+#: addon\globalPlugins\visionAssistant\__init__.py:367
+msgid "OCR"
+msgstr "OCR"
+
+#. Translators: Label for the OCR prompt used for image text extraction.
+#: addon\globalPlugins\visionAssistant\__init__.py:357
+msgid "OCR Image Extraction"
+msgstr "Trích xuất văn bản từ hình ảnh (OCR)"
+
+#. Translators: Label for the OCR prompt used for document text extraction.
+#. Translators: Feature name used in guarded prompt warnings for OCR document extraction.
+#: addon\globalPlugins\visionAssistant\__init__.py:369
+#: addon\globalPlugins\visionAssistant\__init__.py:372
+msgid "OCR Document Extraction"
+msgstr "Trích xuất văn bản từ tài liệu (OCR)"
+
+#. Translators: Label for the combined OCR and translation prompt for documents.
+#: addon\globalPlugins\visionAssistant\__init__.py:386
+msgid "Document OCR + Translate"
+msgstr "OCR Tài liệu + Dịch"
+
+#. Translators: Section header for CAPTCHA-related prompts in Prompt Manager.
+#. --- CAPTCHA Group ---
+#. Translators: Title of the settings group for CAPTCHA options
+#: addon\globalPlugins\visionAssistant\__init__.py:396
+#: addon\globalPlugins\visionAssistant\__init__.py:1742
+msgid "CAPTCHA"
+msgstr "CAPTCHA"
+
+#. Translators: Label for the CAPTCHA solving prompt.
+#. Translators: Feature name used in guarded prompt warnings for CAPTCHA solver.
+#: addon\globalPlugins\visionAssistant\__init__.py:398
+#: addon\globalPlugins\visionAssistant\__init__.py:401
+msgid "CAPTCHA Solver"
+msgstr "Giải CAPTCHA"
+
+#. Translators: Label for the fallback prompt when only files are provided in Refine.
+#: addon\globalPlugins\visionAssistant\__init__.py:413
+msgid "Refine Files-Only Fallback"
+msgstr "Dự phòng tinh chỉnh chỉ dành cho tệp"
+
+#. Translators: Description and input type for the [selection] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:421
+msgid "Currently selected text"
+msgstr "Văn bản đang được chọn"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:421
+#: addon\globalPlugins\visionAssistant\__init__.py:423
+msgid "Text"
+msgstr "Văn bản"
+
+#. Translators: Description for the [clipboard] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:423
+msgid "Clipboard content"
+msgstr "Nội dung clipboard"
+
+#. Translators: Description and input type for the [screen_obj] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:425
+msgid "Screenshot of the navigator object"
+msgstr "Ảnh chụp màn hình của đối tượng navigator"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:425
+#: addon\globalPlugins\visionAssistant\__init__.py:427
+msgid "Image"
+msgstr "Hình ảnh"
+
+#. Translators: Description for the [screen_full] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:427
+msgid "Screenshot of the entire screen"
+msgstr "Ảnh chụp toàn bộ màn hình"
+
+#. Translators: Description and input type for the [file_ocr] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:429
+msgid "Select image/PDF/TIFF for text extraction"
+msgstr "Chọn hình ảnh/PDF/TIFF để trích xuất văn bản"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:429
+msgid "Image, PDF, TIFF"
+msgstr "Hình ảnh, PDF, TIFF"
+
+#. Translators: Description and input type for the [file_read] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:431
+msgid "Select document for reading"
+msgstr "Chọn tài liệu để đọc"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:431
+msgid "TXT, Code, PDF"
+msgstr "TXT, Code, PDF"
+
+#. Translators: Description and input type for the [file_audio] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\__init__.py:433
+msgid "Select audio file for analysis"
+msgstr "Chọn tệp âm thanh để phân tích"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:433
+msgid "MP3, WAV, OGG"
+msgstr "MP3, WAV, OGG"
+
+#. Translators: Prefix for custom prompts in the Refine menu
+#: addon\globalPlugins\visionAssistant\__init__.py:721
+msgid "Custom: "
+msgstr "Tùy chỉnh: "
 
 #. Translators: Title of the error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:698
+#: addon\globalPlugins\visionAssistant\__init__.py:805
 #, python-brace-format
 msgid "{name} Error"
 msgstr "Lỗi {name}"
 
 #. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\__init__.py:959
+#: addon\globalPlugins\visionAssistant\__init__.py:1068
 msgid "Error 400: Bad Request (Check API Key)"
-msgstr ""
-"Lỗi 400: Yêu cầu không hợp lệ (Kiểm tra khóa API)Lỗi 400: Yêu cầu không hợp "
-"lệ (Kiểm tra định dạng khóa API)"
+msgstr "Lỗi 400: Yêu cầu không hợp lệ (Kiểm tra Khóa API)"
 
 #. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\__init__.py:961
+#: addon\globalPlugins\visionAssistant\__init__.py:1070
 msgid "Error 403: Forbidden (Check Region)"
-msgstr ""
-"Lỗi 403: Bị cấm (Kiểm tra vùng)Lỗi 403: Bị từ chối (Kiểm tra vùng địa lý "
-"hoặc quyền truy cập)"
+msgstr "Lỗi 403: Bị cấm (Kiểm tra Khu vực)"
+
+#. Translators: Message of a dialog which may pop up while performing an AI call
+#: addon\globalPlugins\visionAssistant\__init__.py:1113
+#: addon\globalPlugins\visionAssistant\__init__.py:1234
+msgid "Error 429: Quota Exceeded (Try later)"
+msgstr "Lỗi 429: Vượt quá hạn ngạch (Thử lại sau)"
+
+#. Translators: Message of a dialog which may pop up while performing an AI call
+#: addon\globalPlugins\visionAssistant\__init__.py:1116
+#: addon\globalPlugins\visionAssistant\__init__.py:1237
+#, python-brace-format
+msgid "Server Error {code}: {reason}"
+msgstr "Lỗi máy chủ {code}: {reason}"
 
 #. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:1017
+#: addon\globalPlugins\visionAssistant\__init__.py:1126
 msgid "No API Keys configured."
-msgstr "Chưa cấu hình khóa API."
+msgstr "Chưa cấu hình Khóa API nào."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1032
+#: addon\globalPlugins\visionAssistant\__init__.py:1141
 msgid "All API Keys failed (Quota/Server)."
-msgstr "Tất cả khóa API đều thất bại (Hết hạn mức hoặc lỗi máy chủ)."
+msgstr "Tất cả Khóa API đều thất bại (Hạn ngạch/Máy chủ)."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1036
+#: addon\globalPlugins\visionAssistant\__init__.py:1145
 msgid "Unknown error occurred."
 msgstr "Đã xảy ra lỗi không xác định."
 
 #. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\__init__.py:1068
+#: addon\globalPlugins\visionAssistant\__init__.py:1177
 msgid "No API Keys."
-msgstr "Không có khóa API."
+msgstr "Không có Khóa API."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1134
+#: addon\globalPlugins\visionAssistant\__init__.py:1214
+#: addon\globalPlugins\visionAssistant\__init__.py:1944
+#: addon\globalPlugins\visionAssistant\__init__.py:3344
+msgid "Upload failed."
+msgstr "Tải lên thất bại."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:1243
 msgid "All keys failed."
 msgstr "Tất cả các khóa đều thất bại."
 
 #. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1231
+#: addon\globalPlugins\visionAssistant\__init__.py:1340
 msgid "Update Available"
 msgstr "Có bản cập nhật mới"
 
 #. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\__init__.py:1238
+#: addon\globalPlugins\visionAssistant\__init__.py:1347
 #, python-brace-format
 msgid "A new version ({version}) of {name} is available."
 msgstr "Đã có phiên bản mới ({version}) của {name}."
 
 #. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\__init__.py:1243
+#: addon\globalPlugins\visionAssistant\__init__.py:1352
 msgid "Changes:"
-msgstr "Thay đổi:"
+msgstr "Những thay đổi:"
 
 #. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\__init__.py:1250
+#: addon\globalPlugins\visionAssistant\__init__.py:1359
 msgid "Download and Install?"
-msgstr "Tải về và cài đặt?"
+msgstr "Tải xuống và Cài đặt?"
 
 #. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\__init__.py:1255
+#: addon\globalPlugins\visionAssistant\__init__.py:1364
 msgid "&Yes"
 msgstr "&Có"
 
 #. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\__init__.py:1257
+#: addon\globalPlugins\visionAssistant\__init__.py:1366
 msgid "&No"
 msgstr "&Không"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1298
+#. Translators: Error message when an update is found but the addon file is missing from GitHub.
+#: addon\globalPlugins\visionAssistant\__init__.py:1408
 msgid "Update found but no .nvda-addon file in release."
-msgstr "Đã thấy bản cập nhật nhưng không tìm thấy tệp .nvda-addon."
+msgstr "Đã tìm thấy bản cập nhật nhưng không có tệp .nvda-addon trong bản phát hành."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1301
+#. Translators: Status message informing the user they are already on the latest version.
+#: addon\globalPlugins\visionAssistant\__init__.py:1412
 msgid "You have the latest version."
 msgstr "Bạn đang sử dụng phiên bản mới nhất."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1305
+#: addon\globalPlugins\visionAssistant\__init__.py:1416
 #, python-brace-format
 msgid "Update check failed: {error}"
 msgstr "Kiểm tra cập nhật thất bại: {error}"
 
 #. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\__init__.py:1324
+#: addon\globalPlugins\visionAssistant\__init__.py:1435
 msgid "Downloading update..."
-msgstr "Đang tải bản cập nhật..."
+msgstr "Đang tải xuống bản cập nhật..."
 
 #. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1333
+#: addon\globalPlugins\visionAssistant\__init__.py:1444
 #, python-brace-format
 msgid "Download failed: {error}"
 msgstr "Tải xuống thất bại: {error}"
 
 #. Translators: Label for the AI response text area in a chat dialog
 #. Translators: Label for AI Response Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1353 addon\globalPlugins\visionAssistant\__init__.py:1595
+#: addon\globalPlugins\visionAssistant\__init__.py:1464
+#: addon\globalPlugins\visionAssistant\__init__.py:1706
 msgid "AI Response:"
-msgstr "Phản hồi từ AI:"
+msgstr "Phản hồi của AI:"
 
 #. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1363 addon\globalPlugins\visionAssistant\__init__.py:1451 addon\globalPlugins\visionAssistant\__init__.py:1468
+#: addon\globalPlugins\visionAssistant\__init__.py:1474
+#: addon\globalPlugins\visionAssistant\__init__.py:1562
+#: addon\globalPlugins\visionAssistant\__init__.py:1579
 #, python-brace-format
 msgid "AI: {text}\n"
 msgstr "AI: {text}\n"
 
 #. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1374
+#: addon\globalPlugins\visionAssistant\__init__.py:1485
 msgid "Ask:"
 msgstr "Hỏi:"
 
 #. Translators: Button to send message in a chat dialog
 #. Translators: Button to send message
-#: addon\globalPlugins\visionAssistant\__init__.py:1384 addon\globalPlugins\visionAssistant\__init__.py:1808
+#: addon\globalPlugins\visionAssistant\__init__.py:1495
+#: addon\globalPlugins\visionAssistant\__init__.py:1925
 msgid "Send"
 msgstr "Gửi"
 
 #. Translators: Button to view the content in a formatted HTML window
 #. Translators: Button to view formatted content
-#: addon\globalPlugins\visionAssistant\__init__.py:1386 addon\globalPlugins\visionAssistant\__init__.py:1920
+#: addon\globalPlugins\visionAssistant\__init__.py:1497
+#: addon\globalPlugins\visionAssistant\__init__.py:2039
 msgid "View Formatted"
-msgstr "Xem bản có định dạng"
+msgstr "Xem định dạng"
 
 #. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:1389
+#: addon\globalPlugins\visionAssistant\__init__.py:1500
 msgid "Save Content"
 msgstr "Lưu nội dung"
 
 #. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1392
+#: addon\globalPlugins\visionAssistant\__init__.py:1503
 msgid "Save Chat"
-msgstr "Lưu cuộc trò chuyện"
-
-#. Translators: Button to close chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1394 addon\globalPlugins\visionAssistant\__init__.py:1930 addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:112
-msgid "Close"
-msgstr "Đóng"
+msgstr "Lưu trò chuyện"
 
 #. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1427 addon\globalPlugins\visionAssistant\__init__.py:1466
+#: addon\globalPlugins\visionAssistant\__init__.py:1538
+#: addon\globalPlugins\visionAssistant\__init__.py:1577
 #, python-brace-format
 msgid ""
 "\n"
@@ -365,863 +876,926 @@ msgstr ""
 
 #. Translators: Message shown while processing in a chat dialog
 #. Translators: Message showing AI is thinking
-#: addon\globalPlugins\visionAssistant\__init__.py:1431 addon\globalPlugins\visionAssistant\__init__.py:1843
+#: addon\globalPlugins\visionAssistant\__init__.py:1542
+#: addon\globalPlugins\visionAssistant\__init__.py:1960
 msgid "Thinking..."
 msgstr "Đang suy nghĩ..."
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:1488
+#: addon\globalPlugins\visionAssistant\__init__.py:1599
 msgid "Formatted Conversation"
-msgstr "Hội thoại có định dạng"
+msgstr "Cuộc trò chuyện đã định dạng"
 
 #. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:1491
+#: addon\globalPlugins\visionAssistant\__init__.py:1602
 #, python-brace-format
 msgid "Error displaying content: {error}"
 msgstr "Lỗi khi hiển thị nội dung: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:1496
+#: addon\globalPlugins\visionAssistant\__init__.py:1607
 msgid "Save Chat Log"
 msgstr "Lưu nhật ký trò chuyện"
 
+#. Translators: Message shown on successful save of a file.
 #. Translators: Message on successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:1501 addon\globalPlugins\visionAssistant\__init__.py:1515
+#: addon\globalPlugins\visionAssistant\__init__.py:1612
+#: addon\globalPlugins\visionAssistant\__init__.py:1626
 msgid "Saved."
 msgstr "Đã lưu."
 
 #. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1504 addon\globalPlugins\visionAssistant\__init__.py:1518
+#: addon\globalPlugins\visionAssistant\__init__.py:1615
+#: addon\globalPlugins\visionAssistant\__init__.py:1629
 #, python-brace-format
 msgid "Save failed: {error}"
 msgstr "Lưu thất bại: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:1509
+#: addon\globalPlugins\visionAssistant\__init__.py:1620
 msgid "Save Result"
 msgstr "Lưu kết quả"
 
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\__init__.py:1526
+#: addon\globalPlugins\visionAssistant\__init__.py:1637
 msgid "Connection"
 msgstr "Kết nối"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\__init__.py:1532
+#: addon\globalPlugins\visionAssistant\__init__.py:1643
 msgid "Gemini API Key (Separate multiple keys with comma or newline):"
 msgstr "Khóa API Gemini (Phân tách nhiều khóa bằng dấu phẩy hoặc xuống dòng):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\__init__.py:1546
+#: addon\globalPlugins\visionAssistant\__init__.py:1657
 msgid "Show API Key"
-msgstr "Hiện khóa API"
+msgstr "Hiển thị Khóa API"
 
 #. Translators: Label for Model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1552
+#: addon\globalPlugins\visionAssistant\__init__.py:1663
 msgid "AI Model:"
 msgstr "Mô hình AI:"
 
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:1560
+#: addon\globalPlugins\visionAssistant\__init__.py:1671
 msgid "Proxy URL:"
-msgstr "Đường dẫn Proxy:"
+msgstr "URL Proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on NVDA startup
-#: addon\globalPlugins\visionAssistant\__init__.py:1564
+#: addon\globalPlugins\visionAssistant\__init__.py:1675
 msgid "Check for updates on startup"
 msgstr "Kiểm tra cập nhật khi khởi động"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\__init__.py:1567
+#: addon\globalPlugins\visionAssistant\__init__.py:1678
 msgid "Clean Markdown in Chat"
-msgstr "Làm sạch Markdown trong cửa sổ chat"
+msgstr "Làm sạch Markdown trong trò chuyện"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:1570
+#: addon\globalPlugins\visionAssistant\__init__.py:1681
 msgid "Copy AI responses to clipboard"
-msgstr "Sao chép phản hồi AI vào bộ nhớ tạm"
+msgstr "Sao chép phản hồi của AI vào clipboard"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\__init__.py:1573
+#: addon\globalPlugins\visionAssistant\__init__.py:1684
 msgid "Direct Output (No Chat Window)"
-msgstr "Kết quả trực tiếp (Không hiện cửa sổ chat)"
+msgstr "Đầu ra trực tiếp (Không có cửa sổ trò chuyện)"
 
 #. --- Translation Languages Group ---
 #. Translators: Title of the settings group for translation languages configuration
-#: addon\globalPlugins\visionAssistant\__init__.py:1579
+#: addon\globalPlugins\visionAssistant\__init__.py:1690
 msgid "Translation Languages"
-msgstr "Ngôn ngữ dịch thuật"
+msgstr "Ngôn ngữ dịch"
 
 #. Translators: Label for Source Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1585
+#: addon\globalPlugins\visionAssistant\__init__.py:1696
 msgid "Source:"
 msgstr "Nguồn:"
 
 #. Translators: Label for Target Language selection
 #. Translators: Label for target language
-#: addon\globalPlugins\visionAssistant\__init__.py:1590 addon\globalPlugins\visionAssistant\__init__.py:1747
+#: addon\globalPlugins\visionAssistant\__init__.py:1701
+#: addon\globalPlugins\visionAssistant\__init__.py:1864
 msgid "Target:"
 msgstr "Đích:"
 
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\__init__.py:1600
+#: addon\globalPlugins\visionAssistant\__init__.py:1711
 msgid "Smart Swap"
-msgstr "Hoán đổi thông minh"
+msgstr "Chuyển đổi thông minh"
 
 #. --- Document Reader Settings ---
 #. Translators: Title of settings group for Document Reader features
-#: addon\globalPlugins\visionAssistant\__init__.py:1606
+#. Translators: Title of the Document Reader window.
+#: addon\globalPlugins\visionAssistant\__init__.py:1717
+#: addon\globalPlugins\visionAssistant\__init__.py:1982
 msgid "Document Reader"
 msgstr "Trình đọc tài liệu"
 
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1612
+#: addon\globalPlugins\visionAssistant\__init__.py:1723
 msgid "OCR Engine:"
 msgstr "Công cụ OCR:"
 
 #. Translators: Label for TTS Voice selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1621
+#: addon\globalPlugins\visionAssistant\__init__.py:1732
 msgid "TTS Voice:"
-msgstr "Giọng đọc TTS:"
-
-#. --- CAPTCHA Group ---
-#. Translators: Title of the settings group for CAPTCHA options
-#: addon\globalPlugins\visionAssistant\__init__.py:343 addon\globalPlugins\visionAssistant\__init__.py:1631
-msgid "CAPTCHA"
-msgstr "CAPTCHA"
+msgstr "Giọng nói TTS:"
 
 #. Translators: Label for CAPTCHA capture method selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1636
+#: addon\globalPlugins\visionAssistant\__init__.py:1747
 msgid "Capture Method:"
-msgstr "Phương thức chụp:"
+msgstr "Phương pháp chụp:"
 
 #. Translators: A choice for capture method. Captures only the specific object under the NVDA navigator cursor.
-#: addon\globalPlugins\visionAssistant\__init__.py:1638
+#: addon\globalPlugins\visionAssistant\__init__.py:1749
 msgid "Navigator Object"
-msgstr "Đối tượng điều hướng"
+msgstr "Đối tượng Navigator"
 
 #. Translators: A choice for capture method. Captures the entire visible screen area.
-#: addon\globalPlugins\visionAssistant\__init__.py:1640
+#: addon\globalPlugins\visionAssistant\__init__.py:1751
 msgid "Full Screen"
 msgstr "Toàn màn hình"
 
-#. --- Custom Prompts Group ---
-#. Translators: Title of the settings group for custom prompts
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:136 addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:223
-msgid "Custom Prompts"
-msgstr "Lệnh tùy chỉnh"
+#. --- Prompt Manager Group ---
+#. Translators: Title of the settings group for prompt management
+#: addon\globalPlugins\visionAssistant\__init__.py:1761
+msgid "Prompts"
+msgstr "Prompt"
 
-#. Translators: Helper text explaining the format for custom prompts
-#: addon\globalPlugins\visionAssistant\__init__.py:1110
-msgid "Format: Name:Content"
-msgstr "Định dạng: Tên:Nội dung"
+#. Translators: Description for the prompt manager button.
+#: addon\globalPlugins\visionAssistant\__init__.py:1766
+msgid "Manage default and custom prompts."
+msgstr "Quản lý các prompt mặc định và tùy chỉnh."
+
+#. Translators: Button label to open prompt manager dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:1768
+msgid "Manage Prompts..."
+msgstr "Quản lý Prompt..."
+
+#. Translators: Summary text for prompt counts in settings.
+#: addon\globalPlugins\visionAssistant\__init__.py:1778
+#, python-brace-format
+msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
+msgstr "Prompt mặc định: {defaultCount}, Prompt tùy chỉnh: {customCount}"
 
 #. Translators: Title of the PDF options dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1721
+#: addon\globalPlugins\visionAssistant\__init__.py:1838
 msgid "Options"
 msgstr "Tùy chọn"
 
 #. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:1724
+#: addon\globalPlugins\visionAssistant\__init__.py:1841
 #, python-brace-format
 msgid "Total Pages (All Files): {count}"
-msgstr "Tổng số trang (Tất cả tệp): {count}"
+msgstr "Tổng số trang (Tất cả các tệp): {count}"
 
 #. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1727
+#: addon\globalPlugins\visionAssistant\__init__.py:1844
 msgid "Range"
 msgstr "Phạm vi"
 
 #. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\__init__.py:1730
+#: addon\globalPlugins\visionAssistant\__init__.py:1847
 msgid "From:"
-msgstr "Từ trang:"
+msgstr "Từ:"
 
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\__init__.py:1734
+#: addon\globalPlugins\visionAssistant\__init__.py:1851
 msgid "To:"
-msgstr "Đến trang:"
-
-#. Translators: Box title for translation options
-#: addon\globalPlugins\visionAssistant\__init__.py:227 addon\globalPlugins\visionAssistant\__init__.py:233 addon\globalPlugins\visionAssistant\__init__.py:1741
-msgid "Translation"
-msgstr "Dịch thuật"
+msgstr "Đến:"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\__init__.py:1743
+#: addon\globalPlugins\visionAssistant\__init__.py:1860
 msgid "Translate Output"
-msgstr "Dịch kết quả đầu ra"
+msgstr "Dịch đầu ra"
 
 #. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\__init__.py:1756
+#: addon\globalPlugins\visionAssistant\__init__.py:1873
 msgid "Start"
 msgstr "Bắt đầu"
 
 #. Translators: Button to cancel
-#: addon\globalPlugins\visionAssistant\__init__.py:1759
+#: addon\globalPlugins\visionAssistant\__init__.py:1876
 msgid "Cancel"
 msgstr "Hủy"
 
 #. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1784
+#: addon\globalPlugins\visionAssistant\__init__.py:1901
 msgid "Ask about Document"
 msgstr "Hỏi về tài liệu"
 
 #. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\__init__.py:1793
+#: addon\globalPlugins\visionAssistant\__init__.py:1910
 #, python-brace-format
 msgid "File: {name}"
 msgstr "Tệp: {name}"
 
 #. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\__init__.py:1798
+#: addon\globalPlugins\visionAssistant\__init__.py:1915
 msgid "Uploading to Gemini...\n"
 msgstr "Đang tải lên Gemini...\n"
 
 #. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\__init__.py:1802
+#: addon\globalPlugins\visionAssistant\__init__.py:1919
 msgid "Your Question:"
-msgstr "Nhập câu hỏi:"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:1105 addon\globalPlugins\visionAssistant\__init__.py:1827 addon\globalPlugins\visionAssistant\__init__.py:3216
-msgid "Upload failed."
-msgstr "Tải lên không thành công."
+msgstr "Câu hỏi của bạn:"
 
 #. Translators: Message when ready to chat
-#: addon\globalPlugins\visionAssistant\__init__.py:1833
+#: addon\globalPlugins\visionAssistant\__init__.py:1950
 msgid "Ready! Ask your questions.\n"
-msgstr "Đã sẵn sàng! Hãy đặt câu hỏi .\n"
+msgstr "Đã sẵn sàng! Hãy đặt câu hỏi của bạn.\n"
 
 #. Translators: Initial status when the add-on is doing nothing
 #. Translators: Status message when the add-on is doing nothing
-#: addon\globalPlugins\visionAssistant\__init__.py:1853 addon\globalPlugins\visionAssistant\__init__.py:2132 addon\globalPlugins\visionAssistant\__init__.py:2219 addon\globalPlugins\visionAssistant\__init__.py:2223 addon\globalPlugins\visionAssistant\__init__.py:2287 addon\globalPlugins\visionAssistant\__init__.py:2484 addon\globalPlugins\visionAssistant\__init__.py:3078 addon\globalPlugins\visionAssistant\__init__.py:3194 addon\globalPlugins\visionAssistant\__init__.py:3199 addon\globalPlugins\visionAssistant\__init__.py:3215 addon\globalPlugins\visionAssistant\__init__.py:3228 addon\globalPlugins\visionAssistant\__init__.py:3237 addon\globalPlugins\visionAssistant\__init__.py:3325 addon\globalPlugins\visionAssistant\__init__.py:3329 addon\globalPlugins\visionAssistant\__init__.py:3393 addon\globalPlugins\visionAssistant\__init__.py:3407 addon\globalPlugins\visionAssistant\__init__.py:3411 addon\globalPlugins\visionAssistant\__init__.py:3416 addon\globalPlugins\visionAssistant\__init__.py:3502 addon\globalPlugins\visionAssistant\__init__.py:3515 addon\globalPlugins\visionAssistant\__init__.py:3519 addon\globalPlugins\visionAssistant\__init__.py:3555 addon\globalPlugins\visionAssistant\__init__.py:3565
+#: addon\globalPlugins\visionAssistant\__init__.py:1970
+#: addon\globalPlugins\visionAssistant\__init__.py:2257
+#: addon\globalPlugins\visionAssistant\__init__.py:2344
+#: addon\globalPlugins\visionAssistant\__init__.py:2348
+#: addon\globalPlugins\visionAssistant\__init__.py:2412
+#: addon\globalPlugins\visionAssistant\__init__.py:2605
+#: addon\globalPlugins\visionAssistant\__init__.py:3203
+#: addon\globalPlugins\visionAssistant\__init__.py:3323
+#: addon\globalPlugins\visionAssistant\__init__.py:3328
+#: addon\globalPlugins\visionAssistant\__init__.py:3343
+#: addon\globalPlugins\visionAssistant\__init__.py:3356
+#: addon\globalPlugins\visionAssistant\__init__.py:3364
+#: addon\globalPlugins\visionAssistant\__init__.py:3461
+#: addon\globalPlugins\visionAssistant\__init__.py:3464
+#: addon\globalPlugins\visionAssistant\__init__.py:3537
+#: addon\globalPlugins\visionAssistant\__init__.py:3551
+#: addon\globalPlugins\visionAssistant\__init__.py:3554
+#: addon\globalPlugins\visionAssistant\__init__.py:3559
+#: addon\globalPlugins\visionAssistant\__init__.py:3645
+#: addon\globalPlugins\visionAssistant\__init__.py:3658
+#: addon\globalPlugins\visionAssistant\__init__.py:3661
+#: addon\globalPlugins\visionAssistant\__init__.py:3697
+#: addon\globalPlugins\visionAssistant\__init__.py:3707
 msgid "Idle"
-msgstr "Sẵn sàng"
+msgstr "Nhàn rỗi"
 
 #. Translators: Spoken prefix for AI response
-#: addon\globalPlugins\visionAssistant\__init__.py:1860
+#: addon\globalPlugins\visionAssistant\__init__.py:1977
 msgid "AI: "
 msgstr "AI: "
 
 #. Translators: Initial status message
-#: addon\globalPlugins\visionAssistant\__init__.py:1883
+#: addon\globalPlugins\visionAssistant\__init__.py:2002
 msgid "Initializing..."
-msgstr "Đang phân tích..."
+msgstr "Đang khởi tạo..."
 
 #. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\__init__.py:1889
+#: addon\globalPlugins\visionAssistant\__init__.py:2008
 msgid "Previous (Ctrl+PageUp)"
-msgstr "Trang trước (Ctrl+PageUp)"
+msgstr "Trước (Ctrl+PageUp)"
 
 #. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\__init__.py:1893
+#: addon\globalPlugins\visionAssistant\__init__.py:2012
 msgid "Next (Ctrl+PageDown)"
-msgstr "Trang sau (Ctrl+PageDown)"
+msgstr "Tiếp (Ctrl+PageDown)"
 
 #. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\__init__.py:1897
+#: addon\globalPlugins\visionAssistant\__init__.py:2016
 msgid "Go to:"
-msgstr "Đi đến trang:"
+msgstr "Đến trang:"
 
 #. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\__init__.py:1905
+#: addon\globalPlugins\visionAssistant\__init__.py:2024
 msgid "Ask AI (Alt+A)"
 msgstr "Hỏi AI (Alt+A)"
 
 #. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\__init__.py:1910
+#: addon\globalPlugins\visionAssistant\__init__.py:2029
 msgid "Re-scan with Gemini (Alt+R)"
-msgstr "Quét lại với Gemini (Alt+R)"
+msgstr "Quét lại bằng Gemini (Alt+R)"
 
 #. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\__init__.py:1915
+#: addon\globalPlugins\visionAssistant\__init__.py:2034
 msgid "Generate Audio (Alt+G)"
 msgstr "Tạo âm thanh (Alt+G)"
 
 #. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\__init__.py:1925
+#: addon\globalPlugins\visionAssistant\__init__.py:2044
 msgid "Save (Alt+S)"
 msgstr "Lưu (Alt+S)"
 
 #. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\__init__.py:1964
+#: addon\globalPlugins\visionAssistant\__init__.py:2083
 #, python-brace-format
 msgid "Page {num} ready"
 msgstr "Trang {num} đã sẵn sàng"
 
 #. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\__init__.py:1986
+#: addon\globalPlugins\visionAssistant\__init__.py:2105
 msgid "[OCR failed. Try Gemini Re-scan.]"
 msgstr "[OCR thất bại. Hãy thử quét lại bằng Gemini.]"
 
 #. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1995
+#: addon\globalPlugins\visionAssistant\__init__.py:2114
 msgid "Error processing page."
 msgstr "Lỗi khi xử lý trang."
 
 #. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\__init__.py:2000
+#: addon\globalPlugins\visionAssistant\__init__.py:2119
 #, python-brace-format
 msgid "Page {current} of {total}"
 msgstr "Trang {current} trên {total}"
 
 #. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\__init__.py:2007
+#: addon\globalPlugins\visionAssistant\__init__.py:2126
 msgid "Processing in background..."
 msgstr "Đang xử lý trong nền..."
 
 #. Translators: Spoken message when switching pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2018 addon\globalPlugins\visionAssistant\__init__.py:2037
+#. Translators: Heading for each page in the formatted content view.
+#: addon\globalPlugins\visionAssistant\__init__.py:2137
+#: addon\globalPlugins\visionAssistant\__init__.py:2156
 #, python-brace-format
 msgid "Page {num}"
 msgstr "Trang {num}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:2050
+#: addon\globalPlugins\visionAssistant\__init__.py:2169
 msgid "Formatted Content"
-msgstr "Nội dung đã định dạng"
+msgstr "Nội dung được định dạng"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2056 addon\globalPlugins\visionAssistant\__init__.py:2141 addon\globalPlugins\visionAssistant\__init__.py:2228
+#: addon\globalPlugins\visionAssistant\__init__.py:2175
+#: addon\globalPlugins\visionAssistant\__init__.py:2266
+#: addon\globalPlugins\visionAssistant\__init__.py:2353
 msgid "Please configure Gemini API Key."
-msgstr "Vui lòng cấu hình khóa API Gemini."
+msgstr "Vui lòng cấu hình Khóa API Gemini."
 
 #. Translators: Status reported when an error occurs
-#: addon\globalPlugins\visionAssistant\__init__.py:2056 addon\globalPlugins\visionAssistant\__init__.py:2141 addon\globalPlugins\visionAssistant\__init__.py:2228 addon\globalPlugins\visionAssistant\__init__.py:2596 addon\globalPlugins\visionAssistant\__init__.py:2603 addon\globalPlugins\visionAssistant\__init__.py:2672
+#: addon\globalPlugins\visionAssistant\__init__.py:2175
+#: addon\globalPlugins\visionAssistant\__init__.py:2266
+#: addon\globalPlugins\visionAssistant\__init__.py:2353
+#: addon\globalPlugins\visionAssistant\__init__.py:2717
+#: addon\globalPlugins\visionAssistant\__init__.py:2724
+#: addon\globalPlugins\visionAssistant\__init__.py:2793
 msgid "Error"
 msgstr "Lỗi"
 
 #. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\__init__.py:2060
+#: addon\globalPlugins\visionAssistant\__init__.py:2179
 msgid "Current Page"
 msgstr "Trang hiện tại"
 
 #. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2062
+#: addon\globalPlugins\visionAssistant\__init__.py:2181
 msgid "All Pages (In Range)"
 msgstr "Tất cả các trang (Trong phạm vi)"
 
 #. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\__init__.py:2072
+#: addon\globalPlugins\visionAssistant\__init__.py:2191
 msgid "Scanning with Gemini..."
-msgstr "Đang quét với Gemini..."
+msgstr "Đang quét bằng Gemini..."
 
 #. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2088
+#: addon\globalPlugins\visionAssistant\__init__.py:2207
 msgid "Scan complete"
 msgstr "Quét hoàn tất"
 
 #. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\__init__.py:2096
+#: addon\globalPlugins\visionAssistant\__init__.py:2215
 msgid "Batch Processing Started"
 msgstr "Đã bắt đầu xử lý hàng loạt"
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:2107
+#: addon\globalPlugins\visionAssistant\__init__.py:2226
 msgid "Error creating temporary PDF."
 msgstr "Lỗi khi tạo tệp PDF tạm thời."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2115
+#: addon\globalPlugins\visionAssistant\__init__.py:2234
 msgid "Unknown error"
 msgstr "Lỗi không xác định"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2116
+#. Translators: Message reported when batch scan fails
+#: addon\globalPlugins\visionAssistant\__init__.py:2236
 #, python-brace-format
 msgid "Scan failed: {err}"
 msgstr "Quét thất bại: {err}"
 
 #. Translators: Message when batch scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2129
+#: addon\globalPlugins\visionAssistant\__init__.py:2254
 msgid "Batch Scan Complete"
-msgstr "Hoàn tất quét hàng loạt"
+msgstr "Quét hàng loạt hoàn tất"
 
 #. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\__init__.py:2145
+#: addon\globalPlugins\visionAssistant\__init__.py:2270
 msgid "Generate for Current Page"
-msgstr "Tạo âm thanh cho trang hiện tại"
+msgstr "Tạo cho trang hiện tại"
 
 #. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:2147
+#: addon\globalPlugins\visionAssistant\__init__.py:2272
 msgid "Generate for All Pages (In Range)"
-msgstr "Tạo âm thanh cho tất cả các trang (Trong phạm vi)"
+msgstr "Tạo cho tất cả các trang (Trong phạm vi)"
 
 #. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\__init__.py:2157
+#: addon\globalPlugins\visionAssistant\__init__.py:2282
 msgid "No text to read."
 msgstr "Không có văn bản để đọc."
 
 #. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\__init__.py:2167
+#: addon\globalPlugins\visionAssistant\__init__.py:2292
 msgid "Gathering text for audio..."
-msgstr "Đang thu thập văn bản để tạo âm thanh..."
+msgstr "Đang thu thập văn bản cho âm thanh..."
 
 #. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2177
+#: addon\globalPlugins\visionAssistant\__init__.py:2302
 msgid "Save Audio"
-msgstr "Lưu tệp âm thanh"
+msgstr "Lưu âm thanh"
 
 #. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2184
+#: addon\globalPlugins\visionAssistant\__init__.py:2309
 msgid "Generating Audio..."
 msgstr "Đang tạo âm thanh..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2200
+#: addon\globalPlugins\visionAssistant\__init__.py:2325
 msgid "lame.exe not found in lib folder."
-msgstr "không tìm thấy  lame.exe trong thư mục lib."
+msgstr "Không tìm thấy lame.exe trong thư mục lib."
 
 #. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:2218
+#: addon\globalPlugins\visionAssistant\__init__.py:2343
 msgid "Audio Saved"
 msgstr "Đã lưu âm thanh"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2221
+#: addon\globalPlugins\visionAssistant\__init__.py:2346
 msgid "Audio file generated and saved successfully."
-msgstr "Tệp âm thanh đã được tạo và lưu thành công."
+msgstr "Đã tạo và lưu tệp âm thanh thành công."
 
 #. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\__init__.py:2243
+#: addon\globalPlugins\visionAssistant\__init__.py:2368
 msgid "Save"
 msgstr "Lưu"
 
 #. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\__init__.py:2254
+#: addon\globalPlugins\visionAssistant\__init__.py:2379
 #, python-brace-format
 msgid "Saving Page {num}..."
-msgstr "Đang lưu trang {num}..."
+msgstr "Đang lưu Trang {num}..."
 
 #. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2267
+#: addon\globalPlugins\visionAssistant\__init__.py:2392
 msgid "Saved"
 msgstr "Đã lưu"
 
 #. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:2269
+#: addon\globalPlugins\visionAssistant\__init__.py:2394
 msgid "File saved successfully."
-msgstr "Tệp đã được lưu thành công."
+msgstr "Đã lưu tệp thành công."
 
 #. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:2304
+#: addon\globalPlugins\visionAssistant\__init__.py:2429
 msgid "&Document Reader..."
-msgstr "Trình đọc &tài liệu..."
+msgstr "Trình đọc tài liệu (&D)..."
 
 #. Translators: Menu item for Audio Transcription
-#: addon\globalPlugins\visionAssistant\__init__.py:2308
+#: addon\globalPlugins\visionAssistant\__init__.py:2433
 msgid "Transcribe &Audio File..."
-msgstr "Chuyển đổi tệp &âm thanh..."
+msgstr "Chuyển biên tệp âm thanh (&A)..."
 
 #. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:2312
+#: addon\globalPlugins\visionAssistant\__init__.py:2437
 msgid "Analyze &Video URL..."
-msgstr "Phân tích đường dẫn &Video..."
+msgstr "Phân tích URL &Video..."
 
 #. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:2318
+#: addon\globalPlugins\visionAssistant\__init__.py:2443
 msgid "&Settings..."
-msgstr "&Cài đặt..."
+msgstr "Cài đặt (&S)..."
 
 #. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:2322
+#: addon\globalPlugins\visionAssistant\__init__.py:2447
 msgid "Check for &Update"
-msgstr "Kiểm tra cập &nhật"
+msgstr "Kiểm tra cập nhật (&U)"
 
 #. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:2326
+#: addon\globalPlugins\visionAssistant\__init__.py:2451
 msgid "Docu&mentation"
-msgstr "&Tài liệu hướng dẫn"
+msgstr "Tài liệu hướng dẫn (&M)"
 
 #. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:2330
+#: addon\globalPlugins\visionAssistant\__init__.py:2455
 msgid "D&onate"
-msgstr "Ủng &hộ"
+msgstr "Quyên góp (&O)"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2334
+#. Translators: Menu item to open the Telegram channel
+#: addon\globalPlugins\visionAssistant\__init__.py:2459
+msgid "Telegram &Channel"
+msgstr "Kênh Telegram (&C)"
+
+#. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
+#: addon\globalPlugins\visionAssistant\__init__.py:2464
 msgid "Vision Assistant"
 msgstr "Vision Assistant"
 
 #. Translators: Standard title for opening a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2348 addon\globalPlugins\visionAssistant\__init__.py:2490 addon\globalPlugins\visionAssistant\__init__.py:2957
+#: addon\globalPlugins\visionAssistant\__init__.py:2479
+#: addon\globalPlugins\visionAssistant\__init__.py:2611
+#: addon\globalPlugins\visionAssistant\__init__.py:3082
 msgid "Open"
 msgstr "Mở"
 
 #. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:2356
+#: addon\globalPlugins\visionAssistant\__init__.py:2487
 msgid "Supported Files"
 msgstr "Các tệp được hỗ trợ"
 
 #. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:2363 addon\globalPlugins\visionAssistant\__init__.py:3140
+#: addon\globalPlugins\visionAssistant\__init__.py:2494
+#: addon\globalPlugins\visionAssistant\__init__.py:3269
 msgid "PyMuPDF library is missing."
 msgstr "Thiếu thư viện PyMuPDF."
 
 #. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:2369 addon\globalPlugins\visionAssistant\__init__.py:3146
+#: addon\globalPlugins\visionAssistant\__init__.py:2500
+#: addon\globalPlugins\visionAssistant\__init__.py:3275
 msgid "No readable pages found."
-msgstr "Không tìm thấy trang nào có thể đọc được."
+msgstr "Không tìm thấy trang nào có thể đọc."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2403
+#: addon\globalPlugins\visionAssistant\__init__.py:2534
 msgid "Activates the Command Layer for quick access to all features."
-msgstr "Kích hoạt Lớp lệnh để truy cập nhanh mọi tính năng."
+msgstr "Kích hoạt Lớp lệnh để truy cập nhanh vào tất cả các tính năng."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2461 addon\globalPlugins\visionAssistant\__init__.py:2772
+#: addon\globalPlugins\visionAssistant\__init__.py:2581
+#: addon\globalPlugins\visionAssistant\__init__.py:2893
 msgid "Translates the selected text or navigator object."
-msgstr "Dịch văn bản đã chọn hoặc đối tượng điều hướng."
+msgstr "Dịch văn bản đã chọn hoặc đối tượng navigator."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2462 addon\globalPlugins\visionAssistant\__init__.py:3607
+#: addon\globalPlugins\visionAssistant\__init__.py:2582
+#: addon\globalPlugins\visionAssistant\__init__.py:3749
 msgid "Translates the text currently in the clipboard."
-msgstr "Dịch văn bản trong bộ nhớ tạm."
+msgstr "Dịch văn bản hiện có trong clipboard."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2463 addon\globalPlugins\visionAssistant\__init__.py:2901
+#: addon\globalPlugins\visionAssistant\__init__.py:2583
+#: addon\globalPlugins\visionAssistant\__init__.py:3026
 msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
-msgstr "Mở trình đơn để Giải thích, Tóm tắt hoặc Sửa văn bản đã chọn."
+msgstr "Mở menu để Giải thích, Tóm tắt hoặc Sửa lỗi văn bản đã chọn."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2464 addon\globalPlugins\visionAssistant\__init__.py:3289
+#: addon\globalPlugins\visionAssistant\__init__.py:2584
+#: addon\globalPlugins\visionAssistant\__init__.py:3425
 msgid "Performs OCR and description on the entire screen."
-msgstr "Nhận diện văn bản và mô tả toàn bộ màn hình."
+msgstr "Thực hiện OCR và mô tả toàn bộ màn hình."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2465 addon\globalPlugins\visionAssistant\__init__.py:3295
+#: addon\globalPlugins\visionAssistant\__init__.py:2585
+#: addon\globalPlugins\visionAssistant\__init__.py:3431
 msgid "Describes the current object (Navigator Object)."
-msgstr "Mô tả đối tượng hiện tại (Đối tượng điều hướng)."
+msgstr "Mô tả đối tượng hiện tại (Đối tượng Navigator)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2466 addon\globalPlugins\visionAssistant\__init__.py:3240
+#: addon\globalPlugins\visionAssistant\__init__.py:2586
+#: addon\globalPlugins\visionAssistant\__init__.py:3367
 msgid ""
 "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
 msgstr "Mở Trình đọc tài liệu để phân tích chi tiết từng trang (PDF/Hình ảnh)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2467 addon\globalPlugins\visionAssistant\__init__.py:3127
+#: addon\globalPlugins\visionAssistant\__init__.py:2587
+#: addon\globalPlugins\visionAssistant\__init__.py:3256
 msgid "Recognizes text from a selected image or PDF file."
-msgstr "Nhận diện văn bản từ hình ảnh hoặc tệp PDF đã chọn."
+msgstr "Nhận dạng văn bản từ một hình ảnh hoặc tệp PDF đã chọn."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2468 addon\globalPlugins\visionAssistant\__init__.py:3375
+#: addon\globalPlugins\visionAssistant\__init__.py:2588
+#: addon\globalPlugins\visionAssistant\__init__.py:3519
 msgid "Transcribes a selected audio file."
-msgstr "Chuyển âm thanh thành văn bản từ tệp đã chọn."
+msgstr "Chuyển biên một tệp âm thanh đã chọn."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2469 addon\globalPlugins\visionAssistant\__init__.py:3419
+#: addon\globalPlugins\visionAssistant\__init__.py:2589
+#: addon\globalPlugins\visionAssistant\__init__.py:3562
 msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
-msgstr "Phân tích URL video YouTube, Instagram, Twitter hoặc TikTok."
+msgstr "Phân tích URL video trên YouTube, Instagram, Twitter hoặc TikTok."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2470 addon\globalPlugins\visionAssistant\__init__.py:3522
+#: addon\globalPlugins\visionAssistant\__init__.py:2590
+#: addon\globalPlugins\visionAssistant\__init__.py:3664
 msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
-msgstr "Cố gắng giải CAPTCHA trên màn hình hoặc đối tượng điều hướng."
+msgstr "Thử giải quyết CAPTCHA trên màn hình hoặc đối tượng navigator."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2471 addon\globalPlugins\visionAssistant\__init__.py:2679
+#: addon\globalPlugins\visionAssistant\__init__.py:2591
+#: addon\globalPlugins\visionAssistant\__init__.py:2800
 msgid "Records voice, transcribes it using AI, and types the result."
-msgstr "Ghi âm, chuyển thành văn bản bằng AI và tự động nhập kết quả."
+msgstr "Ghi âm giọng nói, chuyển biên bằng AI và gõ kết quả."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2472 addon\globalPlugins\visionAssistant\__init__.py:2480
+#: addon\globalPlugins\visionAssistant\__init__.py:2592
+#: addon\globalPlugins\visionAssistant\__init__.py:2601
 msgid "Announces the current status of the add-on."
 msgstr "Thông báo trạng thái hiện tại của add-on."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2473 addon\globalPlugins\visionAssistant\__init__.py:3576
+#: addon\globalPlugins\visionAssistant\__init__.py:2593
+#: addon\globalPlugins\visionAssistant\__init__.py:3718
 msgid "Checks for updates manually."
-msgstr "Kiểm tra cập nhật thủ công."
+msgstr "Kiểm tra cập nhật theo cách thủ công."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2474
+#. Translators: Script description for Input Gestures dialog
+#: addon\globalPlugins\visionAssistant\__init__.py:2594
+#: addon\globalPlugins\visionAssistant\__init__.py:3764
+msgid ""
+"Shows the last AI response in a chat dialog for review or follow-up "
+"questions."
+msgstr "Hiển thị phản hồi cuối cùng của AI trong hộp thoại trò chuyện để xem lại hoặc đặt câu hỏi tiếp theo."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:2595
 msgid "Shows a list of available commands in the layer."
-msgstr "Hiện danh sách các lệnh có sẵn trong Lớp lệnh."
+msgstr "Hiển thị danh sách các lệnh có sẵn trong lớp."
 
 #. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2477
+#: addon\globalPlugins\visionAssistant\__init__.py:2598
 #, python-brace-format
 msgid "{name} Help"
 msgstr "Trợ giúp {name}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2562
+#: addon\globalPlugins\visionAssistant\__init__.py:2683
 #, python-brace-format
 msgid "Upload Connection Error: {reason}"
-msgstr "Lỗi kết nối khi tải lên: {reason}"
+msgstr "Lỗi kết nối tải lên: {reason}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2568
+#: addon\globalPlugins\visionAssistant\__init__.py:2689
 #, python-brace-format
 msgid "Upload Server Error {code}: {reason}"
-msgstr "Lỗi máy chủ khi tải lên {code}: {reason}"
+msgstr "Lỗi máy chủ tải lên {code}: {reason}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:2574
+#: addon\globalPlugins\visionAssistant\__init__.py:2695
 #, python-brace-format
 msgid "File Upload Error: {error}"
-msgstr "Lỗi tải tệp: {error}"
+msgstr "Lỗi tải lên tệp: {error}"
+
+#. Translators: Error message when there's no content to send
+#: addon\globalPlugins\visionAssistant\__init__.py:2716
+#: addon\globalPlugins\visionAssistant\__init__.py:2723
+msgid "Nothing to send."
+msgstr "Không có gì để gửi."
 
 #. Translators: Error message when AI refuses to answer due to safety guidelines
-#: addon\globalPlugins\visionAssistant\__init__.py:2648
+#: addon\globalPlugins\visionAssistant\__init__.py:2769
 msgid "Error: Response blocked by AI safety filters."
-msgstr "Lỗi: Phản hồi bị chặn bởi bộ lọc an toàn của AI."
+msgstr "Lỗi: Phản hồi bị chặn bởi các bộ lọc an toàn của AI."
 
 #. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:2689
+#: addon\globalPlugins\visionAssistant\__init__.py:2810
 msgid "Listening..."
 msgstr "Đang nghe..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2693
+#: addon\globalPlugins\visionAssistant\__init__.py:2814
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Lỗi phần cứng âm thanh: {error}"
 
 #. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\__init__.py:2703
+#: addon\globalPlugins\visionAssistant\__init__.py:2824
 msgid "Typing..."
-msgstr "Đang nhập..."
+msgstr "Đang gõ..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2708
+#: addon\globalPlugins\visionAssistant\__init__.py:2829
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Lỗi lưu bản ghi: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\__init__.py:2723 addon\globalPlugins\visionAssistant\__init__.py:2746
+#: addon\globalPlugins\visionAssistant\__init__.py:2844
+#: addon\globalPlugins\visionAssistant\__init__.py:2867
 msgid "No speech detected."
-msgstr "Không phát hiện tiếng nói."
+msgstr "Không phát hiện thấy giọng nói."
 
 #. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2753
+#: addon\globalPlugins\visionAssistant\__init__.py:2874
 msgid "No speech recognized or Error."
-msgstr "Không thể nhận diện tiếng nói hoặc có lỗi."
+msgstr "Không nhận dạng được giọng nói hoặc có lỗi."
 
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:2768
+#: addon\globalPlugins\visionAssistant\__init__.py:2889
 #, python-brace-format
 msgid "Typed: {text}"
-msgstr "Đã nhập: {text}"
+msgstr "Đã gõ: {text}"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2779
+#: addon\globalPlugins\visionAssistant\__init__.py:2900
 msgid "No text found."
 msgstr "Không tìm thấy văn bản."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2784
+#: addon\globalPlugins\visionAssistant\__init__.py:2905
 msgid "Translating..."
 msgstr "Đang dịch..."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:2818
+#: addon\globalPlugins\visionAssistant\__init__.py:2937
 #, python-brace-format
 msgid "Translated: {text}"
 msgstr "Đã dịch: {text}"
 
-#. Translators: A choice in the menu of the text refinement command
-#: addon\globalPlugins\visionAssistant\__init__.py:204
-msgid "Summarize"
-msgstr "Tóm tắt"
-
-#. Translators: A choice in the menu of the text refinement command
-#: addon\globalPlugins\visionAssistant\__init__.py:210
-msgid "Fix Grammar"
-msgstr "Sửa lỗi ngữ pháp"
-
-#. Translators: A choice in the menu of the text refinement command
-#: addon\globalPlugins\visionAssistant\__init__.py:216
-msgid "Fix Grammar & Translate"
-msgstr "Sửa lỗi ngữ pháp & Dịch"
-
-#. Translators: A choice in the menu of the text refinement command
-#: addon\globalPlugins\visionAssistant\__init__.py:222
-msgid "Explain"
-msgstr "Giải thích"
-
-#. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\__init__.py:614
-msgid "Custom: "
-msgstr "Tùy chỉnh: "
+#: addon\globalPlugins\visionAssistant\__init__.py:2961
+#, python-brace-format
+msgid "{name} - Translation"
+msgstr "{name} - Dịch thuật"
 
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2928
+#: addon\globalPlugins\visionAssistant\__init__.py:3053
 msgid "Choose action:"
 msgstr "Chọn hành động:"
 
-#. Translators: main message of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:203 addon\globalPlugins\visionAssistant\__init__.py:209 addon\globalPlugins\visionAssistant\__init__.py:215 addon\globalPlugins\visionAssistant\__init__.py:221 addon\globalPlugins\visionAssistant\__init__.py:2930
-msgid "Refine"
-msgstr "Tinh chỉnh"
-
 #. Translators: Message while processing request of the refine text command
-#: addon\globalPlugins\visionAssistant\__init__.py:2965
+#: addon\globalPlugins\visionAssistant\__init__.py:3090
 msgid "Processing..."
 msgstr "Đang xử lý..."
 
 #. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\__init__.py:3023
+#: addon\globalPlugins\visionAssistant\__init__.py:3148
 msgid "Uploading file..."
-msgstr "Đang tải tệp lên..."
+msgstr "Đang tải lên tệp..."
 
 #. Translators: Message reported when executing the refine command
 #. Translators: Message reported when calling the audio transcription command
 #. Translators: Message reported when AI is analyzing the video
-#: addon\globalPlugins\visionAssistant\__init__.py:3073 addon\globalPlugins\visionAssistant\__init__.py:3397 addon\globalPlugins\visionAssistant\__init__.py:3499
+#: addon\globalPlugins\visionAssistant\__init__.py:3198
+#: addon\globalPlugins\visionAssistant\__init__.py:3541
+#: addon\globalPlugins\visionAssistant\__init__.py:3642
 msgid "Analyzing..."
 msgstr "Đang phân tích..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3115
+#: addon\globalPlugins\visionAssistant\__init__.py:3244
 #, python-brace-format
 msgid "{name} - Refine Result"
 msgstr "{name} - Kết quả tinh chỉnh"
 
 #. Translators: Message reported when calling the OCR file recognition command
-#: addon\globalPlugins\visionAssistant\__init__.py:3167
+#: addon\globalPlugins\visionAssistant\__init__.py:3296
 msgid "Uploading & Extracting..."
 msgstr "Đang tải lên & Trích xuất..."
 
-#. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3207
-msgid "Error creating PDF."
-msgstr "Lỗi khi tạo tệp PDF."
+#. Translators: Error shown when OCR finds no text in the selected files
+#: addon\globalPlugins\visionAssistant\__init__.py:3325
+#: addon\globalPlugins\visionAssistant\__init__.py:3358
+msgid "No text detected in the selected file(s)."
+msgstr "Không phát hiện thấy văn bản trong (các) tệp đã chọn."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3277
+#. Translators: Error message if PDF creation fails
+#: addon\globalPlugins\visionAssistant\__init__.py:3335
+msgid "Error creating PDF."
+msgstr "Lỗi tạo PDF."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:3413
 #, python-brace-format
 msgid "{name} - Chat"
-msgstr "{name} - Chat"
+msgstr "{name} - Trò chuyện"
 
 #. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\__init__.py:3305
+#: addon\globalPlugins\visionAssistant\__init__.py:3441
 msgid "Scanning..."
 msgstr "Đang quét..."
 
 #. Translators: Message reported when calling an image analysis command
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3310 addon\globalPlugins\visionAssistant\__init__.py:3542
+#: addon\globalPlugins\visionAssistant\__init__.py:3446
+#: addon\globalPlugins\visionAssistant\__init__.py:3684
 msgid "Capture failed."
-msgstr "Không thể chụp màn hình."
+msgstr "Chụp thất bại."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3363
+#: addon\globalPlugins\visionAssistant\__init__.py:3507
 #, python-brace-format
 msgid "{name} - Image Analysis"
 msgstr "{name} - Phân tích hình ảnh"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\__init__.py:3387
+#: addon\globalPlugins\visionAssistant\__init__.py:3531
 msgid "Uploading..."
 msgstr "Đang tải lên..."
 
 #. Translators: Generic error message when audio processing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3414
+#: addon\globalPlugins\visionAssistant\__init__.py:3557
 msgid "Error processing audio."
-msgstr "Lỗi khi xử lý âm thanh."
+msgstr "Lỗi xử lý âm thanh."
 
 #. Translators: Title for the video URL entry dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3426
+#: addon\globalPlugins\visionAssistant\__init__.py:3569
 msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 msgstr "Phân tích YouTube / Instagram / Twitter / TikTok"
 
 #. Translators: Label for the text entry in video dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3428
+#: addon\globalPlugins\visionAssistant\__init__.py:3571
 msgid "Enter Video URL (YouTube/Instagram/Twitter/TikTok):"
-msgstr "Nhập liên kết video (YouTube/Instagram/Twitter/TikTok):"
+msgstr "Nhập URL video (YouTube/Instagram/Twitter/TikTok):"
 
 #. Translators: Error message when the URL is invalid
-#: addon\globalPlugins\visionAssistant\__init__.py:3443 addon\globalPlugins\visionAssistant\__init__.py:3446
+#: addon\globalPlugins\visionAssistant\__init__.py:3586
+#: addon\globalPlugins\visionAssistant\__init__.py:3589
 msgid "Error: Invalid URL."
-msgstr "Lỗi: Liên kết không hợp lệ."
+msgstr "Lỗi: URL không hợp lệ."
 
 #. Translators: Error message when the platform is not supported
-#: addon\globalPlugins\visionAssistant\__init__.py:3456
+#: addon\globalPlugins\visionAssistant\__init__.py:3599
 msgid ""
 "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
 "are supported."
-msgstr ""
-"Lỗi: Nền tảng không hỗ trợ. Chỉ hỗ trợ YouTube, Instagram, Twitter và TikTok."
+msgstr "Lỗi: Nền tảng không được hỗ trợ. Chỉ hỗ trợ YouTube, Instagram, Twitter và TikTok."
 
 #. Translators: Message reported when processing video link
-#: addon\globalPlugins\visionAssistant\__init__.py:3460
+#: addon\globalPlugins\visionAssistant\__init__.py:3603
 msgid "Processing Video..."
-msgstr "Đang xử lý Video..."
+msgstr "Đang xử lý video..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3471
+#: addon\globalPlugins\visionAssistant\__init__.py:3614
 msgid "Error: Could not extract Instagram video."
 msgstr "Lỗi: Không thể trích xuất video Instagram."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3474
+#: addon\globalPlugins\visionAssistant\__init__.py:3617
 msgid "Error: Could not extract Twitter video."
 msgstr "Lỗi: Không thể trích xuất video Twitter."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3477
+#: addon\globalPlugins\visionAssistant\__init__.py:3620
 msgid "Error: Could not extract TikTok video."
 msgstr "Lỗi: Không thể trích xuất video TikTok."
 
 #. Translators: Message reported when downloading video
-#: addon\globalPlugins\visionAssistant\__init__.py:3484
+#: addon\globalPlugins\visionAssistant\__init__.py:3627
 msgid "Downloading Video..."
-msgstr "Đang tải Video..."
+msgstr "Đang tải xuống video..."
 
 #. Translators: Error message when video download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3489
+#: addon\globalPlugins\visionAssistant\__init__.py:3632
 msgid "Error: Download failed."
 msgstr "Lỗi: Tải xuống thất bại."
 
 #. Translators: Message reported when uploading video to AI
-#: addon\globalPlugins\visionAssistant\__init__.py:3493
+#: addon\globalPlugins\visionAssistant\__init__.py:3636
 msgid "Uploading to AI..."
 msgstr "Đang tải lên AI..."
 
 #. Translators: Message reported when analyzing YouTube video
-#: addon\globalPlugins\visionAssistant\__init__.py:3511
+#: addon\globalPlugins\visionAssistant\__init__.py:3654
 msgid "Analyzing YouTube..."
 msgstr "Đang phân tích YouTube..."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3537
+#: addon\globalPlugins\visionAssistant\__init__.py:3679
 msgid "Solving..."
 msgstr "Đang giải..."
 
 #. Translators: Message reported when AI cannot find any CAPTCHA in the image
-#: addon\globalPlugins\visionAssistant\__init__.py:3558
+#: addon\globalPlugins\visionAssistant\__init__.py:3700
 msgid "No CAPTCHA detected."
 msgstr "Không phát hiện thấy CAPTCHA."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3563
+#: addon\globalPlugins\visionAssistant\__init__.py:3705
 msgid "Failed."
 msgstr "Thất bại."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:3572
+#: addon\globalPlugins\visionAssistant\__init__.py:3714
 #, python-brace-format
 msgid "Captcha: {text}"
 msgstr "Captcha: {text}"
 
 #. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:3580
+#: addon\globalPlugins\visionAssistant\__init__.py:3722
 msgid "Checking for updates..."
 msgstr "Đang kiểm tra cập nhật..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:3613
+#: addon\globalPlugins\visionAssistant\__init__.py:3755
 msgid "Translating Clipboard..."
-msgstr "Đang dịch bộ nhớ tạm..."
+msgstr "Đang dịch Clipboard..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:3618
+#: addon\globalPlugins\visionAssistant\__init__.py:3760
 msgid "Clipboard empty."
-msgstr "Bộ nhớ tạm trống."
+msgstr "Clipboard trống."
+
+#. Translators: Message reported when the user tries to show the last result but none is stored.
+#: addon\globalPlugins\visionAssistant\__init__.py:3769
+msgid "No previous result to show."
+msgstr "Không có kết quả trước đó để hiển thị."
 
 #. Translators: Message shown when settings dialog is already open
-#: addon\globalPlugins\visionAssistant\__init__.py:3626
+#: addon\globalPlugins\visionAssistant\__init__.py:3783
+#: addon\globalPlugins\visionAssistant\__init__.py:3793
 msgid "Settings dialog is already open."
-msgstr "Hộp thoại cài đặt hiện đang mở."
+msgstr "Hộp thoại cài đặt đã được mở."
 
 #. Translators: Message when opening documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:3630
+#: addon\globalPlugins\visionAssistant\__init__.py:3799
 msgid "Opening documentation..."
 msgstr "Đang mở tài liệu hướng dẫn..."
 
 #. Translators: Error when help file is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:3640
+#: addon\globalPlugins\visionAssistant\__init__.py:3809
 msgid "Documentation file not found."
 msgstr "Không tìm thấy tệp tài liệu hướng dẫn."
 
@@ -1248,111 +1822,54 @@ msgid ""
 "- Audio Transcription (A)\n"
 "- Smart Dictation (S)\n"
 "- Announce Status (L)\n"
-"- Check Update (U)"
+"- Check Update (U)\n"
+"- Recall Last Result (Space),\n"
+"- Commands Help (H),\n"
 msgstr ""
-"Trợ lý AI nâng cao cho NVDA sử dụng các mô hình Gemini.\n"
+"Một trợ lý AI nâng cao dành cho NVDA sử dụng các mô hình Gemini.\n"
 "Lớp lệnh: Nhấn NVDA+Shift+V, sau đó:\n"
-"- Dịch thuật thông minh (T) / Dịch bộ nhớ tạm (Shift+T)\n"
+"- Dịch thông minh (T) / Clipboard (Shift+T)\n"
 "- Tinh chỉnh văn bản (R)\n"
 "- Mô tả đối tượng (V) / Toàn màn hình (O)\n"
-"- Phân tích Video trực tuyến (Shift+V)\n"
-"- Hỏi đáp tài liệu (D)\n"
-"- Nhận diện văn bản OCR (F)\n"
-"- Giải mã CAPTCHA (C)\n"
-"- Chuyển tệp âm thanh thành văn bản (A)\n"
-"- Soạn thảo giọng nói thông minh (S)\n"
+"- Phân tích video trực tuyến (Shift+V)\n"
+"- Trình đọc tài liệu (D)\n"
+"- OCR tệp (F)\n"
+"- Giải CAPTCHA (C)\n"
+"- Chuyển biên âm thanh (A)\n"
+"- Đọc chính tả thông minh (S)\n"
 "- Thông báo trạng thái (L)\n"
-"- Kiểm tra cập nhật (U)"
+"- Kiểm tra cập nhật (U)\n"
+"- Gọi lại kết quả cuối cùng (Space),\n"
+"- Trợ giúp lệnh (H),\n"
 
 #. Brief changelog for this version
 #. Translators: what's new content for the add-on version to be shown in the add-on store
-#: buildVars.py:29
+#: buildVars.py:32
 msgid ""
-"## Changes for 4.0.1\n"
-"*   **Advanced Document Reader:** A powerful new viewer for PDF and images "
-"with page range selection, background processing, and seamless `Ctrl+PageUp/"
-"Down` navigation.\n"
-"*   **New Tools Submenu:** Added a dedicated \"Vision Assistant\" submenu "
-"under NVDA's Tools menu for quicker access to core features, settings, and "
-"documentation.\n"
-"*   **Flexible Customization:** You can now choose your preferred OCR engine "
-"and TTS voice directly from the settings panel.\n"
-"*   **Multiple API Key Support:** Added support for multiple Gemini API "
-"keys. You can enter one key per line or separate them with commas in the "
-"settings.\n"
-"*   **Alternative OCR Engine:** Introduced a new OCR engine to ensure "
-"reliable text recognition even when hitting Gemini API quota limits.\n"
-"*   **Smart API Key Rotation:** Automatically switches to and remembers the "
-"fastest working API key to bypass quota limits.\n"
-"*   **Document to MP3/WAV:** Integrated capability to generate and save high-"
-"quality audio files in both MP3 (128kbps) and WAV formats directly within "
-"the reader.\n"
-"*   **Instagram Stories Support:** Added the ability to describe and analyze "
-"Instagram Stories using their URLs.\n"
-"*   **TikTok Support:** Introduced support for TikTok videos, allowing for "
-"full visual description and audio transcription of clips.\n"
-"*   **Redesigned Update Dialog:** Features a new accessible interface with a "
-"scrollable text box to clearly read version changes before installing.\n"
-"*   **Unified Status & UX:** Standardized file dialogs across the add-on and "
-"enhanced the 'L' command to report real-time progress."
+"## Changes for 4.6\n"
+"* **Interactive Result Recall:** Added the **Space** key to the command "
+"layer, allowing users to instantly reopen the last AI response in a chat "
+"window for follow-up questions, even when \"Direct Output\" mode is active.\n"
+"* **Telegram Community Hub:** Added an \"Official Telegram Channel\" link to "
+"the NVDA Tools menu, providing a quick way to stay updated with the latest "
+"news, features, and releases.\n"
+"* **Enhanced Response Stability:** Optimized the core logic for Translation, "
+"OCR, and Vision features to ensure more reliable performance and a smoother "
+"experience when using direct speech output.\n"
+"* **Improved Interface Guidance:** Updated the settings descriptions and "
+"documentation to better explain the new recall system and how it works "
+"alongside the direct output settings."
 msgstr ""
-"## Những thay đổi cho phiên bản 4.0\n"
-"* **Trình đọc tài liệu nâng cao:** Trình xem PDF và hình ảnh mạnh mẽ mới, hỗ "
-"trợ chọn phạm vi trang, xử lý trong nền và điều hướng mượt mà bằng phím "
-"`Ctrl+PageUp/Down`.\n"
-"* **Trình đơn phụ mới:** Đã thêm trình đơn \"Vision Assistant\" vào menu "
-"Công cụ của NVDA để truy cập nhanh các tính năng, cài đặt và tài liệu.\n"
-"* **Tùy biến linh hoạt:** Bạn có thể chọn công cụ OCR và giọng đọc TTS ưa "
-"thích ngay trong bảng cài đặt.\n"
-"* **Hỗ trợ nhiều khóa API:** Cho phép nhập nhiều khóa API Gemini (mỗi dòng "
-"một khóa hoặc cách nhau bằng dấu phẩy) để đảm bảo hoạt động liên tục.\n"
-"* **Công cụ OCR thay thế:** Bổ sung công cụ OCR mới để đảm bảo nhận diện văn "
-"bản ổn định khi API Gemini đạt giới hạn hạn mức.\n"
-"* **Tự động luân chuyển khóa API:** Hệ thống tự động chuyển và ghi nhớ khóa "
-"API hoạt động nhanh nhất để vượt qua giới hạn hạn mức.\n"
-"* **Chuyển tài liệu thành âm thanh:** Tích hợp khả năng tạo và lưu tệp âm "
-"thanh chất lượng cao (WAV) từ các trang tài liệu trực tiếp trong trình đọc.\n"
-"* **Hỗ trợ story trên Instagram:** Đã thêm khả năng mô tả và phân tích Story "
-"trên Instagram bằng URL của chúng.\\n\n"
-"* **Hỗ trợ TikTok:** Giới thiệu hỗ trợ cho video TikTok, cho phép mô tả đầy "
-"đủ bằng hình ảnh và phiên âm âm thanh của clip.\\n\n"
-"* **Cải tiến hộp thoại cập nhật:** Giao diện mới hỗ trợ tiếp cận tốt hơn với "
-"khung văn bản có thể cuộn để đọc nội dung thay đổi rõ ràng hơn.\n"
-"* **Hợp nhất trạng thái & trải nghiệm:** Chuẩn hóa các hộp thoại chọn tệp và "
-"cải tiến lệnh 'L' để báo cáo tiến độ thời gian thực của các tác vụ chạy nền."
-
-#~ msgid "[Legacy]"
-#~ msgstr "[Bản cũ]"
-
-#~ msgid "Gemini API Key:"
-#~ msgstr "Khóa API Gemini:"
-
-#~ msgid "API Key missing."
-#~ msgstr "Thiếu khóa API."
-
-#~ msgid "Error 429: Quota Exceeded (Try later)"
-#~ msgstr "Lỗi 429: Hết hạn mức (Vui lòng thử lại sau)"
-
-#, python-brace-format
-#~ msgid "Server Error {code}: {reason}"
-#~ msgstr "Lỗi máy chủ {code}: {reason}"
-
-#, python-brace-format
-#~ msgid "Connection Error: {reason}"
-#~ msgstr "Lỗi kết nối: {reason}"
-
-#, python-brace-format
-#~ msgid "Error: {error}"
-#~ msgstr "Lỗi: {error}"
-
-#~ msgid "Allows asking questions about a selected document (PDF/Text/Image)."
-#~ msgstr "Đặt câu hỏi về tài liệu đã chọn (PDF/Văn bản/Hình ảnh)."
-
-#~ msgid "Uploading & Analyzing..."
-#~ msgstr "Đang tải lên & Phân tích..."
-
-#~ msgid "Announces the last received translation."
-#~ msgstr "Đọc bản dịch nhận được gần nhất."
-
-#~ msgid "No history."
-#~ msgstr "Không có lịch sử."
+"## Những thay đổi trong phiên bản 4.6\n"
+"* **Gọi lại kết quả tương tác:** Đã thêm phím **Space** vào lớp lệnh, cho phép "
+"người dùng mở lại ngay lập tức phản hồi cuối cùng của AI trong cửa sổ trò chuyện "
+"để đặt câu hỏi tiếp theo, ngay cả khi chế độ \"Đầu ra trực tiếp\" đang hoạt động.\n"
+"* **Cộng đồng Telegram:** Đã thêm liên kết \"Kênh Telegram chính thức\" vào "
+"menu Công cụ của NVDA, cung cấp một cách nhanh chóng để cập nhật những "
+"tin tức, tính năng và bản phát hành mới nhất.\n"
+"* **Tăng cường độ ổn định của phản hồi:** Tối ưu hóa logic cốt lõi cho các "
+"tính năng Dịch thuật, OCR và Thị giác để đảm bảo hiệu suất đáng tin cậy "
+"hơn và trải nghiệm mượt mà hơn khi sử dụng đầu ra giọng nói trực tiếp.\n"
+"* **Cải thiện hướng dẫn giao diện:** Đã cập nhật các mô tả cài đặt và tài liệu "
+"hướng dẫn để giải thích rõ hơn về hệ thống gọi lại mới và cách thức hoạt động "
+"của nó cùng với các cài đặt đầu ra trực tiếp."


### PR DESCRIPTION
Revise Vietnamese documentation and localization strings.

- Rewrite and refine addon/doc/vi/readme.md: wording improvements, unify terminology (Command Layer, Direct Output, Clipboard), update keyboard shortcuts and command names, expand prompt/variables docs and examples, add Support & Community section (Telegram link), and include detailed changelogs (4.6, 4.5, 4.0.3, etc.). Also add Space key to recall last AI result and other UX/feature clarifications.
- Update addon/locale/vi/LC_MESSAGES/nvda.po: refresh headers (Project-Id-Version -> 4.6, POT/PO dates), clear translator metadata, adjust message references, add/modify translation entries (e.g. "Copy Support Email", unified clipboard success message) and tidy existing strings.