### PR TITLE
Update Vietnamese docs and translations for v5.5

### DIFF
--- a/addon/doc/vi/readme.md
+++ b/addon/doc/vi/readme.md
@@ -1,6 +1,6 @@
 # Tài liệu hướng dẫn Vision Assistant Pro
 
-**Vision Assistant Pro** là một trợ lý AI đa phương thức, nâng cao dành cho NVDA. Nó tận dụng các mô hình Gemini của Google để cung cấp khả năng đọc màn hình thông minh, dịch thuật, đọc chính tả bằng giọng nói và phân tích tài liệu.
+**Vision Assistant Pro** là một trợ lý AI đa phương thức, nâng cao dành cho NVDA. Nó tận dụng các công cụ AI hàng đầu thế giới để cung cấp khả năng đọc màn hình thông minh, dịch thuật, đọc chính tả bằng giọng nói và phân tích tài liệu.
 
 *Add-on này được phát hành cho cộng đồng nhằm tôn vinh Ngày Quốc tế Người khuyết tật.*
 
@@ -8,24 +8,52 @@
 
 Đi tới **Menu NVDA > Tùy chọn > Cài đặt > Vision Assistant Pro**.
 
-* **Khóa API (API Key):** Bắt buộc. Bạn có thể nhập nhiều khóa (phân tách bằng dấu phẩy hoặc xuống dòng). Trợ lý sẽ tự động luân phiên giữa các khóa nếu đạt đến giới hạn hạn ngạch.
-* **Mô hình AI:** Chọn giữa các mô hình **Flash** (Nhanh nhất/Miễn phí), **Lite**, hoặc **Pro** (Trí thông minh cao).
-* **URL Proxy:** Tùy chọn. Sử dụng thiết lập này nếu Google bị chặn ở khu vực của bạn. Đây phải là một địa chỉ web hoạt động như một cầu nối với Gemini API.
-* **Công cụ OCR:** Chọn giữa **Chrome (Fast)** để có kết quả nhanh hoặc **Gemini (Formatted)** để giữ nguyên bố cục và nhận dạng bảng tốt hơn.
-* **Giọng nói TTS:** Chọn kiểu giọng nói ưa thích để tạo tệp âm thanh từ các trang tài liệu.
-* **Chuyển đổi thông minh (Smart Swap):** Tự động chuyển đổi ngôn ngữ nếu văn bản nguồn khớp với ngôn ngữ đích.
-* **Đầu ra trực tiếp (Direct Output):** Bỏ qua cửa sổ trò chuyện và đọc thẳng phản hồi của AI qua giọng nói. **Lưu ý:** Ngay cả trong chế độ này, bạn có thể nhấn **Space** trong lớp lệnh để mở lại kết quả cuối cùng trong một hộp thoại trò chuyện.
-* **Tích hợp Clipboard:** Tự động sao chép phản hồi của AI vào clipboard.
+### 1.1 Cài đặt kết nối
+- **Nhà cung cấp (Provider):** Chọn dịch vụ AI bạn ưu tiên. Các nhà cung cấp được hỗ trợ bao gồm **Google Gemini**, **OpenAI**, **Mistral**, **Groq**, và **Tùy chỉnh** (các máy chủ tương thích OpenAI như Ollama/LM Studio).
+- **Lưu ý quan trọng:** Chúng tôi khuyên bạn nên sử dụng **Google Gemini** để có hiệu suất và độ chính xác tốt nhất (đặc biệt là đối với phân tích hình ảnh/tệp).
+- **Khóa API (API Key):** Bắt buộc. Bạn có thể nhập nhiều khóa (phân tách bằng dấu phẩy hoặc xuống dòng) để tự động luân phiên.
+- **Tải mô hình (Fetch Models):** Sau khi nhập khóa API, nhấn nút này để tải xuống danh sách các mô hình mới nhất hiện có từ nhà cung cấp.
+- **Mô hình AI:** Chọn mô hình chính được sử dụng cho trò chuyện và phân tích chung.
+
+### 1.2 Định tuyến mô hình nâng cao (Advanced Model Routing)
+*Khả dụng cho tất cả các nhà cung cấp bao gồm Gemini, OpenAI, Groq, Mistral và Tùy chỉnh.*
+
+> **⚠️ Cảnh báo:** Các cài đặt này chỉ dành cho **người dùng nâng cao**. Nếu bạn không chắc chắn một mô hình cụ thể làm gì, vui lòng để trống phần này. Việc chọn một mô hình không tương thích cho một tác vụ (ví dụ: chọn mô hình chỉ có văn bản cho Thị giác) sẽ gây ra lỗi và khiến add-on ngừng hoạt động.
+
+Chọn **"Định tuyến mô hình nâng cao (Theo tác vụ)"** để mở khóa quyền kiểm soát chi tiết. Điều này cho phép bạn chọn các mô hình cụ thể từ danh sách thả xuống cho các tác vụ khác nhau:
+- **Mô hình OCR / Thị giác:** Chọn một mô hình chuyên dụng để phân tích hình ảnh.
+- **Chuyển giọng nói thành văn bản (STT):** Chọn một mô hình cụ thể để đọc chính tả.
+- **Chuyển văn bản thành giọng nói (TTS):** Chọn một mô hình để tạo âm thanh.
+- **Mô hình AI Operator:** Chọn một mô hình cụ thể cho các tác vụ điều khiển máy tính tự động.
+*Lưu ý: Các tính năng không được hỗ trợ (ví dụ: TTS cho Groq) sẽ tự động bị ẩn.*
+
+### 1.3 Cấu hình Endpoint nâng cao (Nhà cung cấp tùy chỉnh)
+*Chỉ khả dụng khi chọn "Tùy chỉnh".*
+
+> **⚠️ Cảnh báo:** Phần này cho phép cấu hình API thủ công và được thiết kế cho **người dùng chuyên sâu** đang chạy các máy chủ cục bộ hoặc proxy. URL hoặc tên mô hình không chính xác sẽ làm mất kết nối. Nếu bạn không biết chính xác các endpoint này là gì, hãy để trống.
+
+Chọn **"Cấu hình Endpoint nâng cao"** để nhập chi tiết máy chủ theo cách thủ công. Không giống như các nhà cung cấp gốc, tại đây bạn phải **tự nhập** các URL và Tên mô hình cụ thể:
+- **URL danh sách mô hình (Models List URL):** Endpoint để tải các mô hình hiện có.
+- **URL Endpoint OCR/STT/TTS:** URL đầy đủ cho các dịch vụ cụ thể (ví dụ: `http://localhost:11434/v1/audio/speech`).
+- **Mô hình tùy chỉnh:** Nhập thủ công tên mô hình (ví dụ: `llama3:8b`) cho từng tác vụ.
+
+### 1.4 Tùy chọn chung
+- **Công cụ OCR:** Chọn giữa **Chrome (Fast)** để có kết quả nhanh hoặc **AI (Advanced)** để nhận dạng bố cục vượt trội.
+    - *Lưu ý:* Nếu bạn chọn "AI (Advanced)" nhưng nhà cung cấp được đặt là OpenAI/Groq, add-on sẽ thông minh tự chuyển hình ảnh đến mô hình thị giác của nhà cung cấp đó.
+- **Giọng nói TTS:** Chọn kiểu giọng nói ưu thích của bạn. Danh sách này cập nhật động dựa trên nhà cung cấp đang hoạt động.
+- **Độ sáng tạo (Temperature):** Kiểm soát tính ngẫu nhiên của AI. Giá trị thấp hơn sẽ tốt hơn cho độ chính xác của dịch thuật/OCR.
+- **URL Proxy:** Cấu hình nếu các dịch vụ AI bị hạn chế ở khu vực của bạn (hỗ trợ proxy cục bộ như `127.0.0.1` hoặc các URL cầu nối).
 
 ## 2. Lớp lệnh & Phím tắt
 
 Để ngăn ngừa xung đột bàn phím, add-on này sử dụng một **Lớp lệnh (Command Layer)**.
-
 1. Nhấn **NVDA + Shift + V** (Phím chính) để kích hoạt lớp lệnh (bạn sẽ nghe thấy tiếng bíp).
 2. Nhả các phím, sau đó nhấn một trong các phím đơn sau:
 
 | Phím | Chức năng | Mô tả |
 | --- | --- | --- |
+| **Shift + A** | **AI Operator** | **Điều khiển tự động:** Yêu cầu AI thực hiện một tác vụ trực tiếp trên màn hình của bạn. |
+| **E** | **UI Explorer** | **Click tương tác:** Nhận diện và click vào các thành phần giao diện trong bất kỳ ứng dụng nào. |
 | **T** | Dịch thông minh | Dịch văn bản dưới con trỏ navigator hoặc vùng đang chọn. |
 | **Shift + T** | Dịch Clipboard | Dịch nội dung hiện có trong clipboard. |
 | **R** | Tinh chỉnh văn bản | Tóm tắt, Sửa ngữ pháp, Giải thích hoặc chạy các **Prompt tùy chỉnh**. |
@@ -33,7 +61,7 @@
 | **O** | Thị giác toàn màn hình | Phân tích toàn bộ bố cục và nội dung màn hình. |
 | **Shift + V** | Phân tích Video trực tuyến | Phân tích video trên **YouTube**, **Instagram**, **TikTok**, hoặc **Twitter (X)**. |
 | **D** | Trình đọc tài liệu | Trình đọc nâng cao cho PDF và hình ảnh với tùy chọn chọn phạm vi trang. |
-| **F** | OCR Tệp | Nhận dạng văn bản trực tiếp từ các tệp hình ảnh, PDF hoặc TIFF được chọn. |
+| **F** | **Hành động tệp thông minh** | Nhận diện theo ngữ cảnh từ các tệp hình ảnh, PDF hoặc TIFF được chọn. |
 | **A** | Chuyển biên âm thanh | Chuyển biên các tệp MP3, WAV hoặc OGG thành văn bản. |
 | **C** | Giải CAPTCHA | Chụp và giải mã CAPTCHA trên màn hình hoặc đối tượng navigator. |
 | **S** | Đọc chính tả thông minh | Chuyển đổi giọng nói thành văn bản. Nhấn để bắt đầu ghi âm, nhấn lần nữa để dừng/gõ văn bản. |
@@ -43,63 +71,64 @@
 | **H** | Trợ giúp lệnh | Hiển thị danh sách tất cả các phím tắt có sẵn trong lớp lệnh. |
 
 ### 2.1 Phím tắt Trình đọc tài liệu (Bên trong Trình xem)
-
-Khi một tài liệu được mở qua lệnh **D**:
-
-* **Ctrl + PageDown:** Chuyển đến trang tiếp theo (thông báo số trang).
-* **Ctrl + PageUp:** Chuyển đến trang trước đó (thông báo số trang).
-* **Alt + A:** Mở hộp thoại trò chuyện để đặt câu hỏi về tài liệu.
-* **Alt + R:** Buộc quét lại trang hiện tại hoặc tất cả các trang bằng công cụ Gemini.
-* **Alt + G:** Tạo và lưu tệp âm thanh chất lượng cao (WAV) từ nội dung.
-* **Alt + S / Ctrl + S:** Lưu văn bản được trích xuất dưới dạng tệp TXT hoặc HTML.
+- **Ctrl + PageDown:** Chuyển đến trang tiếp theo.
+- **Ctrl + PageUp:** Chuyển đến trang trước đó.
+- **Alt + A:** Mở hộp thoại trò chuyện để đặt câu hỏi về tài liệu.
+- **Alt + R:** Buộc **Quét lại bằng AI** bằng nhà cung cấp hiện tại của bạn.
+- **Alt + G:** Tạo và lưu tệp âm thanh chất lượng cao (WAV/MP3). *Ẩn nếu nhà cung cấp không hỗ trợ TTS.*
+- **Alt + S / Ctrl + S:** Lưu văn bản được trích xuất dưới dạng tệp TXT hoặc HTML.
 
 ## 3. Prompt tùy chỉnh & Biến
 
-Mở **Cài đặt > Prompts > Manage Prompts...** để cấu hình các prompt hệ thống và tùy chỉnh.
+Bạn có thể quản lý các prompt trong **Cài đặt > Prompts > Manage Prompts...**.
 
-* **Thẻ Default Prompts:** chỉnh sửa các prompt có sẵn. Bạn có thể đặt lại một prompt duy nhất hoặc đặt lại tất cả về mặc định.
-* **Thẻ Custom Prompts:** thêm, sửa, xóa và sắp xếp lại các prompt tùy chỉnh.
-* **Nút Variables Guide:** mở cửa sổ trợ giúp với tất cả các biến và loại đầu vào được hỗ trợ.
+### Các biến được hỗ trợ
+- `[selection]`: Văn bản hiện đang được chọn.
+- `[clipboard]`: Nội dung clipboard.
+- `[screen_obj]`: Ảnh chụp màn hình của đối tượng navigator.
+- `[screen_full]`: Ảnh chụp toàn bộ màn hình.
+- `[file_ocr]`: Chọn tệp hình ảnh/PDF để trích xuất văn bản.
+- `[file_read]`: Chọn tài liệu để đọc (TXT, Code, PDF).
+- `[file_audio]`: Chọn tệp âm thanh để phân tích (MP3, WAV, OGG).
 
-### Các biến có sẵn
-
-| Biến | Mô tả | Loại đầu vào |
-| --- | --- | --- |
-| `[selection]` | Văn bản hiện đang được chọn | Text |
-| `[clipboard]` | Nội dung clipboard | Text |
-| `[screen_obj]` | Ảnh chụp màn hình của đối tượng navigator | Image |
-| `[screen_full]` | Ảnh chụp toàn bộ màn hình | Image |
-| `[file_ocr]` | Chọn tệp hình ảnh/PDF để trích xuất văn bản | Image, PDF, TIFF |
-| `[file_read]` | Chọn tài liệu để đọc | TXT, Code, PDF |
-| `[file_audio]` | Chọn tệp âm thanh để phân tích | MP3, WAV, OGG |
-
-### Ví dụ về Prompt tùy chỉnh
-
-* **OCR Nhanh:** `My OCR:[file_ocr]`
-* **Dịch hình ảnh:** `Translate Img:Extract text from this image and translate to English. [file_ocr]`
-* **Phân tích âm thanh:** `Summarize Audio:Listen to this recording and summarize the main points. [file_audio]`
-* **Tìm lỗi mã nguồn (Code Debugger):** `Debug:Find bugs in this code and explain them: [selection]`
-
----
-
-**Lưu ý:** Cần có kết nối internet đang hoạt động cho tất cả các tính năng AI. Tài liệu nhiều trang và tệp TIFF được xử lý tự động.
+***
+**Lưu ý:** Cần có kết nối internet đang hoạt động cho tất cả các tính năng AI. Tài liệu nhiều trang được xử lý tự động.
 
 ## 4. Hỗ trợ & Cộng đồng
 
 Cập nhật những tin tức, tính năng và bản phát hành mới nhất:
+- **Kênh Telegram:** [t.me/VisionAssistantPro](https://t.me/VisionAssistantPro)
+- **GitHub Issues:** Dành cho báo cáo lỗi và yêu cầu tính năng.
 
-* **Kênh Telegram:** [t.me/VisionAssistantPro](https://t.me/VisionAssistantPro)
-* **GitHub Issues:** Dành cho báo cáo lỗi và yêu cầu tính năng.
+---
+
+## Những thay đổi trong phiên bản 5.5 (Bản cập nhật Tự động hóa)
+
+* **AI Operator (Điều khiển tự động - Shift+A):** Đây là tính năng sáng giá nhất của v5.5. Vision Assistant Pro đã nâng cấp từ một trợ lý thụ động thành **AI Operator** cá nhân của bạn. Nó không chỉ mô tả màn hình mà còn thực sự nắm quyền điều khiển.
+    * *Cách thức hoạt động:* Giờ đây bạn có thể đưa ra các chỉ dẫn bằng văn bản để vận hành máy tính. Ví dụ, trong một ứng dụng hoàn toàn không tiếp cận được nơi trình đọc màn hình im lặng, bạn có thể nhấn **Shift+A** và nhập: *"Click vào nút Cài đặt"* hoặc *"Tìm ô tìm kiếm, nhập 'Tin tức mới nhất' rồi nhấn enter."* AI sẽ nhận diện các thành phần bằng hình ảnh, di chuyển chuột và thực hiện tác vụ cho bạn.
+    * *Lưu ý về hiệu suất:* Tính năng này được tối ưu hóa cho **Gemini 3.0 Flash (Bản xem trước)**, mang lại phản hồi cực nhanh và thông minh, có thể xử lý cả những bố cục giao diện phức tạp nhất.
+    * **⚠️ Cảnh báo sử dụng API:** Vì AI Operator cần "nhìn" chính xác những gì đang diễn ra để đảm bảo độ chính xác, nó sẽ gửi ảnh chụp màn hình độ phân giải cao sau mỗi bước. Lưu ý rằng việc sử dụng thường xuyên sẽ tiêu tốn hạn ngạch API nhanh hơn nhiều so với các tác vụ văn bản thông thường.
+* **Trình thám hiểm giao diện (UI Explorer - E):** Bạn mệt mỏi vì phải điều hướng qua các "nút không nhãn"? Nhấn **E** để kích hoạt UI Explorer. AI sẽ quét toàn bộ cửa sổ và tạo danh sách mọi thành phần có thể click mà nó thấy—bao gồm cả icon, đồ họa và menu. Chỉ cần chọn một mục từ danh sách và AI Operator sẽ click giúp bạn. Nó giống như việc thêm một "lớp tiếp cận" lên trên bất kỳ ứng dụng nào.
+* **Hành động tệp thông minh theo ngữ cảnh (F):** Phím "F" đã được đại tu hoàn toàn. Nó không còn mặc định là bạn chỉ muốn OCR nữa. Khi bạn chọn một hình ảnh, nó sẽ hỏi ý định của bạn: bạn có thể chọn **Mô tả hình ảnh chi tiết** để hiểu bối cảnh hoặc **Trích xuất văn bản có cấu trúc (OCR)** để đọc. Menu sẽ thay đổi linh hoạt dựa trên loại tệp và công cụ AI bạn đang dùng.
+* **Tối ưu hóa cốt lõi:** Chúng tôi đã dọn dẹp sâu logic nội bộ của add-on, loại bỏ các hàm cũ không còn sử dụng và mã dư thừa. Điều này giúp add-on nhẹ hơn, nhanh hơn và hoạt động ổn định hơn cho tất cả người dùng.
+
+## Những thay đổi trong phiên bản 5.0
+
+* **Kiến trúc đa nhà cung cấp**: Bổ sung hỗ trợ đầy đủ cho **OpenAI**, **Groq**, và **Mistral** bên cạnh Google Gemini. Người dùng hiện có thể chọn backend AI ưa thích của mình.
+* **Định tuyến mô hình nâng cao**: Người dùng các nhà cung cấp gốc (Gemini, OpenAI, v.v.) hiện có thể chọn các mô hình cụ thể từ danh sách thả xuống cho các tác vụ khác nhau (OCR, STT, TTS).
+* **Cấu hình Endpoint nâng cao**: Người dùng nhà cung cấp tùy chỉnh có thể nhập thủ công các URL và tên mô hình cụ thể để kiểm soát chi tiết các máy chủ cục bộ hoặc bên thứ ba.
+* **Hiển thị tính năng thông minh**: Menu cài đặt và giao diện Trình đọc tài liệu giờ đây tự động ẩn các tính năng không được hỗ trợ (như TTS) dựa trên nhà cung cấp đã chọn.
+* **Tìm nạp mô hình động**: Add-on hiện tìm nạp danh sách mô hình có sẵn trực tiếp từ API của nhà cung cấp, đảm bảo khả năng tương thích với các mô hình mới ngay khi chúng được phát hành.
+* **Kết hợp OCR & Dịch thuật**: Tối ưu hóa logic để sử dụng Google Dịch nhằm tăng tốc độ khi dùng Chrome OCR, và dịch thuật bằng AI khi dùng các công cụ Gemini/Groq/OpenAI.
+* **"Quét lại bằng AI" toàn cầu**: Tính năng quét lại của Trình đọc tài liệu không còn bị giới hạn ở Gemini. Giờ đây, tính năng này sử dụng bất kỳ nhà cung cấp AI nào đang hoạt động để xử lý lại các trang.
 
 ## Những thay đổi trong phiên bản 4.6
-
-* **Gọi lại kết quả tương tác:** Đã thêm phím **Space** vào lớp lệnh, cho phép người dùng mở lại ngay lập tức phản hồi cuối cùng của AI trong cửa sổ trò chuyện để đặt câu hỏi tiếp theo, ngay cả khi chế độ "Direct Output" đang hoạt động.
-* **Cộng đồng Telegram:** Đã thêm liên kết "Official Telegram Channel" vào menu Tools của NVDA, cung cấp một cách nhanh chóng để cập nhật những tin tức, tính năng và bản phát hành mới nhất.
+* **Gọi lại kết quả tương tác:** Đã thêm phím **Space** vào lớp lệnh, cho phép người dùng mở lại ngay lập tức phản hồi cuối cùng của AI trong cửa sổ trò chuyện để đặt câu hỏi tiếp theo, ngay cả khi chế độ "Đầu ra trực tiếp" đang hoạt động.
+* **Cộng đồng Telegram:** Đã thêm liên kết "Kênh Telegram chính thức" vào menu Công cụ của NVDA, cung cấp một cách nhanh chóng để cập nhật những tin tức, tính năng và bản phát hành mới nhất.
 * **Tăng cường độ ổn định của phản hồi:** Tối ưu hóa logic cốt lõi cho các tính năng Dịch thuật, OCR và Thị giác để đảm bảo hiệu suất đáng tin cậy hơn và trải nghiệm mượt mà hơn khi sử dụng đầu ra giọng nói trực tiếp.
 * **Cải thiện hướng dẫn giao diện:** Đã cập nhật các mô tả cài đặt và tài liệu hướng dẫn để giải thích rõ hơn về hệ thống gọi lại mới và cách thức hoạt động của nó cùng với các cài đặt đầu ra trực tiếp.
 
 ## Những thay đổi trong phiên bản 4.5
-
 * **Trình quản lý Prompt nâng cao:** Giới thiệu một hộp thoại quản lý chuyên dụng trong cài đặt để tùy chỉnh các prompt hệ thống mặc định và quản lý các prompt do người dùng xác định với hỗ trợ đầy đủ cho việc thêm, sửa, sắp xếp lại và xem trước.
 * **Hỗ trợ Proxy toàn diện:** Đã giải quyết các sự cố kết nối mạng bằng cách đảm bảo rằng các cài đặt proxy do người dùng định cấu hình được áp dụng nghiêm ngặt cho tất cả các yêu cầu API, bao gồm dịch thuật, OCR và tạo giọng nói.
 * **Di chuyển dữ liệu tự động:** Tích hợp hệ thống di chuyển thông minh để tự động nâng cấp các cấu hình prompt cũ sang định dạng v2 JSON mạnh mẽ trong lần chạy đầu tiên mà không làm mất dữ liệu.
@@ -108,7 +137,6 @@ Cập nhật những tin tức, tính năng và bản phát hành mới nhất:
 * **Hướng dẫn về biến Prompt:** Đã thêm hướng dẫn tích hợp trong các hộp thoại prompt để giúp người dùng dễ dàng xác định và sử dụng các biến động như `[selection]`, `[clipboard]`, và `[screen_obj]`.
 
 ## Những thay đổi trong phiên bản 4.0.3
-
 * **Tăng cường độ ổn định mạng:** Đã thêm cơ chế thử lại tự động để xử lý tốt hơn các kết nối internet không ổn định và lỗi máy chủ tạm thời, đảm bảo phản hồi AI đáng tin cậy hơn.
 * **Hộp thoại dịch trực quan:** Giới thiệu một cửa sổ dành riêng cho kết quả dịch. Người dùng giờ đây có thể dễ dàng điều hướng và đọc các bản dịch dài theo từng dòng, tương tự như kết quả OCR.
 * **Chế độ xem định dạng tổng hợp:** Tính năng "View Formatted" trong Trình đọc tài liệu hiện hiển thị tất cả các trang đã xử lý trong một cửa sổ duy nhất, được tổ chức với các tiêu đề trang rõ ràng.
@@ -117,7 +145,6 @@ Cập nhật những tin tức, tính năng và bản phát hành mới nhất:
 * **Sửa lỗi:** Đã giải quyết một số sự cố treo có thể xảy ra, bao gồm sự cố trong quá trình tắt add-on và lỗi tiêu điểm trong hộp thoại trò chuyện.
 
 ## Những thay đổi trong phiên bản 4.0.1
-
 * **Trình đọc tài liệu nâng cao:** Một trình xem mới, mạnh mẽ dành cho PDF và hình ảnh với khả năng chọn phạm vi trang, xử lý nền và điều hướng liền mạch bằng `Ctrl+PageUp/Down`.
 * **Menu con Tools mới:** Đã thêm một menu con "Vision Assistant" chuyên dụng bên dưới menu Tools của NVDA để truy cập nhanh hơn vào các tính năng cốt lõi, cài đặt và tài liệu hướng dẫn.
 * **Tùy chỉnh linh hoạt:** Giờ đây, bạn có thể chọn công cụ OCR và giọng nói TTS ưa thích trực tiếp từ bảng cài đặt.

--- a/addon/locale/vi/LC_MESSAGES/nvda.po
+++ b/addon/locale/vi/LC_MESSAGES/nvda.po
@@ -1,16 +1,16 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Vietnamese translation for Vision Assistant Pro.
+# Copyright (C) 2026 Nguyễn Anh Đức
 # This file is distributed under the same license as the 'VisionAssistant' package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Nguyễn Anh Đức <ducn98224@gmail.com>, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 'VisionAssistant' '4.6'\n"
+"Project-Id-Version: 'VisionAssistant' '5.5'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-02-27 13:25+0330\n"
-"PO-Revision-Date: 2026-04-27 08:23+0700\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"POT-Creation-Date: 2026-05-01 12:12+0330\n"
+"PO-Revision-Date: 2026-05-03 09:31+0700\n"
+"Last-Translator: Nguyễn Anh Đức <ducn98224@gmail.com>\n"
+"Language-Team: Vietnamese\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,8 +44,8 @@ msgstr "Đã sao chép vào clipboard! Rất trân trọng sự ủng hộ của
 
 #. Translators: Title for the success message box.
 #: addon\globalPlugins\visionAssistant\donate_dialog.py:42
-#: addon\globalPlugins\visionAssistant\__init__.py:3325
-#: addon\globalPlugins\visionAssistant\__init__.py:3374
+#: addon\globalPlugins\visionAssistant\__init__.py:3545
+#: addon\globalPlugins\visionAssistant\__init__.py:3600
 msgid "Success"
 msgstr "Thành công"
 
@@ -148,8 +148,8 @@ msgstr "Sử dụng các biến này bên trong văn bản prompt:"
 
 #. Translators: Button to close chat dialog
 #: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:110
-#: addon\globalPlugins\visionAssistant\__init__.py:1958
-#: addon\globalPlugins\visionAssistant\__init__.py:2987
+#: addon\globalPlugins\visionAssistant\__init__.py:2060
+#: addon\globalPlugins\visionAssistant\__init__.py:3200
 msgid "Close"
 msgstr "Đóng"
 
@@ -316,604 +316,642 @@ msgstr "Xác nhận xóa"
 
 #. --- 1. Recommended (Auto-Updating) ---
 #. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest version.
-#: addon\globalPlugins\visionAssistant\__init__.py:67
-#: addon\globalPlugins\visionAssistant\__init__.py:68
+#: addon\globalPlugins\visionAssistant\__init__.py:71
+#: addon\globalPlugins\visionAssistant\__init__.py:72
 msgid "[Auto]"
 msgstr "[Tự động]"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:67
-#: addon\globalPlugins\visionAssistant\__init__.py:68
+#: addon\globalPlugins\visionAssistant\__init__.py:71
+#: addon\globalPlugins\visionAssistant\__init__.py:72
 msgid "(Latest)"
 msgstr "(Mới nhất)"
 
 #. --- 2. Current Standard (Free & Fast) ---
 #. Translators: AI Model info. [Free] = Generous usage limits. (Preview) = Experimental or early-access version.
-#: addon\globalPlugins\visionAssistant\__init__.py:72
-#: addon\globalPlugins\visionAssistant\__init__.py:73
-#: addon\globalPlugins\visionAssistant\__init__.py:74
+#: addon\globalPlugins\visionAssistant\__init__.py:76
+#: addon\globalPlugins\visionAssistant\__init__.py:77
+#: addon\globalPlugins\visionAssistant\__init__.py:78
 msgid "[Free]"
 msgstr "[Miễn phí]"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:72
-#: addon\globalPlugins\visionAssistant\__init__.py:78
+#: addon\globalPlugins\visionAssistant\__init__.py:76
+#: addon\globalPlugins\visionAssistant\__init__.py:82
 msgid "(Preview)"
 msgstr "(Bản xem trước)"
 
 #. --- 3. High Intelligence (Paid/Pro/Preview) ---
 #. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview) = Experimental version.
-#: addon\globalPlugins\visionAssistant\__init__.py:78
-#: addon\globalPlugins\visionAssistant\__init__.py:79
+#: addon\globalPlugins\visionAssistant\__init__.py:82
+#: addon\globalPlugins\visionAssistant\__init__.py:83
 msgid "[Pro]"
 msgstr "[Pro]"
 
 #. Translators: Adjective describing a bright AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:84
-#: addon\globalPlugins\visionAssistant\__init__.py:102
+#: addon\globalPlugins\visionAssistant\__init__.py:88
+#: addon\globalPlugins\visionAssistant\__init__.py:106
 msgid "Bright"
 msgstr "Sáng sủa"
 
 #. Translators: Adjective describing an upbeat AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:86
-#: addon\globalPlugins\visionAssistant\__init__.py:120
+#: addon\globalPlugins\visionAssistant\__init__.py:90
+#: addon\globalPlugins\visionAssistant\__init__.py:124
 msgid "Upbeat"
 msgstr "Vui vẻ"
 
 #. Translators: Adjective describing an informative AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:88
-#: addon\globalPlugins\visionAssistant\__init__.py:118
+#: addon\globalPlugins\visionAssistant\__init__.py:92
+#: addon\globalPlugins\visionAssistant\__init__.py:122
 msgid "Informative"
 msgstr "Nhiều thông tin"
 
 #. Translators: Adjective describing a firm AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:90
-#: addon\globalPlugins\visionAssistant\__init__.py:96
-#: addon\globalPlugins\visionAssistant\__init__.py:124
+#: addon\globalPlugins\visionAssistant\__init__.py:94
+#: addon\globalPlugins\visionAssistant\__init__.py:100
+#: addon\globalPlugins\visionAssistant\__init__.py:128
 msgid "Firm"
 msgstr "Quả quyết"
 
 #. Translators: Adjective describing an excitable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:92
+#: addon\globalPlugins\visionAssistant\__init__.py:96
 msgid "Excitable"
 msgstr "Sôi nổi"
 
 #. Translators: Adjective describing a youthful AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:94
+#: addon\globalPlugins\visionAssistant\__init__.py:98
 msgid "Youthful"
 msgstr "Trẻ trung"
 
 #. Translators: Adjective describing a breezy AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:98
+#: addon\globalPlugins\visionAssistant\__init__.py:102
 msgid "Breezy"
 msgstr "Thoải mái"
 
 #. Translators: Adjective describing an easy-going AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:100
-#: addon\globalPlugins\visionAssistant\__init__.py:108
+#: addon\globalPlugins\visionAssistant\__init__.py:104
+#: addon\globalPlugins\visionAssistant\__init__.py:112
 msgid "Easy-going"
 msgstr "Dễ tính"
 
 #. Translators: Adjective describing a breathy AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:104
+#: addon\globalPlugins\visionAssistant\__init__.py:108
 msgid "Breathy"
 msgstr "Nhẹ nhàng"
 
 #. Translators: Adjective describing a clear AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:106
-#: addon\globalPlugins\visionAssistant\__init__.py:114
-#: addon\globalPlugins\visionAssistant\__init__.py:164
+#: addon\globalPlugins\visionAssistant\__init__.py:110
+#: addon\globalPlugins\visionAssistant\__init__.py:118
+#: addon\globalPlugins\visionAssistant\__init__.py:168
 msgid "Clear"
 msgstr "Rõ ràng"
 
 #. Translators: Adjective describing a smooth AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:110
-#: addon\globalPlugins\visionAssistant\__init__.py:112
+#: addon\globalPlugins\visionAssistant\__init__.py:114
+#: addon\globalPlugins\visionAssistant\__init__.py:116
 msgid "Smooth"
 msgstr "Mượt mà"
 
 #. Translators: Adjective describing a gravelly AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:116
+#: addon\globalPlugins\visionAssistant\__init__.py:120
 msgid "Gravelly"
 msgstr "Khàn"
 
 #. Translators: Adjective describing a soft AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:122
+#: addon\globalPlugins\visionAssistant\__init__.py:126
 msgid "Soft"
 msgstr "Mềm mại"
 
 #. Translators: Adjective describing an even AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:126
+#: addon\globalPlugins\visionAssistant\__init__.py:130
 msgid "Even"
 msgstr "Đều đặn"
 
 #. Translators: Adjective describing a mature AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:128
+#: addon\globalPlugins\visionAssistant\__init__.py:132
 msgid "Mature"
 msgstr "Trưởng thành"
 
 #. Translators: Adjective describing a forward AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:130
+#: addon\globalPlugins\visionAssistant\__init__.py:134
 msgid "Forward"
 msgstr "Thẳng thắn"
 
 #. Translators: Adjective describing a friendly AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:132
+#: addon\globalPlugins\visionAssistant\__init__.py:136
 msgid "Friendly"
 msgstr "Thân thiện"
 
 #. Translators: Adjective describing a casual AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:134
+#: addon\globalPlugins\visionAssistant\__init__.py:138
 msgid "Casual"
 msgstr "Bình thường"
 
 #. Translators: Adjective describing a gentle AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:136
-#: addon\globalPlugins\visionAssistant\__init__.py:162
+#: addon\globalPlugins\visionAssistant\__init__.py:140
+#: addon\globalPlugins\visionAssistant\__init__.py:166
 msgid "Gentle"
 msgstr "Dịu dàng"
 
 #. Translators: Adjective describing a lively AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:138
+#: addon\globalPlugins\visionAssistant\__init__.py:142
 msgid "Lively"
 msgstr "Sống động"
 
 #. Translators: Adjective describing a knowledgeable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:140
+#: addon\globalPlugins\visionAssistant\__init__.py:144
 msgid "Knowledgeable"
 msgstr "Uyên bác"
 
 #. Translators: Adjective describing a warm AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:142
+#: addon\globalPlugins\visionAssistant\__init__.py:146
 msgid "Warm"
 msgstr "Ấm áp"
 
 #. Translators: Adjective describing a neutral AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:146
+#: addon\globalPlugins\visionAssistant\__init__.py:150
 msgid "Neutral"
 msgstr "Trung tính"
 
 #. Translators: Adjective describing a quirky AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:148
+#: addon\globalPlugins\visionAssistant\__init__.py:152
 msgid "Quirky"
 msgstr "Độc đáo"
 
 #. Translators: Adjective describing a professional AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:150
+#: addon\globalPlugins\visionAssistant\__init__.py:154
 msgid "Professional"
 msgstr "Chuyên nghiệp"
 
 #. Translators: Adjective describing a cheerful AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:152
+#: addon\globalPlugins\visionAssistant\__init__.py:156
 msgid "Cheerful"
 msgstr "Tươi vui"
 
 #. Translators: Adjective describing a confident AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:154
+#: addon\globalPlugins\visionAssistant\__init__.py:158
 msgid "Confident"
 msgstr "Tự tự tin"
 
 #. Translators: Adjective describing a British AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:156
+#: addon\globalPlugins\visionAssistant\__init__.py:160
 msgid "British"
 msgstr "Anh (Anh)"
 
 #. Translators: Adjective describing a pleasant AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:158
+#: addon\globalPlugins\visionAssistant\__init__.py:162
 msgid "Pleasant"
 msgstr "Dễ chịu"
 
 #. Translators: Adjective describing a deep AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:160
+#: addon\globalPlugins\visionAssistant\__init__.py:164
 msgid "Deep"
 msgstr "Trầm"
 
 #. Translators: Adjective describing an expressive AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:166
+#: addon\globalPlugins\visionAssistant\__init__.py:170
 msgid "Expressive"
 msgstr "Diễn cảm"
 
 #. Translators: Adjective describing a reliable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:168
+#: addon\globalPlugins\visionAssistant\__init__.py:172
 msgid "Reliable"
 msgstr "Đáng tin cậy"
 
 #. Translators: Adjective describing an energetic AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:170
+#: addon\globalPlugins\visionAssistant\__init__.py:174
 msgid "Energetic"
 msgstr "Năng động"
 
 #. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\__init__.py:191
+#: addon\globalPlugins\visionAssistant\__init__.py:195
 msgid "Chrome (Fast)"
 msgstr "Chrome (Nhanh)"
 
 #. Translators: OCR Engine option (Slower but better formatting/AI-driven)
-#: addon\globalPlugins\visionAssistant\__init__.py:193
+#: addon\globalPlugins\visionAssistant\__init__.py:197
 msgid "AI (Advanced)"
 msgstr "AI (Nâng cao)"
 
 #. Translators: Section header for text refinement prompts in Prompt Manager.
 #. Translators: main message of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:273
-#: addon\globalPlugins\visionAssistant\__init__.py:281
-#: addon\globalPlugins\visionAssistant\__init__.py:289
-#: addon\globalPlugins\visionAssistant\__init__.py:297
-#: addon\globalPlugins\visionAssistant\__init__.py:4014
+#: addon\globalPlugins\visionAssistant\__init__.py:283
+#: addon\globalPlugins\visionAssistant\__init__.py:291
+#: addon\globalPlugins\visionAssistant\__init__.py:299
+#: addon\globalPlugins\visionAssistant\__init__.py:307
+#: addon\globalPlugins\visionAssistant\__init__.py:4271
 msgid "Refine"
 msgstr "Tinh chỉnh"
 
 #. Translators: Label for the text summarization prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:275
+#: addon\globalPlugins\visionAssistant\__init__.py:285
 msgid "Summarize"
 msgstr "Tóm tắt"
 
 #. Translators: Label for the grammar correction prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:283
+#: addon\globalPlugins\visionAssistant\__init__.py:293
 msgid "Fix Grammar"
 msgstr "Sửa ngữ pháp"
 
 #. Translators: Label for the grammar correction and translation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:291
+#: addon\globalPlugins\visionAssistant\__init__.py:301
 msgid "Fix Grammar & Translate"
 msgstr "Sửa ngữ pháp & Dịch"
 
 #. Translators: Label for the text explanation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:299
+#: addon\globalPlugins\visionAssistant\__init__.py:309
 msgid "Explain"
 msgstr "Giải thích"
 
 #. Translators: Section header for translation-related prompts in Prompt Manager.
 #. Translators: Box title for translation options
-#: addon\globalPlugins\visionAssistant\__init__.py:305
-#: addon\globalPlugins\visionAssistant\__init__.py:317
-#: addon\globalPlugins\visionAssistant\__init__.py:2741
+#: addon\globalPlugins\visionAssistant\__init__.py:315
+#: addon\globalPlugins\visionAssistant\__init__.py:327
+#: addon\globalPlugins\visionAssistant\__init__.py:2949
 msgid "Translation"
 msgstr "Dịch thuật"
 
 #. Translators: Label for the smart translation prompt.
 #. Translators: Feature name used in guarded prompt warnings for smart translation.
-#: addon\globalPlugins\visionAssistant\__init__.py:307
-#: addon\globalPlugins\visionAssistant\__init__.py:310
+#: addon\globalPlugins\visionAssistant\__init__.py:317
+#: addon\globalPlugins\visionAssistant\__init__.py:320
 msgid "Smart Translation"
 msgstr "Dịch thông minh"
 
 #. Translators: Label for the quick translation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:319
+#: addon\globalPlugins\visionAssistant\__init__.py:329
 msgid "Quick Translation"
 msgstr "Dịch nhanh"
 
 #. Translators: Section header for document-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:325
-#: addon\globalPlugins\visionAssistant\__init__.py:446
+#: addon\globalPlugins\visionAssistant\__init__.py:335
+#: addon\globalPlugins\visionAssistant\__init__.py:456
 msgid "Document"
 msgstr "Tài liệu"
 
 #. Translators: Label for the initial context prompt in document chat.
-#: addon\globalPlugins\visionAssistant\__init__.py:327
+#: addon\globalPlugins\visionAssistant\__init__.py:337
 msgid "Document Chat Context"
 msgstr "Ngữ cảnh trò chuyện tài liệu"
 
 #. Translators: Section header for image analysis prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:340
-#: addon\globalPlugins\visionAssistant\__init__.py:354
+#. Translators: Section header for AI Operator prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\__init__.py:350
+#: addon\globalPlugins\visionAssistant\__init__.py:364
+#: addon\globalPlugins\visionAssistant\__init__.py:490
 msgid "Vision"
 msgstr "Thị giác"
 
 #. Translators: Label for the prompt used to analyze the current navigator object.
-#: addon\globalPlugins\visionAssistant\__init__.py:342
+#: addon\globalPlugins\visionAssistant\__init__.py:352
 msgid "Navigator Object Analysis"
 msgstr "Phân tích đối tượng Navigator"
 
 #. Translators: Label for the prompt used to analyze the entire screen.
-#: addon\globalPlugins\visionAssistant\__init__.py:356
+#: addon\globalPlugins\visionAssistant\__init__.py:366
 msgid "Full Screen Analysis"
 msgstr "Phân tích toàn màn hình"
 
 #. Translators: Section header for video analysis prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:382
+#: addon\globalPlugins\visionAssistant\__init__.py:392
 msgid "Video"
 msgstr "Video"
 
 #. Translators: Label for the video content analysis prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:384
+#: addon\globalPlugins\visionAssistant\__init__.py:394
 msgid "Video Analysis"
 msgstr "Phân tích Video"
 
 #. Translators: Section header for audio-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:394
-#: addon\globalPlugins\visionAssistant\__init__.py:402
+#: addon\globalPlugins\visionAssistant\__init__.py:404
+#: addon\globalPlugins\visionAssistant\__init__.py:412
 msgid "Audio"
 msgstr "Âm thanh"
 
 #. Translators: Label for the audio file transcription prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:396
+#: addon\globalPlugins\visionAssistant\__init__.py:406
 msgid "Audio Transcription"
 msgstr "Chuyển biên âm thanh"
 
 #. Translators: Label for the smart voice dictation prompt.
 #. Translators: Feature name used in guarded prompt warnings for smart dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:404
-#: addon\globalPlugins\visionAssistant\__init__.py:407
+#: addon\globalPlugins\visionAssistant\__init__.py:414
+#: addon\globalPlugins\visionAssistant\__init__.py:417
 msgid "Smart Dictation"
 msgstr "Đọc chính tả thông minh"
 
 #. Translators: Section header for OCR-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:417
-#: addon\globalPlugins\visionAssistant\__init__.py:429
+#: addon\globalPlugins\visionAssistant\__init__.py:427
+#: addon\globalPlugins\visionAssistant\__init__.py:439
 msgid "OCR"
 msgstr "OCR"
 
 #. Translators: Label for the OCR prompt used for image text extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:419
+#: addon\globalPlugins\visionAssistant\__init__.py:429
 msgid "OCR Image Extraction"
 msgstr "Trích xuất văn bản từ hình ảnh (OCR)"
 
 #. Translators: Label for the OCR prompt used for document text extraction.
 #. Translators: Feature name used in guarded prompt warnings for OCR document extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:431
-#: addon\globalPlugins\visionAssistant\__init__.py:434
+#: addon\globalPlugins\visionAssistant\__init__.py:441
+#: addon\globalPlugins\visionAssistant\__init__.py:444
 msgid "OCR Document Extraction"
 msgstr "Trích xuất văn bản từ tài liệu (OCR)"
 
 #. Translators: Label for the combined OCR and translation prompt for documents.
-#: addon\globalPlugins\visionAssistant\__init__.py:448
+#: addon\globalPlugins\visionAssistant\__init__.py:458
 msgid "Document OCR + Translate"
 msgstr "OCR Tài liệu + Dịch"
 
 #. Translators: Section header for CAPTCHA-related prompts in Prompt Manager.
 #. --- CAPTCHA Group ---
-#: addon\globalPlugins\visionAssistant\__init__.py:458
-#: addon\globalPlugins\visionAssistant\__init__.py:2337
+#: addon\globalPlugins\visionAssistant\__init__.py:468
+#: addon\globalPlugins\visionAssistant\__init__.py:2461
 msgid "CAPTCHA"
 msgstr "CAPTCHA"
 
 #. Translators: Label for the CAPTCHA solving prompt.
 #. Translators: Feature name used in guarded prompt warnings for CAPTCHA solver.
-#: addon\globalPlugins\visionAssistant\__init__.py:460
-#: addon\globalPlugins\visionAssistant\__init__.py:463
+#: addon\globalPlugins\visionAssistant\__init__.py:470
+#: addon\globalPlugins\visionAssistant\__init__.py:473
 msgid "CAPTCHA Solver"
 msgstr "Giải CAPTCHA"
 
+#. Translators: Label for the AI Operator system prompt.
+#: addon\globalPlugins\visionAssistant\__init__.py:492
+msgid "AI Operator Instruction"
+msgstr "Chỉ dẫn cho AI Operator"
+
+#. Translators: Feature name used in guarded prompt warnings for AI Operator.
+#: addon\globalPlugins\visionAssistant\__init__.py:495
+#: addon\globalPlugins\visionAssistant\__init__.py:5372
+msgid "AI Operator"
+msgstr "AI Operator"
+
 #. Translators: Description and input type for the [selection] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:481
+#: addon\globalPlugins\visionAssistant\__init__.py:511
 msgid "Currently selected text"
 msgstr "Văn bản đang được chọn"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:481
-#: addon\globalPlugins\visionAssistant\__init__.py:483
+#: addon\globalPlugins\visionAssistant\__init__.py:511
+#: addon\globalPlugins\visionAssistant\__init__.py:513
 msgid "Text"
 msgstr "Văn bản"
 
 #. Translators: Description for the [clipboard] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:483
+#: addon\globalPlugins\visionAssistant\__init__.py:513
 msgid "Clipboard content"
 msgstr "Nội dung clipboard"
 
 #. Translators: Description and input type for the [screen_obj] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:485
+#: addon\globalPlugins\visionAssistant\__init__.py:515
 msgid "Screenshot of the navigator object"
 msgstr "Ảnh chụp màn hình của đối tượng navigator"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:485
-#: addon\globalPlugins\visionAssistant\__init__.py:487
+#: addon\globalPlugins\visionAssistant\__init__.py:515
+#: addon\globalPlugins\visionAssistant\__init__.py:517
 msgid "Image"
 msgstr "Hình ảnh"
 
 #. Translators: Description for the [screen_full] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:487
+#: addon\globalPlugins\visionAssistant\__init__.py:517
 msgid "Screenshot of the entire screen"
 msgstr "Ảnh chụp toàn bộ màn hình"
 
 #. Translators: Description and input type for the [file_ocr] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:489
+#: addon\globalPlugins\visionAssistant\__init__.py:519
 msgid "Select image/PDF/TIFF for text extraction"
 msgstr "Chọn hình ảnh/PDF/TIFF để trích xuất văn bản"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:489
+#: addon\globalPlugins\visionAssistant\__init__.py:519
 msgid "Image, PDF, TIFF"
 msgstr "Hình ảnh, PDF, TIFF"
 
 #. Translators: Description and input type for the [file_read] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:491
+#: addon\globalPlugins\visionAssistant\__init__.py:521
 msgid "Select document for reading"
 msgstr "Chọn tài liệu để đọc"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:491
+#: addon\globalPlugins\visionAssistant\__init__.py:521
 msgid "TXT, Code, PDF"
 msgstr "TXT, Code, PDF"
 
 #. Translators: Description and input type for the [file_audio] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:493
+#: addon\globalPlugins\visionAssistant\__init__.py:523
 msgid "Select audio file for analysis"
 msgstr "Chọn tệp âm thanh để phân tích"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:493
+#: addon\globalPlugins\visionAssistant\__init__.py:523
 msgid "MP3, WAV, OGG"
 msgstr "MP3, WAV, OGG"
 
 #. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\__init__.py:781
+#: addon\globalPlugins\visionAssistant\__init__.py:811
 msgid "Custom: "
 msgstr "Tùy chỉnh: "
 
 #. Translators: Title of the error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:865
+#: addon\globalPlugins\visionAssistant\__init__.py:908
 #, python-brace-format
 msgid "{name} Error"
 msgstr "Lỗi {name}"
 
 #. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\__init__.py:1138
+#: addon\globalPlugins\visionAssistant\__init__.py:1206
 msgid "Error 400: Bad Request (Check API Key)"
 msgstr "Lỗi 400: Yêu cầu không hợp lệ (Kiểm tra Khóa API)"
 
 #. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\__init__.py:1140
+#: addon\globalPlugins\visionAssistant\__init__.py:1208
 msgid "Error 403: Forbidden (Check Region)"
 msgstr "Lỗi 403: Bị cấm (Kiểm tra Khu vực)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1183
-#: addon\globalPlugins\visionAssistant\__init__.py:1346
+#: addon\globalPlugins\visionAssistant\__init__.py:1251
+#: addon\globalPlugins\visionAssistant\__init__.py:1461
 msgid "Error 429: Quota Exceeded (Try later)"
 msgstr "Lỗi 429: Vượt quá hạn ngạch (Thử lại sau)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1186
-#: addon\globalPlugins\visionAssistant\__init__.py:1349
+#: addon\globalPlugins\visionAssistant\__init__.py:1254
+#: addon\globalPlugins\visionAssistant\__init__.py:1464
 #, python-brace-format
 msgid "Server Error {code}: {reason}"
 msgstr "Lỗi máy chủ {code}: {reason}"
 
+#. Translators: Error prefix shown when the AI response is blocked by safety filters.
+#: addon\globalPlugins\visionAssistant\__init__.py:1319
+msgid "Blocked by AI Safety Filters: "
+msgstr "Bị chặn bởi bộ lọc an toàn AI: "
+
+#. Translators: Generic error message when Gemini returns an empty response.
+#: addon\globalPlugins\visionAssistant\__init__.py:1321
+msgid ""
+"AI failed to provide a response. This might be due to safety filters or a "
+"temporary server issue."
+msgstr ""
+"AI không thể đưa ra phản hồi. Điều này có thể do các bộ lọc an toàn hoặc sự "
+"\"\n"
+"\"cố máy chủ tạm thời."
+
+#. Translators: Error shown when the AI response is blocked during generation.
+#: addon\globalPlugins\visionAssistant\__init__.py:1331
+msgid "The response was blocked mid-generation by safety filters."
+msgstr "Phản hồi đã bị chặn giữa chừng bởi các bộ lọc an toàn."
+
+#. Translators: Error shown when the response structure is unexpected or empty.
+#: addon\globalPlugins\visionAssistant\__init__.py:1333
+msgid "AI returned an empty response structure."
+msgstr "AI đã trả về một cấu trúc phản hồi trống."
+
 #. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:1231
-#: addon\globalPlugins\visionAssistant\__init__.py:1614
-#: addon\globalPlugins\visionAssistant\__init__.py:1704
-#: addon\globalPlugins\visionAssistant\__init__.py:1747
-#: addon\globalPlugins\visionAssistant\__init__.py:3124
-#: addon\globalPlugins\visionAssistant\__init__.py:3241
+#: addon\globalPlugins\visionAssistant\__init__.py:1342
+#: addon\globalPlugins\visionAssistant\__init__.py:1742
+#: addon\globalPlugins\visionAssistant\__init__.py:1804
+#: addon\globalPlugins\visionAssistant\__init__.py:1849
+#: addon\globalPlugins\visionAssistant\__init__.py:3337
+#: addon\globalPlugins\visionAssistant\__init__.py:3455
 msgid "No API Keys configured."
 msgstr "Chưa cấu hình Khóa API nào."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1246
+#: addon\globalPlugins\visionAssistant\__init__.py:1359
 msgid "All API Keys failed (Quota/Server)."
 msgstr "Tất cả Khóa API đều thất bại (Hạn ngạch/Máy chủ)."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1250
+#: addon\globalPlugins\visionAssistant\__init__.py:1365
 msgid "Unknown error occurred."
 msgstr "Đã xảy ra lỗi không xác định."
 
 #. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\__init__.py:1285
+#: addon\globalPlugins\visionAssistant\__init__.py:1400
 msgid "No API Keys."
 msgstr "Không có Khóa API."
 
 #. Translators: Error message for upload failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1326
-#: addon\globalPlugins\visionAssistant\__init__.py:2828
+#: addon\globalPlugins\visionAssistant\__init__.py:1441
+#: addon\globalPlugins\visionAssistant\__init__.py:3037
 msgid "Upload failed."
 msgstr "Tải lên thất bại."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1356
+#: addon\globalPlugins\visionAssistant\__init__.py:1471
 msgid "All keys failed."
 msgstr "Tất cả các khóa đều thất bại."
 
 #. Translators: Error message when speech-to-text fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1734
+#: addon\globalPlugins\visionAssistant\__init__.py:1836
 msgid "Transcription Failed"
 msgstr "Chuyển biên thất bại"
 
 #. Translators: Error message when TTS is not supported by the provider
-#: addon\globalPlugins\visionAssistant\__init__.py:1740
+#: addon\globalPlugins\visionAssistant\__init__.py:1842
 msgid "TTS is not supported by this provider."
 msgstr "TTS không được hỗ trợ bởi nhà cung cấp này."
 
 #. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1789
+#: addon\globalPlugins\visionAssistant\__init__.py:1891
 msgid "Update Available"
 msgstr "Có bản cập nhật mới"
 
 #. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\__init__.py:1796
+#: addon\globalPlugins\visionAssistant\__init__.py:1898
 #, python-brace-format
 msgid "A new version ({version}) of {name} is available."
 msgstr "Đã có phiên bản mới ({version}) của {name}."
 
 #. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\__init__.py:1801
+#: addon\globalPlugins\visionAssistant\__init__.py:1903
 msgid "Changes:"
 msgstr "Những thay đổi:"
 
 #. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\__init__.py:1808
+#: addon\globalPlugins\visionAssistant\__init__.py:1910
 msgid "Download and Install?"
 msgstr "Tải xuống và Cài đặt?"
 
 #. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\__init__.py:1813
+#: addon\globalPlugins\visionAssistant\__init__.py:1915
 msgid "&Yes"
 msgstr "&Có"
 
 #. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\__init__.py:1815
+#: addon\globalPlugins\visionAssistant\__init__.py:1917
 msgid "&No"
 msgstr "&Không"
 
 #. Translators: Error message when an update is found but the addon file is missing from GitHub.
-#: addon\globalPlugins\visionAssistant\__init__.py:1857
+#: addon\globalPlugins\visionAssistant\__init__.py:1959
 msgid "Update found but no .nvda-addon file in release."
 msgstr ""
 "Đã tìm thấy bản cập nhật nhưng không có tệp .nvda-addon trong bản phát hành."
 
 #. Translators: Status message informing the user they are already on the latest version.
-#: addon\globalPlugins\visionAssistant\__init__.py:1861
+#: addon\globalPlugins\visionAssistant\__init__.py:1963
 msgid "You have the latest version."
 msgstr "Bạn đang sử dụng phiên bản mới nhất."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1865
+#: addon\globalPlugins\visionAssistant\__init__.py:1967
 #, python-brace-format
 msgid "Update check failed: {error}"
 msgstr "Kiểm tra cập nhật thất bại: {error}"
 
 #. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\__init__.py:1888
+#: addon\globalPlugins\visionAssistant\__init__.py:1990
 msgid "Downloading update..."
 msgstr "Đang tải xuống bản cập nhật..."
 
 #. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1897
+#: addon\globalPlugins\visionAssistant\__init__.py:1999
 #, python-brace-format
 msgid "Download failed: {error}"
 msgstr "Tải xuống thất bại: {error}"
 
 #. Translators: Label for the AI response text area in a chat dialog
 #. Translators: Label for AI Response Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:1917
-#: addon\globalPlugins\visionAssistant\__init__.py:2306
+#: addon\globalPlugins\visionAssistant\__init__.py:2019
+#: addon\globalPlugins\visionAssistant\__init__.py:2430
 msgid "AI Response:"
 msgstr "Phản hồi của AI:"
 
 #. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1927
-#: addon\globalPlugins\visionAssistant\__init__.py:2015
-#: addon\globalPlugins\visionAssistant\__init__.py:2032
+#: addon\globalPlugins\visionAssistant\__init__.py:2029
+#: addon\globalPlugins\visionAssistant\__init__.py:2123
+#: addon\globalPlugins\visionAssistant\__init__.py:2140
 #, python-brace-format
 msgid "AI: {text}\n"
 msgstr "AI: {text}\n"
 
 #. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1938
+#: addon\globalPlugins\visionAssistant\__init__.py:2040
 msgid "Ask:"
 msgstr "Hỏi:"
 
 #. Translators: Button to send message in a chat dialog
 #. Translators: Button to send message
-#: addon\globalPlugins\visionAssistant\__init__.py:1948
-#: addon\globalPlugins\visionAssistant\__init__.py:2808
+#: addon\globalPlugins\visionAssistant\__init__.py:2050
+#: addon\globalPlugins\visionAssistant\__init__.py:3016
 msgid "Send"
 msgstr "Gửi"
 
 #. Translators: Button to view the content in a formatted HTML window
 #. Translators: Button to view formatted content
-#: addon\globalPlugins\visionAssistant\__init__.py:1950
-#: addon\globalPlugins\visionAssistant\__init__.py:2956
+#: addon\globalPlugins\visionAssistant\__init__.py:2052
+#: addon\globalPlugins\visionAssistant\__init__.py:3169
 msgid "View Formatted"
 msgstr "Xem định dạng"
 
 #. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:1953
+#: addon\globalPlugins\visionAssistant\__init__.py:2055
 msgid "Save Content"
 msgstr "Lưu nội dung"
 
 #. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1956
+#: addon\globalPlugins\visionAssistant\__init__.py:2058
 msgid "Save Chat"
 msgstr "Lưu trò chuyện"
 
 #. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1991
-#: addon\globalPlugins\visionAssistant\__init__.py:2030
+#: addon\globalPlugins\visionAssistant\__init__.py:2093
+#: addon\globalPlugins\visionAssistant\__init__.py:2138
 #, python-brace-format
 msgid ""
 "\n"
@@ -924,842 +962,913 @@ msgstr ""
 
 #. Translators: Message shown while processing in a chat dialog
 #. Translators: Message showing AI is thinking
-#: addon\globalPlugins\visionAssistant\__init__.py:1995
-#: addon\globalPlugins\visionAssistant\__init__.py:2853
+#: addon\globalPlugins\visionAssistant\__init__.py:2097
+#: addon\globalPlugins\visionAssistant\__init__.py:3064
 msgid "Thinking..."
 msgstr "Đang suy nghĩ..."
 
+#. Translators: Initial status when the add-on is doing nothing
+#. Translators: Status message when the add-on is doing nothing
+#. Translators: Initial status when the add-on is doing nothing
+#: addon\globalPlugins\visionAssistant\__init__.py:2108
+#: addon\globalPlugins\visionAssistant\__init__.py:3073
+#: addon\globalPlugins\visionAssistant\__init__.py:3089
+#: addon\globalPlugins\visionAssistant\__init__.py:3103
+#: addon\globalPlugins\visionAssistant\__init__.py:3409
+#: addon\globalPlugins\visionAssistant\__init__.py:3443
+#: addon\globalPlugins\visionAssistant\__init__.py:3510
+#: addon\globalPlugins\visionAssistant\__init__.py:3528
+#: addon\globalPlugins\visionAssistant\__init__.py:3542
+#: addon\globalPlugins\visionAssistant\__init__.py:3548
+#: addon\globalPlugins\visionAssistant\__init__.py:3623
+#: addon\globalPlugins\visionAssistant\__init__.py:3826
+#: addon\globalPlugins\visionAssistant\__init__.py:4056
+#: addon\globalPlugins\visionAssistant\__init__.py:4061
+#: addon\globalPlugins\visionAssistant\__init__.py:4065
+#: addon\globalPlugins\visionAssistant\__init__.py:4071
+#: addon\globalPlugins\visionAssistant\__init__.py:4078
+#: addon\globalPlugins\visionAssistant\__init__.py:4130
+#: addon\globalPlugins\visionAssistant\__init__.py:4141
+#: addon\globalPlugins\visionAssistant\__init__.py:4146
+#: addon\globalPlugins\visionAssistant\__init__.py:4452
+#: addon\globalPlugins\visionAssistant\__init__.py:4456
+#: addon\globalPlugins\visionAssistant\__init__.py:4610
+#: addon\globalPlugins\visionAssistant\__init__.py:4638
+#: addon\globalPlugins\visionAssistant\__init__.py:4656
+#: addon\globalPlugins\visionAssistant\__init__.py:4666
+#: addon\globalPlugins\visionAssistant\__init__.py:4785
+#: addon\globalPlugins\visionAssistant\__init__.py:4788
+#: addon\globalPlugins\visionAssistant\__init__.py:4792
+#: addon\globalPlugins\visionAssistant\__init__.py:4814
+#: addon\globalPlugins\visionAssistant\__init__.py:4818
+#: addon\globalPlugins\visionAssistant\__init__.py:4924
+#: addon\globalPlugins\visionAssistant\__init__.py:4939
+#: addon\globalPlugins\visionAssistant\__init__.py:4943
+#: addon\globalPlugins\visionAssistant\__init__.py:4948
+#: addon\globalPlugins\visionAssistant\__init__.py:4987
+#: addon\globalPlugins\visionAssistant\__init__.py:4998
+#: addon\globalPlugins\visionAssistant\__init__.py:5024
+#: addon\globalPlugins\visionAssistant\__init__.py:5035
+#: addon\globalPlugins\visionAssistant\__init__.py:5073
+#: addon\globalPlugins\visionAssistant\__init__.py:5079
+#: addon\globalPlugins\visionAssistant\__init__.py:5117
+#: addon\globalPlugins\visionAssistant\__init__.py:5120
+#: addon\globalPlugins\visionAssistant\__init__.py:5128
+#: addon\globalPlugins\visionAssistant\__init__.py:5439
+msgid "Idle"
+msgstr "Nhàn rỗi"
+
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:2052
+#: addon\globalPlugins\visionAssistant\__init__.py:2160
 msgid "Formatted Conversation"
 msgstr "Cuộc trò chuyện đã định dạng"
 
 #. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:2055
+#: addon\globalPlugins\visionAssistant\__init__.py:2163
 #, python-brace-format
 msgid "Error displaying content: {error}"
 msgstr "Lỗi khi hiển thị nội dung: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:2060
+#: addon\globalPlugins\visionAssistant\__init__.py:2168
 msgid "Save Chat Log"
 msgstr "Lưu nhật ký trò chuyện"
 
 #. Translators: Message shown on successful save of a file.
 #. Translators: Message on successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:2065
-#: addon\globalPlugins\visionAssistant\__init__.py:2079
+#: addon\globalPlugins\visionAssistant\__init__.py:2173
+#: addon\globalPlugins\visionAssistant\__init__.py:2187
 msgid "Saved."
 msgstr "Đã lưu."
 
 #. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:2068
-#: addon\globalPlugins\visionAssistant\__init__.py:2082
+#: addon\globalPlugins\visionAssistant\__init__.py:2176
+#: addon\globalPlugins\visionAssistant\__init__.py:2190
 #, python-brace-format
 msgid "Save failed: {error}"
 msgstr "Lưu thất bại: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:2073
+#: addon\globalPlugins\visionAssistant\__init__.py:2181
 msgid "Save Result"
 msgstr "Lưu kết quả"
 
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\__init__.py:2092
+#: addon\globalPlugins\visionAssistant\__init__.py:2201
 msgid "Connection"
 msgstr "Kết nối"
 
 #. Translators: Name of the Google Gemini AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2099
+#: addon\globalPlugins\visionAssistant\__init__.py:2208
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
 #. Translators: Name of the OpenAI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2101
+#: addon\globalPlugins\visionAssistant\__init__.py:2210
 msgid "OpenAI"
 msgstr "OpenAI"
 
 #. Translators: Name of the Mistral AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2103
+#: addon\globalPlugins\visionAssistant\__init__.py:2212
 msgid "Mistral AI"
 msgstr "Mistral AI"
 
 #. Translators: Name of the Groq AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2105
+#: addon\globalPlugins\visionAssistant\__init__.py:2214
 msgid "Groq"
 msgstr "Groq"
 
 #. Translators: Option for a user-defined custom AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2107
+#: addon\globalPlugins\visionAssistant\__init__.py:2216
 msgid "Custom"
 msgstr "Tùy chỉnh"
 
 #. Translators: Label for AI Provider selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2110
+#: addon\globalPlugins\visionAssistant\__init__.py:2219
 msgid "Provider:"
 msgstr "Nhà cung cấp:"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\__init__.py:2118
+#: addon\globalPlugins\visionAssistant\__init__.py:2227
 msgid "API Key (Separate multiple keys with comma or newline):"
 msgstr "Khóa API (Phân tách nhiều khóa bằng dấu phẩy hoặc xuống dòng):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\__init__.py:2129
+#: addon\globalPlugins\visionAssistant\__init__.py:2238
 msgid "Show API Key"
 msgstr "Hiển thị Khóa API"
 
 #. Custom Fields Box
 #. Translators: Static box title for custom AI provider settings
-#: addon\globalPlugins\visionAssistant\__init__.py:2135
+#: addon\globalPlugins\visionAssistant\__init__.py:2244
 msgid "Custom Provider Settings"
 msgstr "Cài đặt nhà cung cấp tùy chỉnh"
 
 #. Translators: Label for Custom API URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:2139
+#: addon\globalPlugins\visionAssistant\__init__.py:2248
 msgid "API URL:"
 msgstr "URL API:"
 
-#. Translators: Label for Custom Model Name input
-#: addon\globalPlugins\visionAssistant\__init__.py:2144
-msgid "Model Name:"
-msgstr "Tên mô hình:"
-
 #. Translators: Label for Custom API Type selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2149
+#: addon\globalPlugins\visionAssistant\__init__.py:2252
 msgid "API Type:"
 msgstr "Loại API:"
 
 #. Translators: AI API compatibility types
-#: addon\globalPlugins\visionAssistant\__init__.py:2151
+#: addon\globalPlugins\visionAssistant\__init__.py:2254
 msgid "OpenAI Compatible"
 msgstr "Tương thích OpenAI"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2151
+#: addon\globalPlugins\visionAssistant\__init__.py:2254
 msgid "Gemini Compatible"
 msgstr "Tương thích Gemini"
 
+#. Translators: Label for Custom Model Name input
+#: addon\globalPlugins\visionAssistant\__init__.py:2259
+msgid "Model Name:"
+msgstr "Tên mô hình:"
+
 #. Translators: Checkbox to indicate if custom provider supports file upload
-#: addon\globalPlugins\visionAssistant\__init__.py:2156
+#: addon\globalPlugins\visionAssistant\__init__.py:2264
 msgid "Supports File Upload"
 msgstr "Hỗ trợ tải lên tệp"
 
 #. Advanced Endpoints Section
 #. Translators: Checkbox to toggle advanced endpoint URLs
-#: addon\globalPlugins\visionAssistant\__init__.py:2162
+#: addon\globalPlugins\visionAssistant\__init__.py:2270
 msgid "Advanced Endpoint Configuration"
 msgstr "Cấu hình Endpoint nâng cao"
 
 #. Translators: Label for Custom Models List URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2171
+#: addon\globalPlugins\visionAssistant\__init__.py:2279
 msgid "Models List URL:"
 msgstr "URL danh sách mô hình:"
 
 #. Translators: Label for Custom OCR URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2176
+#: addon\globalPlugins\visionAssistant\__init__.py:2284
 msgid "OCR Endpoint URL:"
 msgstr "URL Endpoint OCR:"
 
 #. Translators: Label for Custom OCR Model
-#: addon\globalPlugins\visionAssistant\__init__.py:2181
+#: addon\globalPlugins\visionAssistant\__init__.py:2289
 msgid "Custom OCR Model (Optional):"
 msgstr "Mô hình OCR tùy chỉnh (Tùy chọn):"
 
 #. Translators: Label for Custom STT URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2186
+#: addon\globalPlugins\visionAssistant\__init__.py:2294
 msgid "Speech-to-Text (STT) URL:"
 msgstr "URL Chuyển giọng nói thành văn bản (STT):"
 
 #. Translators: Label for Custom STT Model
-#: addon\globalPlugins\visionAssistant\__init__.py:2191
+#: addon\globalPlugins\visionAssistant\__init__.py:2299
 msgid "Custom STT Model (Optional):"
 msgstr "Mô hình STT tùy chỉnh (Tùy chọn):"
 
 #. Translators: Label for Custom TTS URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2196
+#: addon\globalPlugins\visionAssistant\__init__.py:2304
 msgid "Text-to-Speech (TTS) URL:"
 msgstr "URL Chuyển văn bản thành giọng nói (TTS):"
 
 #. Translators: Label for Custom TTS Model
-#: addon\globalPlugins\visionAssistant\__init__.py:2201
+#: addon\globalPlugins\visionAssistant\__init__.py:2309
 msgid "Custom TTS Model (Optional):"
 msgstr "Mô hình TTS tùy chỉnh (Tùy chọn):"
 
+#. Translators: Label for Custom AI Operator URL
+#: addon\globalPlugins\visionAssistant\__init__.py:2314
+msgid "AI Operator URL:"
+msgstr "URL của AI Operator:"
+
+#. Translators: Label for the manual Assistant model name entry field.
+#: addon\globalPlugins\visionAssistant\__init__.py:2319
+msgid "Custom Assistant Model (Optional):"
+msgstr "Mô hình trợ lý tùy chỉnh (Tùy chọn):"
+
 #. Translators: Label for Custom TTS Voice Name
-#: addon\globalPlugins\visionAssistant\__init__.py:2206
+#: addon\globalPlugins\visionAssistant\__init__.py:2324
 msgid "Custom TTS Voice Name (Optional):"
 msgstr "Tên giọng nói TTS tùy chỉnh (Tùy chọn):"
 
 #. Standard Fetch & Model Logic
 #. Translators: Button to fetch available models from the selected provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2217
+#: addon\globalPlugins\visionAssistant\__init__.py:2335
 msgid "Fetch Models"
 msgstr "Tải mô hình"
 
 #. Translators: Label for AI Model selection choice box
-#: addon\globalPlugins\visionAssistant\__init__.py:2222
+#. Translators: Label for the AI model selection.
+#: addon\globalPlugins\visionAssistant\__init__.py:2340
+#: addon\globalPlugins\visionAssistant\__init__.py:2580
+#: addon\globalPlugins\visionAssistant\__init__.py:2594
 msgid "AI Model:"
 msgstr "Mô hình AI:"
 
 #. Advanced Model Routing Box
 #. Translators: Checkbox to toggle advanced model routing
-#: addon\globalPlugins\visionAssistant\__init__.py:2230
+#: addon\globalPlugins\visionAssistant\__init__.py:2348
 msgid "Advanced Model Routing (Task-specific)"
 msgstr "Định tuyến mô hình nâng cao (Theo tác vụ)"
 
 #. Translators: Label for OCR model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2237
+#: addon\globalPlugins\visionAssistant\__init__.py:2355
 msgid "OCR / Vision Model:"
 msgstr "Mô hình OCR / Thị giác:"
 
 #. Translators: Label for STT model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2243
+#: addon\globalPlugins\visionAssistant\__init__.py:2361
 msgid "Speech-to-Text (STT) Model:"
 msgstr "Mô hình Chuyển giọng nói thành văn bản (STT):"
 
 #. Translators: Label for TTS model selection (Assigning to self to toggle visibility)
-#: addon\globalPlugins\visionAssistant\__init__.py:2249
+#: addon\globalPlugins\visionAssistant\__init__.py:2367
 msgid "Text-to-Speech (TTS) Model:"
 msgstr "Mô hình Chuyển văn bản thành giọng nói (TTS):"
 
+#. Translators: Label for Assistant model selection in settings
+#: addon\globalPlugins\visionAssistant\__init__.py:2373
+msgid "AI Operator Model:"
+msgstr "Mô hình AI Operator:"
+
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:2258
+#: addon\globalPlugins\visionAssistant\__init__.py:2382
 msgid "Proxy URL:"
 msgstr "URL Proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on startup
-#: addon\globalPlugins\visionAssistant\__init__.py:2262
+#: addon\globalPlugins\visionAssistant\__init__.py:2386
 msgid "Check for updates on startup"
 msgstr "Kiểm tra cập nhật khi khởi động"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\__init__.py:2265
+#: addon\globalPlugins\visionAssistant\__init__.py:2389
 msgid "Clean Markdown in Chat"
 msgstr "Làm sạch Markdown trong trò chuyện"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:2268
+#: addon\globalPlugins\visionAssistant\__init__.py:2392
 msgid "Copy AI responses to clipboard"
 msgstr "Sao chép phản hồi của AI vào clipboard"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\__init__.py:2271
+#: addon\globalPlugins\visionAssistant\__init__.py:2395
 msgid "Direct Output (No Chat Window)"
 msgstr "Đầu ra trực tiếp (Không có cửa sổ trò chuyện)"
 
 #. --- AI Behavior Group ---
 #. Translators: Title of the settings group for AI behavior
-#: addon\globalPlugins\visionAssistant\__init__.py:2277
+#: addon\globalPlugins\visionAssistant\__init__.py:2401
 msgid "AI Behavior"
 msgstr "Hành vi của AI"
 
 #. Translators: Label for AI Temperature setting
-#: addon\globalPlugins\visionAssistant\__init__.py:2282
+#: addon\globalPlugins\visionAssistant\__init__.py:2406
 msgid "Creativity (Temperature, does not affect OCR/Translation):"
 msgstr "Độ sáng tạo (Temperature, không ảnh hưởng đến OCR/Dịch thuật):"
 
 #. --- Translation Languages Group ---
 #. Translators: Title of the settings group for translation languages configuration
-#: addon\globalPlugins\visionAssistant\__init__.py:2293
+#: addon\globalPlugins\visionAssistant\__init__.py:2417
 msgid "Translation Languages"
 msgstr "Ngôn ngữ dịch"
 
 #. Translators: Label for Source Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2298
+#: addon\globalPlugins\visionAssistant\__init__.py:2422
 msgid "Source:"
 msgstr "Nguồn:"
 
 #. Translators: Label for Target Language selection
 #. Translators: Label for target language
-#: addon\globalPlugins\visionAssistant\__init__.py:2302
-#: addon\globalPlugins\visionAssistant\__init__.py:2747
+#: addon\globalPlugins\visionAssistant\__init__.py:2426
+#: addon\globalPlugins\visionAssistant\__init__.py:2955
 msgid "Target:"
 msgstr "Đích:"
 
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\__init__.py:2310
+#: addon\globalPlugins\visionAssistant\__init__.py:2434
 msgid "Smart Swap"
 msgstr "Chuyển đổi thông minh"
 
 #. --- Document Reader Settings ---
 #. Translators: Title of settings group for Document Reader features
 #. Translators: Title of the Document Reader window.
-#: addon\globalPlugins\visionAssistant\__init__.py:2316
-#: addon\globalPlugins\visionAssistant\__init__.py:2894
+#: addon\globalPlugins\visionAssistant\__init__.py:2440
+#: addon\globalPlugins\visionAssistant\__init__.py:3108
 msgid "Document Reader"
 msgstr "Trình đọc tài liệu"
 
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2321
+#: addon\globalPlugins\visionAssistant\__init__.py:2445
 msgid "OCR Engine:"
 msgstr "Công cụ OCR:"
 
 #. Translators: Label for TTS Voice selection (Assigning to self to toggle visibility)
 #. Translators: Label for TTS Voice selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2329
-#: addon\globalPlugins\visionAssistant\__init__.py:2970
+#: addon\globalPlugins\visionAssistant\__init__.py:2453
+#: addon\globalPlugins\visionAssistant\__init__.py:3183
 msgid "TTS Voice:"
 msgstr "Giọng nói TTS:"
 
 #. Translators: Label for CAPTCHA capture method selection.
-#: addon\globalPlugins\visionAssistant\__init__.py:2342
+#: addon\globalPlugins\visionAssistant\__init__.py:2466
 msgid "Capture Method:"
 msgstr "Phương pháp chụp:"
 
 #. Translators: A choice for capture method. Captures only the specific object under the cursor.
-#: addon\globalPlugins\visionAssistant\__init__.py:2344
+#: addon\globalPlugins\visionAssistant\__init__.py:2468
 msgid "Navigator Object"
 msgstr "Đối tượng Navigator"
 
 #. Translators: A choice for capture method. Captures the entire visible screen area.
-#: addon\globalPlugins\visionAssistant\__init__.py:2346
+#: addon\globalPlugins\visionAssistant\__init__.py:2470
 msgid "Full Screen"
 msgstr "Toàn màn hình"
 
 #. --- Prompts Group ---
 #. Translators: Title of the settings group for prompt management.
-#: addon\globalPlugins\visionAssistant\__init__.py:2355
+#: addon\globalPlugins\visionAssistant\__init__.py:2481
 msgid "Prompts"
 msgstr "Prompt"
 
 #. Translators: Description for the prompt manager button.
-#: addon\globalPlugins\visionAssistant\__init__.py:2360
+#: addon\globalPlugins\visionAssistant\__init__.py:2486
 msgid "Manage default and custom prompts."
 msgstr "Quản lý các prompt mặc định và tùy chỉnh."
 
 #. Translators: Button label to open prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:2362
+#: addon\globalPlugins\visionAssistant\__init__.py:2488
 msgid "Manage Prompts..."
 msgstr "Quản lý Prompt..."
 
 #. Translators: Summary text for prompt counts in settings.
-#: addon\globalPlugins\visionAssistant\__init__.py:2403
+#: addon\globalPlugins\visionAssistant\__init__.py:2525
 #, python-brace-format
 msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
 msgstr "Prompt mặc định: {defaultCount}, Prompt tùy chỉnh: {customCount}"
 
+#: addon\globalPlugins\visionAssistant\__init__.py:2580
+msgid "Model Name (Manual):"
+msgstr "Tên mô hình (Thủ công):"
+
 #. Translators: Progress message shown while fetching AI models from the server
-#: addon\globalPlugins\visionAssistant\__init__.py:2502
+#: addon\globalPlugins\visionAssistant\__init__.py:2639
 msgid "Fetching models..."
 msgstr "Đang tải mô hình..."
 
-#. Translators: Default model routing option for advanced mode
-#: addon\globalPlugins\visionAssistant\__init__.py:2518
-#: addon\globalPlugins\visionAssistant\__init__.py:2558
-msgid "Default (Auto)"
-msgstr "Mặc định (Tự động)"
+#. Translators: Option to follow the main model selected in the primary dropdown
+#. Translators: Option to follow the main model selected in the primary dropdown.
+#: addon\globalPlugins\visionAssistant\__init__.py:2656
+#: addon\globalPlugins\visionAssistant\__init__.py:2698
+msgid "Default (Main Model)"
+msgstr "Mặc định (Mô hình chính)"
 
-#. Translators: Success message after AI models are successfully updated
-#: addon\globalPlugins\visionAssistant\__init__.py:2546
+#. Translators: Option for the system to automatically choose the best model for this specific task
+#. Translators: Option for the system to automatically choose the best model for this task.
+#: addon\globalPlugins\visionAssistant\__init__.py:2658
+#: addon\globalPlugins\visionAssistant\__init__.py:2700
+msgid "Auto (Optimized)"
+msgstr "Tự động (Tối ưu hóa)"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:2685
 msgid "Models updated"
 msgstr "Đã cập nhật mô hình"
 
-#. Translators: Error message shown when models cannot be fetched from the API
-#: addon\globalPlugins\visionAssistant\__init__.py:2549
+#: addon\globalPlugins\visionAssistant\__init__.py:2687
 msgid "Failed to fetch models"
 msgstr "Tải mô hình thất bại"
 
+#. Translators: Error message shown when saving settings fails.
+#. Translators: Error message shown when saving a file fails.
+#: addon\globalPlugins\visionAssistant\__init__.py:2881
+#: addon\globalPlugins\visionAssistant\__init__.py:3603
+#, python-brace-format
+msgid "Save Error: {error}"
+msgstr "Lỗi lưu: {error}"
+
+#. Translators: Status reported when an error occurs
+#: addon\globalPlugins\visionAssistant\__init__.py:2881
+#: addon\globalPlugins\visionAssistant\__init__.py:3337
+#: addon\globalPlugins\visionAssistant\__init__.py:3448
+#: addon\globalPlugins\visionAssistant\__init__.py:3455
+#: addon\globalPlugins\visionAssistant\__init__.py:3508
+#: addon\globalPlugins\visionAssistant\__init__.py:3550
+#: addon\globalPlugins\visionAssistant\__init__.py:3555
+#: addon\globalPlugins\visionAssistant\__init__.py:3603
+#: addon\globalPlugins\visionAssistant\__init__.py:3966
+msgid "Error"
+msgstr "Lỗi"
+
+#. Translators: Notification showing the number of items found after filtering the model list.
+#: addon\globalPlugins\visionAssistant\__init__.py:2924
+#, python-brace-format
+msgid "{count} items found"
+msgstr "Tìm thấy {count} mục"
+
 #. Translators: Title of the PDF options dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2721
+#: addon\globalPlugins\visionAssistant\__init__.py:2929
 msgid "Options"
 msgstr "Tùy chọn"
 
 #. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:2724
+#: addon\globalPlugins\visionAssistant\__init__.py:2932
 #, python-brace-format
 msgid "Total Pages (All Files): {count}"
 msgstr "Tổng số trang (Tất cả các tệp): {count}"
 
 #. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2727
+#: addon\globalPlugins\visionAssistant\__init__.py:2935
 msgid "Range"
 msgstr "Phạm vi"
 
 #. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\__init__.py:2730
+#: addon\globalPlugins\visionAssistant\__init__.py:2938
 msgid "From:"
 msgstr "Từ:"
 
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\__init__.py:2734
+#: addon\globalPlugins\visionAssistant\__init__.py:2942
 msgid "To:"
 msgstr "Đến:"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\__init__.py:2743
+#: addon\globalPlugins\visionAssistant\__init__.py:2951
 msgid "Translate Output"
 msgstr "Dịch đầu ra"
 
 #. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\__init__.py:2756
+#: addon\globalPlugins\visionAssistant\__init__.py:2964
 msgid "Start"
 msgstr "Bắt đầu"
 
 #. Translators: Button to cancel
-#: addon\globalPlugins\visionAssistant\__init__.py:2759
+#: addon\globalPlugins\visionAssistant\__init__.py:2967
 msgid "Cancel"
 msgstr "Hủy"
 
 #. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2784
+#: addon\globalPlugins\visionAssistant\__init__.py:2992
 msgid "Ask about Document"
 msgstr "Hỏi về tài liệu"
 
 #. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\__init__.py:2793
+#: addon\globalPlugins\visionAssistant\__init__.py:3001
 #, python-brace-format
 msgid "File: {name}"
 msgstr "Tệp: {name}"
 
 #. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\__init__.py:2798
+#: addon\globalPlugins\visionAssistant\__init__.py:3006
 msgid "Uploading to AI...\n"
 msgstr "Đang tải lên AI...\n"
 
 #. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\__init__.py:2802
+#: addon\globalPlugins\visionAssistant\__init__.py:3010
 msgid "Your Question:"
 msgstr "Câu hỏi của bạn:"
 
 #. Translators: Message when ready to chat
-#: addon\globalPlugins\visionAssistant\__init__.py:2843
+#: addon\globalPlugins\visionAssistant\__init__.py:3054
 msgid "Ready! Ask your questions.\n"
 msgstr "Đã sẵn sàng! Hãy đặt câu hỏi của bạn.\n"
 
-#. Translators: Initial status when the add-on is doing nothing
-#. Translators: Status message when the add-on is doing nothing
-#. Translators: Initial status when the add-on is doing nothing
-#: addon\globalPlugins\visionAssistant\__init__.py:2861
-#: addon\globalPlugins\visionAssistant\__init__.py:2877
-#: addon\globalPlugins\visionAssistant\__init__.py:3229
-#: addon\globalPlugins\visionAssistant\__init__.py:3322
-#: addon\globalPlugins\visionAssistant\__init__.py:3327
-#: addon\globalPlugins\visionAssistant\__init__.py:3392
-#: addon\globalPlugins\visionAssistant\__init__.py:3590
-#: addon\globalPlugins\visionAssistant\__init__.py:3885
-#: addon\globalPlugins\visionAssistant\__init__.py:4194
-#: addon\globalPlugins\visionAssistant\__init__.py:4198
-#: addon\globalPlugins\visionAssistant\__init__.py:4316
-#: addon\globalPlugins\visionAssistant\__init__.py:4344
-#: addon\globalPlugins\visionAssistant\__init__.py:4362
-#: addon\globalPlugins\visionAssistant\__init__.py:4372
-#: addon\globalPlugins\visionAssistant\__init__.py:4487
-#: addon\globalPlugins\visionAssistant\__init__.py:4490
-#: addon\globalPlugins\visionAssistant\__init__.py:4493
-#: addon\globalPlugins\visionAssistant\__init__.py:4658
-#: addon\globalPlugins\visionAssistant\__init__.py:4673
-#: addon\globalPlugins\visionAssistant\__init__.py:4677
-#: addon\globalPlugins\visionAssistant\__init__.py:4681
-#: addon\globalPlugins\visionAssistant\__init__.py:4781
-#: addon\globalPlugins\visionAssistant\__init__.py:4794
-#: addon\globalPlugins\visionAssistant\__init__.py:4797
-#: addon\globalPlugins\visionAssistant\__init__.py:4835
-#: addon\globalPlugins\visionAssistant\__init__.py:4838
-#: addon\globalPlugins\visionAssistant\__init__.py:4846
-msgid "Idle"
-msgstr "Nhàn rỗi"
-
 #. Translators: Spoken prefix for AI response
-#: addon\globalPlugins\visionAssistant\__init__.py:2889
+#: addon\globalPlugins\visionAssistant\__init__.py:3099
 msgid "AI: "
 msgstr "AI: "
 
 #. Translators: Initial status message
-#: addon\globalPlugins\visionAssistant\__init__.py:2914
+#: addon\globalPlugins\visionAssistant\__init__.py:3128
 msgid "Initializing..."
 msgstr "Đang khởi tạo..."
 
 #. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\__init__.py:2920
+#: addon\globalPlugins\visionAssistant\__init__.py:3134
 msgid "Previous (Ctrl+PageUp)"
 msgstr "Trước (Ctrl+PageUp)"
 
 #. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\__init__.py:2924
+#: addon\globalPlugins\visionAssistant\__init__.py:3138
 msgid "Next (Ctrl+PageDown)"
 msgstr "Tiếp (Ctrl+PageDown)"
 
 #. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\__init__.py:2928
+#: addon\globalPlugins\visionAssistant\__init__.py:3142
 msgid "Go to:"
 msgstr "Đến trang:"
 
 #. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\__init__.py:2940
+#: addon\globalPlugins\visionAssistant\__init__.py:3153
 msgid "Ask AI (Alt+A)"
 msgstr "Hỏi AI (Alt+A)"
 
 #. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\__init__.py:2945
+#: addon\globalPlugins\visionAssistant\__init__.py:3158
 msgid "Re-scan with AI (Alt+R)"
 msgstr "Quét lại bằng AI (Alt+R)"
 
 #. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\__init__.py:2950
+#: addon\globalPlugins\visionAssistant\__init__.py:3163
 msgid "Generate Audio (Alt+G)"
 msgstr "Tạo âm thanh (Alt+G)"
 
 #. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\__init__.py:2961
+#: addon\globalPlugins\visionAssistant\__init__.py:3174
 msgid "Save (Alt+S)"
 msgstr "Lưu (Alt+S)"
 
 #. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\__init__.py:3023
+#: addon\globalPlugins\visionAssistant\__init__.py:3236
 #, python-brace-format
 msgid "Page {num} ready"
 msgstr "Trang {num} đã sẵn sàng"
 
 #. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3049
+#: addon\globalPlugins\visionAssistant\__init__.py:3262
 msgid "[OCR failed. Try a different AI model or provider.]"
 msgstr "[OCR thất bại. Hãy thử một mô hình hoặc nhà cung cấp AI khác.]"
 
 #. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\__init__.py:3060
+#: addon\globalPlugins\visionAssistant\__init__.py:3273
 msgid "Error processing page."
 msgstr "Lỗi khi xử lý trang."
 
 #. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\__init__.py:3065
+#: addon\globalPlugins\visionAssistant\__init__.py:3278
 #, python-brace-format
 msgid "Page {current} of {total}"
 msgstr "Trang {current} trên {total}"
 
 #. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\__init__.py:3072
+#: addon\globalPlugins\visionAssistant\__init__.py:3285
 msgid "Processing in background..."
 msgstr "Đang xử lý trong nền..."
 
 #. Translators: Spoken message when switching pages
 #. Translators: Heading for each page in the formatted content view.
-#: addon\globalPlugins\visionAssistant\__init__.py:3083
-#: addon\globalPlugins\visionAssistant\__init__.py:3102
+#: addon\globalPlugins\visionAssistant\__init__.py:3296
+#: addon\globalPlugins\visionAssistant\__init__.py:3315
+#: addon\globalPlugins\visionAssistant\__init__.py:3588
 #, python-brace-format
 msgid "Page {num}"
 msgstr "Trang {num}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:3115
+#: addon\globalPlugins\visionAssistant\__init__.py:3328
 msgid "Formatted Content"
 msgstr "Nội dung được định dạng"
 
-#. Translators: Status reported when an error occurs
-#: addon\globalPlugins\visionAssistant\__init__.py:3124
-#: addon\globalPlugins\visionAssistant\__init__.py:3234
-#: addon\globalPlugins\visionAssistant\__init__.py:3241
-#: addon\globalPlugins\visionAssistant\__init__.py:3333
-#: addon\globalPlugins\visionAssistant\__init__.py:3681
-#: addon\globalPlugins\visionAssistant\__init__.py:3688
-#: addon\globalPlugins\visionAssistant\__init__.py:3757
-msgid "Error"
-msgstr "Lỗi"
-
 #. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\__init__.py:3128
+#: addon\globalPlugins\visionAssistant\__init__.py:3341
 msgid "Current Page"
 msgstr "Trang hiện tại"
 
 #. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:3130
+#: addon\globalPlugins\visionAssistant\__init__.py:3343
 msgid "All Pages (In Range)"
 msgstr "Tất cả các trang (Trong phạm vi)"
 
 #. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\__init__.py:3140
+#: addon\globalPlugins\visionAssistant\__init__.py:3353
 msgid "Scanning with AI..."
 msgstr "Đang quét bằng AI..."
 
 #. Translators: Error shown when a specific page scan fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:3156
-#: addon\globalPlugins\visionAssistant\__init__.py:3216
+#: addon\globalPlugins\visionAssistant\__init__.py:3369
+#: addon\globalPlugins\visionAssistant\__init__.py:3430
 #, python-brace-format
 msgid "[Scan failed: {err}]"
 msgstr "[Quét thất bại: {err}]"
 
 #. Translators: Message shown when OCR returns no text for a page.
-#: addon\globalPlugins\visionAssistant\__init__.py:3161
+#: addon\globalPlugins\visionAssistant\__init__.py:3374
 msgid "[No text detected]"
 msgstr "[Không phát hiện thấy văn bản]"
 
 #. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:3166
+#: addon\globalPlugins\visionAssistant\__init__.py:3379
 msgid "Scan complete"
 msgstr "Quét hoàn tất"
 
 #. Translators: Generic system error message inside the document viewer.
-#: addon\globalPlugins\visionAssistant\__init__.py:3169
+#: addon\globalPlugins\visionAssistant\__init__.py:3382
 #, python-brace-format
 msgid "[Error: {msg}]"
 msgstr "[Lỗi: {msg}]"
 
 #. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\__init__.py:3181
+#: addon\globalPlugins\visionAssistant\__init__.py:3392
 msgid "Batch Processing Started"
 msgstr "Đã bắt đầu xử lý hàng loạt"
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3195
+#: addon\globalPlugins\visionAssistant\__init__.py:3407
 msgid "Error creating temporary PDF."
 msgstr "Lỗi khi tạo tệp PDF tạm thời."
 
 #. Translators: Message when a single page scan or batch is finished.
-#: addon\globalPlugins\visionAssistant\__init__.py:3209
+#: addon\globalPlugins\visionAssistant\__init__.py:3423
 msgid "Batch Scan Complete"
 msgstr "Quét hàng loạt hoàn tất"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3209
+#: addon\globalPlugins\visionAssistant\__init__.py:3423
 msgid "Scan Complete"
 msgstr "Quét hoàn tất"
 
 #. Translators: Message when the entire batch processing fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:3214
+#: addon\globalPlugins\visionAssistant\__init__.py:3428
 msgid "Batch Scan Failed"
 msgstr "Quét hàng loạt thất bại"
 
 #. Translators: Spoken message for background batch processing.
-#: addon\globalPlugins\visionAssistant\__init__.py:3226
+#: addon\globalPlugins\visionAssistant\__init__.py:3440
 #, python-brace-format
 msgid "AI is scanning {n} pages in background."
 msgstr "AI đang quét {n} trang trong nền."
 
 #. Translators: Error message when trying to use TTS with an unsupported provider
-#: addon\globalPlugins\visionAssistant\__init__.py:3234
+#: addon\globalPlugins\visionAssistant\__init__.py:3448
 msgid "TTS is not supported by the current provider or configuration."
 msgstr "TTS không được hỗ trợ bởi nhà cung cấp hoặc cấu hình hiện tại."
 
 #. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\__init__.py:3246
+#: addon\globalPlugins\visionAssistant\__init__.py:3460
 msgid "Generate for Current Page"
 msgstr "Tạo cho trang hiện tại"
 
 #. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:3248
+#: addon\globalPlugins\visionAssistant\__init__.py:3462
 msgid "Generate for All Pages (In Range)"
 msgstr "Tạo cho tất cả các trang (Trong phạm vi)"
 
 #. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\__init__.py:3258
+#: addon\globalPlugins\visionAssistant\__init__.py:3472
 msgid "No text to read."
 msgstr "Không có văn bản để đọc."
 
 #. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\__init__.py:3268
+#: addon\globalPlugins\visionAssistant\__init__.py:3482
 msgid "Gathering text for audio..."
 msgstr "Đang thu thập văn bản cho âm thanh..."
 
 #. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\__init__.py:3278
+#: addon\globalPlugins\visionAssistant\__init__.py:3492
 msgid "Save Audio"
 msgstr "Lưu âm thanh"
 
 #. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\__init__.py:3285
+#: addon\globalPlugins\visionAssistant\__init__.py:3499
 msgid "Generating Audio..."
 msgstr "Đang tạo âm thanh..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3291
+#: addon\globalPlugins\visionAssistant\__init__.py:3506
 msgid "Unknown Error"
 msgstr "Lỗi không xác định"
 
+#. Translators: Error message shown when text-to-speech generation fails.
+#: addon\globalPlugins\visionAssistant\__init__.py:3508
+#: addon\globalPlugins\visionAssistant\__init__.py:3550
+#, python-brace-format
+msgid "TTS Error: {error}"
+msgstr "Lỗi TTS: {error}"
+
 #. Translators: Error message when the MP3 encoder (LAME) is missing.
-#: addon\globalPlugins\visionAssistant\__init__.py:3308
+#: addon\globalPlugins\visionAssistant\__init__.py:3526
 msgid "lame.exe not found in lib folder."
-msgstr "Không tìm thấy lame.exe trong thư mục lib."
+msgstr "không tìm thấy lame.exe trong thư mục lib."
 
 #. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:3321
+#: addon\globalPlugins\visionAssistant\__init__.py:3540
 msgid "Audio Saved"
 msgstr "Đã lưu âm thanh"
 
 #. Translators: Success message after generating TTS audio.
-#: addon\globalPlugins\visionAssistant\__init__.py:3325
+#: addon\globalPlugins\visionAssistant\__init__.py:3545
 msgid "Audio file generated and saved successfully."
 msgstr "Đã tạo và lưu tệp âm thanh thành công."
 
 #. Translators: Warning message when the Gemini key is missing for specific features.
-#: addon\globalPlugins\visionAssistant\__init__.py:3333
+#: addon\globalPlugins\visionAssistant\__init__.py:3555
 msgid "Please configure Gemini API Key."
 msgstr "Vui lòng cấu hình Khóa API Gemini."
 
 #. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\__init__.py:3348
+#: addon\globalPlugins\visionAssistant\__init__.py:3570
 msgid "Save"
 msgstr "Lưu"
 
 #. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\__init__.py:3359
+#: addon\globalPlugins\visionAssistant\__init__.py:3581
 #, python-brace-format
 msgid "Saving Page {num}..."
 msgstr "Đang lưu Trang {num}..."
 
 #. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:3372
+#: addon\globalPlugins\visionAssistant\__init__.py:3598
 msgid "Saved"
 msgstr "Đã lưu"
 
 #. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:3374
+#: addon\globalPlugins\visionAssistant\__init__.py:3600
 msgid "File saved successfully."
 msgstr "Đã lưu tệp thành công."
 
 #. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:3409
+#: addon\globalPlugins\visionAssistant\__init__.py:3641
 msgid "&Document Reader..."
 msgstr "Trình đọc tài liệu (&D)..."
 
 #. Translators: Menu item for Audio Transcription
-#: addon\globalPlugins\visionAssistant\__init__.py:3413
+#: addon\globalPlugins\visionAssistant\__init__.py:3645
 msgid "Transcribe &Audio File..."
 msgstr "Chuyển biên tệp âm thanh (&A)..."
 
 #. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:3417
+#: addon\globalPlugins\visionAssistant\__init__.py:3649
 msgid "Analyze &Video URL..."
 msgstr "Phân tích URL &Video..."
 
 #. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:3423
+#: addon\globalPlugins\visionAssistant\__init__.py:3655
 msgid "&Settings..."
 msgstr "Cài đặt (&S)..."
 
 #. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:3427
+#: addon\globalPlugins\visionAssistant\__init__.py:3659
 msgid "Check for &Update"
 msgstr "Kiểm tra cập nhật (&U)"
 
 #. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:3431
+#: addon\globalPlugins\visionAssistant\__init__.py:3663
 msgid "Docu&mentation"
 msgstr "Tài liệu hướng dẫn (&M)"
 
 #. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:3435
+#: addon\globalPlugins\visionAssistant\__init__.py:3667
 msgid "D&onate"
 msgstr "Quyên góp (&O)"
 
 #. Translators: Menu item to open the Telegram channel
-#: addon\globalPlugins\visionAssistant\__init__.py:3439
+#: addon\globalPlugins\visionAssistant\__init__.py:3671
 msgid "Telegram &Channel"
 msgstr "Kênh Telegram (&C)"
 
 #. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
-#: addon\globalPlugins\visionAssistant\__init__.py:3444
+#: addon\globalPlugins\visionAssistant\__init__.py:3676
 msgid "Vision Assistant"
 msgstr "Vision Assistant"
 
 #. Translators: Standard title for opening a file
-#: addon\globalPlugins\visionAssistant\__init__.py:3459
-#: addon\globalPlugins\visionAssistant\__init__.py:3596
-#: addon\globalPlugins\visionAssistant\__init__.py:4047
+#: addon\globalPlugins\visionAssistant\__init__.py:3691
+#: addon\globalPlugins\visionAssistant\__init__.py:3832
+#: addon\globalPlugins\visionAssistant\__init__.py:4304
 msgid "Open"
 msgstr "Mở"
 
 #. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:3467
+#: addon\globalPlugins\visionAssistant\__init__.py:3699
 msgid "Supported Files"
 msgstr "Các tệp được hỗ trợ"
 
 #. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:3474
-#: addon\globalPlugins\visionAssistant\__init__.py:4265
+#: addon\globalPlugins\visionAssistant\__init__.py:3706
+#: addon\globalPlugins\visionAssistant\__init__.py:4533
 msgid "PyMuPDF library is missing."
 msgstr "Thiếu thư viện PyMuPDF."
 
 #. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:3480
-#: addon\globalPlugins\visionAssistant\__init__.py:4271
+#: addon\globalPlugins\visionAssistant\__init__.py:3712
+#: addon\globalPlugins\visionAssistant\__init__.py:4539
 msgid "No readable pages found."
 msgstr "Không tìm thấy trang nào có thể đọc."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3518
+#: addon\globalPlugins\visionAssistant\__init__.py:3750
 msgid "Activates the Command Layer for quick access to all features."
 msgstr "Kích hoạt Lớp lệnh để truy cập nhanh vào tất cả các tính năng."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3566
-#: addon\globalPlugins\visionAssistant\__init__.py:3857
+#: addon\globalPlugins\visionAssistant\__init__.py:3802
+#: addon\globalPlugins\visionAssistant\__init__.py:4093
 msgid "Translates the selected text or navigator object."
 msgstr "Dịch văn bản đã chọn hoặc đối tượng navigator."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3567
-#: addon\globalPlugins\visionAssistant\__init__.py:4913
+#: addon\globalPlugins\visionAssistant\__init__.py:3803
+#: addon\globalPlugins\visionAssistant\__init__.py:5204
 msgid "Translates the text currently in the clipboard."
 msgstr "Dịch văn bản hiện có trong clipboard."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3568
-#: addon\globalPlugins\visionAssistant\__init__.py:3983
+#: addon\globalPlugins\visionAssistant\__init__.py:3804
+#: addon\globalPlugins\visionAssistant\__init__.py:4240
 msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
 msgstr "Mở menu để Giải thích, Tóm tắt hoặc Sửa lỗi văn bản đã chọn."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3569
-#: addon\globalPlugins\visionAssistant\__init__.py:4449
+#: addon\globalPlugins\visionAssistant\__init__.py:3805
+#: addon\globalPlugins\visionAssistant\__init__.py:4746
 msgid "Performs OCR and description on the entire screen."
 msgstr "Thực hiện OCR và mô tả toàn bộ màn hình."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3570
-#: addon\globalPlugins\visionAssistant\__init__.py:4455
+#: addon\globalPlugins\visionAssistant\__init__.py:3806
+#: addon\globalPlugins\visionAssistant\__init__.py:4752
 msgid "Describes the current object (Navigator Object)."
 msgstr "Mô tả đối tượng hiện tại (Đối tượng Navigator)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3571
-#: addon\globalPlugins\visionAssistant\__init__.py:4378
+#: addon\globalPlugins\visionAssistant\__init__.py:3807
+#: addon\globalPlugins\visionAssistant\__init__.py:4672
 msgid ""
 "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
 msgstr "Mở Trình đọc tài liệu để phân tích chi tiết từng trang (PDF/Hình ảnh)."
 
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3572
-#: addon\globalPlugins\visionAssistant\__init__.py:4252
-msgid "Recognizes text from a selected image or PDF file."
-msgstr "Nhận dạng văn bản từ một hình ảnh hoặc tệp PDF đã chọn."
+#: addon\globalPlugins\visionAssistant\__init__.py:3808
+msgid ""
+"Performs smart actions (OCR or Description) on a selected image or PDF file."
+msgstr ""
+"Thực hiện các hành động thông minh (OCR hoặc Mô tả) trên tệp hình ảnh hoặc "
+"PDF được chọn."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3573
-#: addon\globalPlugins\visionAssistant\__init__.py:4635
+#: addon\globalPlugins\visionAssistant\__init__.py:3809
+#: addon\globalPlugins\visionAssistant\__init__.py:4901
 msgid "Transcribes a selected audio file."
 msgstr "Chuyển biên một tệp âm thanh đã chọn."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3574
-#: addon\globalPlugins\visionAssistant\__init__.py:4684
+#: addon\globalPlugins\visionAssistant\__init__.py:3810
+#: addon\globalPlugins\visionAssistant\__init__.py:4951
 msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
 msgstr "Phân tích URL video trên YouTube, Instagram, Twitter hoặc TikTok."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3575
-#: addon\globalPlugins\visionAssistant\__init__.py:4800
+#: addon\globalPlugins\visionAssistant\__init__.py:3811
+#: addon\globalPlugins\visionAssistant\__init__.py:5082
 msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
 msgstr "Thử giải quyết CAPTCHA trên màn hình hoặc đối tượng navigator."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3576
-#: addon\globalPlugins\visionAssistant\__init__.py:3764
+#: addon\globalPlugins\visionAssistant\__init__.py:3812
+#: addon\globalPlugins\visionAssistant\__init__.py:3973
 msgid "Records voice, transcribes it using AI, and types the result."
 msgstr "Ghi âm giọng nói, chuyển biên bằng AI và gõ kết quả."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3577
-#: addon\globalPlugins\visionAssistant\__init__.py:3586
+#: addon\globalPlugins\visionAssistant\__init__.py:3813
+#: addon\globalPlugins\visionAssistant\__init__.py:3822
 msgid "Announces the current status of the add-on."
 msgstr "Thông báo trạng thái hiện tại của add-on."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3578
-#: addon\globalPlugins\visionAssistant\__init__.py:4857
+#: addon\globalPlugins\visionAssistant\__init__.py:3814
+#: addon\globalPlugins\visionAssistant\__init__.py:5146
 msgid "Checks for updates manually."
 msgstr "Kiểm tra cập nhật theo cách thủ công."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3579
-#: addon\globalPlugins\visionAssistant\__init__.py:4928
+#: addon\globalPlugins\visionAssistant\__init__.py:3815
+#: addon\globalPlugins\visionAssistant\__init__.py:5219
 msgid ""
 "Shows the last AI response in a chat dialog for review or follow-up "
 "questions."
@@ -1767,193 +1876,215 @@ msgstr ""
 "Hiển thị phản hồi cuối cùng của AI trong hộp thoại trò chuyện để xem lại "
 "hoặc đặt câu hỏi tiếp theo."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3580
+#: addon\globalPlugins\visionAssistant\__init__.py:3816
 msgid "Shows a list of available commands in the layer."
 msgstr "Hiển thị danh sách các lệnh có sẵn trong lớp."
 
 #. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3583
+#: addon\globalPlugins\visionAssistant\__init__.py:3819
 #, python-brace-format
 msgid "{name} Help"
 msgstr "Trợ giúp {name}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:3659
+#: addon\globalPlugins\visionAssistant\__init__.py:3895
 #, python-brace-format
 msgid "File Upload Error: {error}"
 msgstr "Lỗi tải lên tệp: {error}"
 
-#. Translators: Error message when there's no content to send
-#: addon\globalPlugins\visionAssistant\__init__.py:3680
-#: addon\globalPlugins\visionAssistant\__init__.py:3687
-msgid "Nothing to send."
-msgstr "Không có gì để gửi."
-
 #. Translators: Error message when AI refuses to answer due to safety guidelines
-#: addon\globalPlugins\visionAssistant\__init__.py:3733
+#: addon\globalPlugins\visionAssistant\__init__.py:3942
 msgid "Error: Response blocked by AI safety filters."
 msgstr "Lỗi: Phản hồi bị chặn bởi các bộ lọc an toàn của AI."
 
-#. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:3774
-msgid "Listening..."
-msgstr "Đang nghe..."
-
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:3778
+#: addon\globalPlugins\visionAssistant\__init__.py:3984
+#: addon\globalPlugins\visionAssistant\__init__.py:3993
+#: addon\globalPlugins\visionAssistant\__init__.py:4002
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Lỗi phần cứng âm thanh: {error}"
 
+#. Translators: Message reported when dictation starts
+#: addon\globalPlugins\visionAssistant\__init__.py:3998
+msgid "Listening..."
+msgstr "Đang nghe..."
+
 #. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\__init__.py:3788
+#: addon\globalPlugins\visionAssistant\__init__.py:4012
 msgid "Typing..."
 msgstr "Đang gõ..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:3793
+#: addon\globalPlugins\visionAssistant\__init__.py:4017
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Lỗi lưu bản ghi: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\__init__.py:3808
-#: addon\globalPlugins\visionAssistant\__init__.py:3831
+#: addon\globalPlugins\visionAssistant\__init__.py:4032
+#: addon\globalPlugins\visionAssistant\__init__.py:4059
 msgid "No speech detected."
 msgstr "Không phát hiện thấy giọng nói."
 
 #. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:3838
+#: addon\globalPlugins\visionAssistant\__init__.py:4069
 msgid "No speech recognized or Error."
 msgstr "Không nhận dạng được giọng nói hoặc có lỗi."
 
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:3853
+#: addon\globalPlugins\visionAssistant\__init__.py:4088
 #, python-brace-format
 msgid "Typed: {text}"
 msgstr "Đã gõ: {text}"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:3864
+#: addon\globalPlugins\visionAssistant\__init__.py:4100
 msgid "No text found."
 msgstr "Không tìm thấy văn bản."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:3869
+#: addon\globalPlugins\visionAssistant\__init__.py:4105
 msgid "Translating..."
 msgstr "Đang dịch..."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:3894
+#: addon\globalPlugins\visionAssistant\__init__.py:4150
 #, python-brace-format
 msgid "Translated: {text}"
 msgstr "Đã dịch: {text}"
 
 #. Translators: Dialog title for Translation results
-#: addon\globalPlugins\visionAssistant\__init__.py:3918
+#: addon\globalPlugins\visionAssistant\__init__.py:4175
 #, python-brace-format
 msgid "{name} - Translation"
 msgstr "{name} - Dịch thuật"
 
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4012
+#: addon\globalPlugins\visionAssistant\__init__.py:4269
+#: addon\globalPlugins\visionAssistant\__init__.py:4553
 msgid "Choose action:"
 msgstr "Chọn hành động:"
 
 #. Translators: Message while processing request of the refine text command
-#: addon\globalPlugins\visionAssistant\__init__.py:4057
+#. Translators: Status reported when AI starts processing a command
+#. Translators: Internal feedback during AI processing
+#: addon\globalPlugins\visionAssistant\__init__.py:4314
+#: addon\globalPlugins\visionAssistant\__init__.py:5381
+#: addon\globalPlugins\visionAssistant\__init__.py:5459
 msgid "Processing..."
 msgstr "Đang xử lý..."
 
 #. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\__init__.py:4114
+#: addon\globalPlugins\visionAssistant\__init__.py:4371
 msgid "Uploading file..."
 msgstr "Đang tải lên tệp..."
 
 #. Translators: Message reported when executing the refine command
 #. Translators: Message reported when calling the audio transcription command
 #. Translators: Message reported when AI is analyzing the video
-#: addon\globalPlugins\visionAssistant\__init__.py:4187
-#: addon\globalPlugins\visionAssistant\__init__.py:4666
-#: addon\globalPlugins\visionAssistant\__init__.py:4778
+#: addon\globalPlugins\visionAssistant\__init__.py:4444
+#: addon\globalPlugins\visionAssistant\__init__.py:4932
+#: addon\globalPlugins\visionAssistant\__init__.py:5045
 msgid "Analyzing..."
 msgstr "Đang phân tích..."
 
 #. Translators: Title of Refine Result dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4240
+#: addon\globalPlugins\visionAssistant\__init__.py:4502
 #, python-brace-format
 msgid "{name} - Refine Result"
 msgstr "{name} - Kết quả tinh chỉnh"
 
+#. Translators: Script description for Input Gestures dialog
+#: addon\globalPlugins\visionAssistant\__init__.py:4514
+msgid "Performs smart actions on a selected image or PDF file."
+msgstr "Thực hiện các hành động thông minh trên tệp hình ảnh hoặc PDF đã chọn."
+
+#. Translators: Options for the image file action menu
+#: addon\globalPlugins\visionAssistant\__init__.py:4550
+msgid "Extract Text (OCR)"
+msgstr "Trích xuất văn bản (OCR)"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:4550
+msgid "Describe Image"
+msgstr "Mô tả hình ảnh"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:4553
+msgid "Image File"
+msgstr "Tệp hình ảnh"
+
+#. Translators: Status reported when an image file is being analyzed
+#: addon\globalPlugins\visionAssistant\__init__.py:4563
+msgid "Analyzing Image File..."
+msgstr "Đang phân tích tệp hình ảnh..."
+
 #. Translators: Message reported when extracting text from a file
-#: addon\globalPlugins\visionAssistant\__init__.py:4297
+#: addon\globalPlugins\visionAssistant\__init__.py:4591
 msgid "Extracting Text..."
 msgstr "Đang trích xuất văn bản..."
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:4304
-#: addon\globalPlugins\visionAssistant\__init__.py:4355
+#: addon\globalPlugins\visionAssistant\__init__.py:4598
+#: addon\globalPlugins\visionAssistant\__init__.py:4649
 msgid "Error creating PDF."
 msgstr "Lỗi tạo PDF."
 
 #. Translators: Error shown when OCR finds no text in the selected files
-#: addon\globalPlugins\visionAssistant\__init__.py:4347
+#: addon\globalPlugins\visionAssistant\__init__.py:4641
 msgid "No text detected or error occurred."
 msgstr "Không phát hiện thấy văn bản hoặc đã xảy ra lỗi."
 
 #. Translators: Dialog title for a Chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4437
-#: addon\globalPlugins\visionAssistant\__init__.py:4623
+#: addon\globalPlugins\visionAssistant\__init__.py:4734
 #, python-brace-format
 msgid "{name} - Chat"
 msgstr "{name} - Trò chuyện"
 
 #. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\__init__.py:4465
+#: addon\globalPlugins\visionAssistant\__init__.py:4762
 msgid "Scanning..."
 msgstr "Đang quét..."
 
 #. Translators: Message reported when calling an image analysis command
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:4470
-#: addon\globalPlugins\visionAssistant\__init__.py:4820
+#: addon\globalPlugins\visionAssistant\__init__.py:4767
+#: addon\globalPlugins\visionAssistant\__init__.py:5102
 msgid "Capture failed."
 msgstr "Chụp thất bại."
 
 #. Translators: Dialog title for Image Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:4559
+#: addon\globalPlugins\visionAssistant\__init__.py:4888
 #, python-brace-format
 msgid "{name} - Image Analysis"
 msgstr "{name} - Phân tích hình ảnh"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\__init__.py:4647
+#: addon\globalPlugins\visionAssistant\__init__.py:4913
 msgid "Uploading..."
 msgstr "Đang tải lên..."
 
 #. Translators: Error message when video analysis is attempted with a non-Gemini provider.
-#: addon\globalPlugins\visionAssistant\__init__.py:4692
+#: addon\globalPlugins\visionAssistant\__init__.py:4959
 msgid "Video analysis is only supported by Gemini providers."
 msgstr "Tính năng phân tích video chỉ được hỗ trợ bởi các nhà cung cấp Gemini."
 
 #. Translators: Title for the video URL entry dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4697
+#: addon\globalPlugins\visionAssistant\__init__.py:4964
 msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 msgstr "Phân tích YouTube / Instagram / Twitter / TikTok"
 
 #. Translators: Label for the text entry in video dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4699
+#: addon\globalPlugins\visionAssistant\__init__.py:4966
 msgid "Enter Video URL (YouTube/Instagram/Twitter/TikTok):"
 msgstr "Nhập URL video (YouTube/Instagram/Twitter/TikTok):"
 
 #. Translators: Error message when the URL is invalid
-#: addon\globalPlugins\visionAssistant\__init__.py:4719
-#: addon\globalPlugins\visionAssistant\__init__.py:4722
+#: addon\globalPlugins\visionAssistant\__init__.py:4986
 msgid "Error: Invalid URL."
 msgstr "Lỗi: URL không hợp lệ."
 
 #. Translators: Error message when the platform is not supported
-#: addon\globalPlugins\visionAssistant\__init__.py:4732
+#: addon\globalPlugins\visionAssistant\__init__.py:4997
 msgid ""
 "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
 "are supported."
@@ -1962,96 +2093,163 @@ msgstr ""
 "TikTok."
 
 #. Translators: Message reported when processing video link
-#: addon\globalPlugins\visionAssistant\__init__.py:4736
+#: addon\globalPlugins\visionAssistant\__init__.py:5002
 msgid "Processing Video..."
 msgstr "Đang xử lý video..."
 
-#. Translators: Error message when link extraction fails for Instagram.
-#: addon\globalPlugins\visionAssistant\__init__.py:4748
+#: addon\globalPlugins\visionAssistant\__init__.py:5013
 msgid "Error: Could not extract Instagram video."
 msgstr "Lỗi: Không thể trích xuất video Instagram."
 
-#. Translators: Error message when link extraction fails for Twitter/X.
-#: addon\globalPlugins\visionAssistant\__init__.py:4752
+#: addon\globalPlugins\visionAssistant\__init__.py:5016
 msgid "Error: Could not extract Twitter video."
 msgstr "Lỗi: Không thể trích xuất video Twitter."
 
-#. Translators: Error message when link extraction fails for TikTok.
-#: addon\globalPlugins\visionAssistant\__init__.py:4756
+#: addon\globalPlugins\visionAssistant\__init__.py:5019
 msgid "Error: Could not extract TikTok video."
 msgstr "Lỗi: Không thể trích xuất video TikTok."
 
 #. Translators: Message reported when downloading video
-#: addon\globalPlugins\visionAssistant\__init__.py:4763
+#: addon\globalPlugins\visionAssistant\__init__.py:5028
 msgid "Downloading Video..."
 msgstr "Đang tải xuống video..."
 
 #. Translators: Error message when video download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:4768
+#: addon\globalPlugins\visionAssistant\__init__.py:5034
 msgid "Error: Download failed."
 msgstr "Lỗi: Tải xuống thất bại."
 
 #. Translators: Message reported when uploading video to AI
-#: addon\globalPlugins\visionAssistant\__init__.py:4772
+#: addon\globalPlugins\visionAssistant\__init__.py:5039
 msgid "Uploading to AI..."
 msgstr "Đang tải lên AI..."
 
 #. Translators: Message reported when analyzing YouTube video
-#: addon\globalPlugins\visionAssistant\__init__.py:4790
+#: addon\globalPlugins\visionAssistant\__init__.py:5062
 msgid "Analyzing YouTube..."
 msgstr "Đang phân tích YouTube..."
 
+#: addon\globalPlugins\visionAssistant\__init__.py:5077
+msgid "Error processing video."
+msgstr "Lỗi khi xử lý video."
+
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:4815
+#: addon\globalPlugins\visionAssistant\__init__.py:5097
 msgid "Solving..."
 msgstr "Đang giải..."
 
 #. Translators: Message reported when AI cannot find any CAPTCHA in the image
-#: addon\globalPlugins\visionAssistant\__init__.py:4841
+#: addon\globalPlugins\visionAssistant\__init__.py:5123
 msgid "No CAPTCHA detected."
 msgstr "Không phát hiện thấy CAPTCHA."
 
 #. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:4853
+#: addon\globalPlugins\visionAssistant\__init__.py:5141
 #, python-brace-format
 msgid "Captcha: {text}"
 msgstr "Captcha: {text}"
 
 #. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:4861
+#: addon\globalPlugins\visionAssistant\__init__.py:5150
 msgid "Checking for updates..."
 msgstr "Đang kiểm tra cập nhật..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:4919
+#: addon\globalPlugins\visionAssistant\__init__.py:5210
 msgid "Translating Clipboard..."
 msgstr "Đang dịch Clipboard..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:4924
+#: addon\globalPlugins\visionAssistant\__init__.py:5215
 msgid "Clipboard empty."
 msgstr "Clipboard trống."
 
 #. Translators: Message reported when the user tries to show the last result but none is stored.
-#: addon\globalPlugins\visionAssistant\__init__.py:4933
+#: addon\globalPlugins\visionAssistant\__init__.py:5224
 msgid "No previous result to show."
 msgstr "Không có kết quả trước đó để hiển thị."
 
-#. Translators: Message shown when settings dialog is already open
-#: addon\globalPlugins\visionAssistant\__init__.py:4947
-#: addon\globalPlugins\visionAssistant\__init__.py:4957
-msgid "Settings dialog is already open."
-msgstr "Hộp thoại cài đặt đã được mở."
-
 #. Translators: Message when opening documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:4963
+#: addon\globalPlugins\visionAssistant\__init__.py:5262
 msgid "Opening documentation..."
 msgstr "Đang mở tài liệu hướng dẫn..."
 
 #. Translators: Error when help file is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:4973
+#: addon\globalPlugins\visionAssistant\__init__.py:5272
 msgid "Documentation file not found."
 msgstr "Không tìm thấy tệp tài liệu hướng dẫn."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:5290
+msgid "Toggles the interactive UI elements explorer."
+msgstr "Bật/tắt trình thám hiểm các thành phần giao diện tương tác."
+
+#. Translators: Status message when UI Explorer starts
+#: addon\globalPlugins\visionAssistant\__init__.py:5296
+msgid "UI Explorer Active"
+msgstr "UI Explorer đang hoạt động"
+
+#. Translators: Status message when UI Explorer stops
+#: addon\globalPlugins\visionAssistant\__init__.py:5301
+#: addon\globalPlugins\visionAssistant\__init__.py:5364
+msgid "UI Explorer Stopped"
+msgstr "UI Explorer đã dừng"
+
+#. Translators: Generic error message for AI failures
+#: addon\globalPlugins\visionAssistant\__init__.py:5319
+msgid "Unknown AI Error"
+msgstr "Lỗi AI không xác định"
+
+#. Translators: Error shown when AI fails to find UI elements
+#: addon\globalPlugins\visionAssistant\__init__.py:5335
+msgid "AI failed to identify UI elements."
+msgstr "AI không thể nhận diện các thành phần giao diện."
+
+#. Translators: Instruction for the elements list dialog
+#: addon\globalPlugins\visionAssistant\__init__.py:5350
+msgid "Select an element to click:"
+msgstr "Chọn một thành phần để click:"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:5350
+msgid "UI Elements Explorer"
+msgstr "Trình thám hiểm thành phần giao diện (UI Explorer)"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:5366
+msgid "Asks the AI Operator to perform an action or describe the screen."
+msgstr "Yêu cầu AI Operator thực hiện một hành động hoặc mô tả màn hình."
+
+#. Translators: Title and message for AI Operator command dialog
+#: addon\globalPlugins\visionAssistant\__init__.py:5372
+msgid "What should I do or what is your question?"
+msgstr "Tôi nên làm gì hoặc câu hỏi của bạn là gì?"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:5413
+msgid "AI Error"
+msgstr "Lỗi AI"
+
+#. Translators: Internal history label for user actions in operator sessions
+#: addon\globalPlugins\visionAssistant\__init__.py:5416
+msgid "Action performed. Checking result..."
+msgstr "Đã thực hiện hành động. Đang kiểm tra kết quả..."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:5464
+#, python-brace-format
+#| msgid "{name} - Chat"
+msgid "{name} - AI Operator"
+msgstr "{name} - AI Operator"
+
+#. Translators: Labels for the AI and User in chat history
+#: addon\globalPlugins\visionAssistant\__init__.py:5474
+msgid "Operator"
+msgstr "Operator"
+
+#: addon\globalPlugins\visionAssistant\__init__.py:5474
+msgid "You"
+msgstr "Bạn"
+
+#. Translators: Default text for successful AI action
+#: addon\globalPlugins\visionAssistant\__init__.py:5501
+msgid "Action performed"
+msgstr "Đã thực hiện hành động"
 
 #. Add-on summary/title, usually the user visible name of the add-on
 #. Translators: Summary/title for this add-on
@@ -2100,48 +2298,129 @@ msgstr ""
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:32
 msgid ""
-"## Changes for 5.0\n"
-"* **Multi-Provider Architecture**: Added full support for **OpenAI**, "
-"**Groq**, and **Mistral** alongside Google Gemini. Users can now choose "
-"their preferred AI backend.\n"
-"* **Advanced Model Routing**: Users of native providers (Gemini, OpenAI, "
-"etc.) can now select specific models from a dropdown list for different "
-"tasks (OCR, STT, TTS).\n"
-"* **Advanced Endpoint Configuration**: Custom provider users can manually "
-"input specific URLs and model names for granular control over local or third-"
-"party servers.\n"
-"* **Smart Feature Visibility**: The settings menu and Document Reader UI now "
-"automatically hide unsupported features (like TTS) based on the selected "
-"provider.\n"
-"* **Dynamic Model Fetching**: The addon now fetches the available model list "
-"directly from the provider's API, ensuring compatibility with new models as "
-"soon as they are released.\n"
-"* **Hybrid OCR & Translation**: Optimized the logic to use Google Translate "
-"for speed when using Chrome OCR, and AI-powered translation when using "
-"Gemini/Groq/OpenAI engines.\n"
-"* **Universal \"Re-scan with AI\"**: The Document Reader's re-scan feature "
-"is no longer limited to Gemini. It now utilizes whatever AI provider is "
-"currently active to re-process pages."
+"## Changes for 5.5 (The Automation Update)\n"
+"\n"
+"*   **AI Operator (Autonomous Control - Shift+A):** This is the crown jewel "
+"of v5.5. Vision Assistant Pro has graduated from being a passive assistant "
+"to becoming your personal **AI Operator**. It doesn't just describe the "
+"screen—it takes command.\n"
+"    *   *How it works:* You can now give verbal instructions to operate your "
+"PC. For example, in a completely inaccessible application where your screen "
+"reader stays silent, you can press **Shift+A** and type: *\"Click on the "
+"Settings button\"* or *\"Find the search field, type 'Latest News' and press "
+"enter.\"* The AI visually identifies the elements, moves the mouse, and "
+"executes the task for you.\n"
+"    *   *Performance Note:* This feature is optimized for **Gemini 3.0 Flash "
+"(Preview)**, delivering incredibly fast and intelligent responses that can "
+"handle even the most complex UI layouts.\n"
+"    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" "
+"exactly what's happening to be accurate, it sends a high-resolution "
+"screenshot with every step. Please note that frequent use will consume your "
+"API quota much faster than standard text-based tasks.\n"
+"*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled "
+"buttons\"? Press **E** to activate the UI Explorer. The AI will scan the "
+"entire window and generate a list of every clickable element it sees—"
+"including icons, graphics, and menus. Simply pick an item from the list, and "
+"the AI Operator will click it for you. It’s like having an \"accessible "
+"layer\" on top of any app.\n"
+"*   **Context-Aware Smart File Action (F):** The \"F\" key has been "
+"completely overhauled. It no longer assumes you only want OCR. When you "
+"select a single image, it now intelligently asks for your intent: you can "
+"choose a **Detailed Visual Description** to understand the scene or a "
+"**Structured Text Extraction (OCR)** for reading. The menu adapts "
+"dynamically based on the file type and your active AI engine.\n"
+"*   **Core Optimization:** We've performed a deep cleanup of the add-on’s "
+"internal logic, removing unused legacy functions and redundant code. This "
+"results in a leaner, faster, and more reliable experience for all users."
 msgstr ""
-"## Những thay đổi trong phiên bản 5.0\n"
-"* **Kiến trúc đa nhà cung cấp**: Bổ sung hỗ trợ đầy đủ cho **OpenAI**, "
-"**Groq**, và **Mistral** bên cạnh Google Gemini. Người dùng hiện có thể chọn "
-"backend AI ưa thích của mình.\n"
-"* **Định tuyến mô hình nâng cao**: Người dùng các nhà cung cấp gốc (Gemini, OpenAI, "
-"v.v.) hiện có thể chọn các mô hình cụ thể từ danh sách thả xuống cho các tác vụ khác nhau (OCR, STT, TTS).\n"
-"* **Cấu hình Endpoint nâng cao**: Người dùng nhà cung cấp tùy chỉnh có thể nhập thủ công "
-"các URL và tên mô hình cụ thể để kiểm soát chi tiết các máy chủ cục bộ hoặc bên thứ ba.\n"
-"* **Hiển thị tính năng thông minh**: Menu cài đặt và giao diện Trình đọc tài liệu giờ đây "
-"tự động ẩn các tính năng không được hỗ trợ (như TTS) dựa trên nhà cung cấp đã chọn.\n"
-"* **Tìm nạp mô hình động**: Add-on hiện tìm nạp danh sách mô hình có sẵn "
-"trực tiếp từ API của nhà cung cấp, đảm bảo khả năng tương thích với các mô hình mới ngay khi "
-"chúng được phát hành.\n"
-"* **Kết hợp OCR & Dịch thuật**: Tối ưu hóa logic để sử dụng Google Dịch "
-"nhằm tăng tốc độ khi dùng Chrome OCR, và dịch thuật bằng AI khi dùng "
-"các công cụ Gemini/Groq/OpenAI.\n"
-"* **\"Quét lại bằng AI\" toàn cầu**: Tính năng quét lại của Trình đọc tài liệu "
-"không còn bị giới hạn ở Gemini. Giờ đây, tính năng này sử dụng bất kỳ nhà cung cấp AI nào "
-"đang hoạt động để xử lý lại các trang."
+"## Những thay đổi trong phiên bản 5.5 (Bản cập nhật Tự động hóa)\"\n"
+"\n"
+"\"*   **AI Operator (Điều khiển tự động - Shift+A):** Đây là tính năng sáng "
+"giá nhất của v5.5. Vision Assistant Pro đã nâng cấp từ một trợ lý thụ động "
+"thành **AI Operator** cá nhân của bạn. Nó không chỉ mô tả màn hình mà còn "
+"thực sự nắm quyền điều khiển.\n"
+"\"    *   *Cách thức hoạt động:* Giờ đây bạn có thể đưa ra các chỉ dẫn bằng "
+"văn bản hoặc giọng nói để vận hành máy tính. Ví dụ, trong một ứng dụng hoàn "
+"toàn không tiếp cận được nơi trình đọc màn hình im lặng, bạn có thể nhấn "
+"**Shift+A** và nhập: *\\\"Click vào nút Cài đặt\\\"* hoặc *\\\"Tìm ô tìm "
+"kiếm, nhập 'Tin tức mới nhất' rồi nhấn enter.\\\"* AI sẽ nhận diện các thành "
+"phần bằng hình ảnh, di chuyển chuột và thực hiện tác vụ cho bạn.\n"
+"\"    *   *Lưu ý về hiệu suất:* Tính năng này được tối ưu hóa cho **Gemini "
+"3.0 Flash (Bản xem trước)**, mang lại phản hồi cực nhanh và thông minh, có "
+"thể xử lý cả những bố cục giao diện phức tạp nhất.\n"
+"    *   **⚠️ Cảnh báo sử dụng API:** Vì AI Operator cần \\\"nhìn\\\" chính "
+"xác những gì đang diễn ra để đảm bảo độ chính xác, nó sẽ gửi ảnh chụp màn "
+"hình độ phân giải cao sau mỗi bước. Lưu ý rằng việc sử dụng thường xuyên sẽ "
+"tiêu tốn hạn ngạch API nhanh hơn nhiều so với các tác vụ văn bản thông "
+"thường.\n"
+"\"*   **Trình thám hiểm giao diện (UI Explorer - E):** Bạn mệt mỏi vì phải "
+"điều hướng qua các \\\"nút không nhãn\\\"? Nhấn **E** để kích hoạt UI "
+"Explorer. AI sẽ quét toàn bộ cửa sổ và tạo danh sách mọi thành phần có thể "
+"click mà nó thấy—bao gồm cả icon, đồ họa và menu. Chỉ cần chọn một mục từ "
+"danh sách và AI Operator sẽ click giúp bạn. Nó giống như việc thêm một \\"
+"\"lớp tiếp cận\\\" lên trên bất kỳ ứng dụng nào.\n"
+"\"*   **Hành động tệp thông minh theo ngữ cảnh (F):** Phím \\\"F\\\" đã được "
+"đại tu hoàn toàn. Nó không còn mặc định là bạn chỉ muốn OCR nữa. Khi bạn "
+"chọn một hình ảnh, nó sẽ hỏi ý định của bạn: bạn có thể chọn **Mô tả hình "
+"ảnh chi tiết** để hiểu bối cảnh hoặc **Trích xuất văn bản có cấu trúc "
+"(OCR)** để đọc. Menu sẽ thay đổi linh hoạt dựa trên loại tệp và công cụ AI "
+"bạn đang dùng.\n"
+"\"*   **Tối ưu hóa cốt lõi:** Chúng tôi đã dọn dẹp sâu logic nội bộ của add-"
+"on, loại bỏ các hàm cũ không còn sử dụng và mã dư thừa. Điều này giúp add-on "
+"nhẹ hơn, nhanh hơn và hoạt động ổn định hơn cho tất cả người dùng."
+
+#~ msgid "Nothing to send."
+#~ msgstr "Không có gì để gửi."
+
+#~ msgid "Settings dialog is already open."
+#~ msgstr "Hộp thoại cài đặt đã được mở."
+
+#~ msgid ""
+#~ "## Changes for 5.0\n"
+#~ "* **Multi-Provider Architecture**: Added full support for **OpenAI**, "
+#~ "**Groq**, and **Mistral** alongside Google Gemini. Users can now choose "
+#~ "their preferred AI backend.\n"
+#~ "* **Advanced Model Routing**: Users of native providers (Gemini, OpenAI, "
+#~ "etc.) can now select specific models from a dropdown list for different "
+#~ "tasks (OCR, STT, TTS).\n"
+#~ "* **Advanced Endpoint Configuration**: Custom provider users can manually "
+#~ "input specific URLs and model names for granular control over local or "
+#~ "third-party servers.\n"
+#~ "* **Smart Feature Visibility**: The settings menu and Document Reader UI "
+#~ "now automatically hide unsupported features (like TTS) based on the "
+#~ "selected provider.\n"
+#~ "* **Dynamic Model Fetching**: The addon now fetches the available model "
+#~ "list directly from the provider's API, ensuring compatibility with new "
+#~ "models as soon as they are released.\n"
+#~ "* **Hybrid OCR & Translation**: Optimized the logic to use Google "
+#~ "Translate for speed when using Chrome OCR, and AI-powered translation "
+#~ "when using Gemini/Groq/OpenAI engines.\n"
+#~ "* **Universal \"Re-scan with AI\"**: The Document Reader's re-scan "
+#~ "feature is no longer limited to Gemini. It now utilizes whatever AI "
+#~ "provider is currently active to re-process pages."
+#~ msgstr ""
+#~ "## Những thay đổi trong phiên bản 5.0\n"
+#~ "* **Kiến trúc đa nhà cung cấp**: Bổ sung hỗ trợ đầy đủ cho **OpenAI**, "
+#~ "**Groq**, và **Mistral** bên cạnh Google Gemini. Người dùng hiện có thể "
+#~ "chọn backend AI ưa thích của mình.\n"
+#~ "* **Định tuyến mô hình nâng cao**: Người dùng các nhà cung cấp gốc "
+#~ "(Gemini, OpenAI, v.v.) hiện có thể chọn các mô hình cụ thể từ danh sách "
+#~ "thả xuống cho các tác vụ khác nhau (OCR, STT, TTS).\n"
+#~ "* **Cấu hình Endpoint nâng cao**: Người dùng nhà cung cấp tùy chỉnh có "
+#~ "thể nhập thủ công các URL và tên mô hình cụ thể để kiểm soát chi tiết các "
+#~ "máy chủ cục bộ hoặc bên thứ ba.\n"
+#~ "* **Hiển thị tính năng thông minh**: Menu cài đặt và giao diện Trình đọc "
+#~ "tài liệu giờ đây tự động ẩn các tính năng không được hỗ trợ (như TTS) dựa "
+#~ "trên nhà cung cấp đã chọn.\n"
+#~ "* **Tìm nạp mô hình động**: Add-on hiện tìm nạp danh sách mô hình có sẵn "
+#~ "trực tiếp từ API của nhà cung cấp, đảm bảo khả năng tương thích với các "
+#~ "mô hình mới ngay khi chúng được phát hành.\n"
+#~ "* **Kết hợp OCR & Dịch thuật**: Tối ưu hóa logic để sử dụng Google Dịch "
+#~ "nhằm tăng tốc độ khi dùng Chrome OCR, và dịch thuật bằng AI khi dùng các "
+#~ "công cụ Gemini/Groq/OpenAI.\n"
+#~ "* **\"Quét lại bằng AI\" toàn cầu**: Tính năng quét lại của Trình đọc tài "
+#~ "liệu không còn bị giới hạn ở Gemini. Giờ đây, tính năng này sử dụng bất "
+#~ "kỳ nhà cung cấp AI nào đang hoạt động để xử lý lại các trang."
 
 #~ msgid "Document Chat Bootstrap Reply"
 #~ msgstr "Phản hồi khởi động trò chuyện tài liệu"
@@ -2168,9 +2447,6 @@ msgstr ""
 #, python-brace-format
 #~ msgid "Upload Server Error {code}: {reason}"
 #~ msgstr "Lỗi máy chủ tải lên {code}: {reason}"
-
-#~ msgid "Error processing audio."
-#~ msgstr "Lỗi xử lý âm thanh."
 
 #~ msgid "Failed."
 #~ msgstr "Thất bại."


### PR DESCRIPTION
Revise Vietnamese README and localization for the 5.5 release: expand and restructure settings docs (provider selection, fetch models, advanced model routing, custom endpoints), update OCR/TTS/tooling options, rename/clarify command layer shortcuts and document reader shortcuts, and add release notes for v5.5 and v5.0. Update nvda.po metadata (version, dates, translator info), adjust string references/line numbers, and add/modify translations (including AI Operator entries and OCR/TTS labels) to match the updated UI and features.