### PR TITLE
Update Polish translation for 5.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ manifest.ini
 *.nvda-addon
 .sconsign.dblite
 /[0-9]*.[0-9]*.[0-9]*.json
+.vibe/
+*.po~

--- a/addon/doc/pl/readme.md
+++ b/addon/doc/pl/readme.md
@@ -9,27 +9,28 @@ _Ten dodatek został udostępniony społeczności z okazji Międzynarodowego Dni
 Przejdź do **Menu NVDA > Preferencje > Ustawienia > Vision Assistant Pro**.
 
 ### 1.1 Ustawienia połączenia
-- **Dostawca:** Najpierw Wybierz usługę AI. Obsługiwani dostawcy to **Google Gemini**, **OpenAI**, **Mistral**, **Groq** oraz **Niestandardowy** (serwery zgodne z OpenAI, np. Ollama/LM Studio).
+- **Dostawca:** Wybierz preferowaną usługę AI. Obsługiwani dostawcy to **Google Gemini**, **OpenAI**, **Mistral**, **Groq** oraz **Niestandardowy** (serwery zgodne z OpenAI, np. Ollama/LM Studio).
 - **Ważne:** Zalecamy korzystanie z **Google Gemini**, który zapewnia najlepszą jakość (szczególnie przy analizie obrazów i plików).
 - **Klucz API:** Wymagany. Można podać wiele kluczy (rozdzielonych przecinkami lub w osobnych wierszach), aby dodatek rotował je automatycznie.
 - **Pobierz modele:** Po wprowadzeniu klucza API naciśnij ten przycisk, aby pobrać aktualną listę dostępnych modeli od dostawcy.
 - **Model AI:** Wybierz główny model używany do czatu i analizy.
 
 ### 1.2 Osobny model dla każdego zadania
-*Dostępne dla Gemini, OpenAI, Groq i Mistral.*
+*Dostępne dla wszystkich dostawców, w tym Gemini, OpenAI, Groq, Mistral i Niestandardowy.*
 
-> **⚠️ Uwaga:** Te ustawienia są przeznaczone dla **doświadczonych użytkowników**. Jeśli nie wiesz, do czego służy dany model, zostaw tę opcję **odznaczoną**. Wybranie nieodpowiedniego modelu (np. modelu tekstowego do rozpoznawania obrazów) spowoduje błędy.
+> **⚠️ Uwaga:** Te ustawienia są przeznaczone wyłącznie dla **doświadczonych użytkowników**. Jeśli nie wiesz, do czego służy dany model, zostaw tę opcję **odznaczoną**. Wybranie nieodpowiedniego modelu (np. modelu tekstowego dla zadań wizualnych) spowoduje błędy i zatrzyma działanie dodatku.
 
-Zaznacz **„Osobny model dla każdego zadania"**. Pozwala to wybrać konkretne modele z listy rozwijanej:
-- **Model dla OCR / rozpoznawania obrazów:** Model do analizy obrazów.
-- **Rozpoznawanie mowy (STT):** Model do dyktowania.
+Zaznacz **„Osobny model dla każdego zadania"**, aby uzyskać szczegółową kontrolę. Pozwala to wybrać konkretne modele z listy rozwijanej dla różnych zadań:
+- **Model dla OCR / rozpoznawania obrazów:** Wyspecjalizowany model do analizy obrazów.
+- **Rozpoznawanie mowy (STT):** Konkretny model do dyktowania.
 - **Synteza mowy (TTS):** Model do generowania audio.
+- **Model Operatora AI:** Konkretny model do zadań autonomicznego sterowania komputerem.
 *Uwaga: Nieobsługiwane funkcje (np. TTS dla Groq) zostaną automatycznie ukryte.*
 
 ### 1.3 Adresy usług (niestandardowy dostawca)
 *Dostępne tylko przy wybranym dostawcy „Niestandardowy".*
 
-> **⚠️ Uwaga:** Ta sekcja umożliwia ręczną konfigurację API i jest przeznaczona dla **użytkowników prowadzących lokalne serwery lub proxy**. Błędne adresy URL lub nazwy modeli uniemożliwią połączenie. Jeśli nie wiesz, do czego służą te pola, zostaw tę opcję **odznaczoną**.
+> **⚠️ Uwaga:** Ta sekcja umożliwia ręczną konfigurację API i jest przeznaczona dla **zaawansowanych użytkowników** prowadzących lokalne serwery lub proxy. Błędne adresy URL lub nazwy modeli uniemożliwią połączenie. Jeśli nie wiesz dokładnie, do czego służą te pola, zostaw tę opcję **odznaczoną**.
 
 Zaznacz **„Adresy usług"**, aby ręcznie podać dane serwera. W przeciwieństwie do natywnych dostawców, tutaj trzeba **wpisać** konkretne adresy URL i nazwy modeli:
 - **URL listy modeli:** Adres do pobrania dostępnych modeli.
@@ -37,8 +38,8 @@ Zaznacz **„Adresy usług"**, aby ręcznie podać dane serwera. W przeciwieńst
 - **Niestandardowe modele:** Wpisz ręcznie nazwę modelu (np. `llama3:8b`) dla każdego zadania.
 
 ### 1.4 Preferencje ogólne
-- **Silnik OCR:** Wybierz między **Chrome (szybki)** a **Gemini (formatowany)**, który lepiej zachowuje układ strony.
-    - *Uwaga:* Jeśli wybierzesz „Gemini (formatowany)", ale dostawcą jest np. OpenAI/Groq, dodatek automatycznie skieruje obraz do modelu rozpoznawania aktywnego dostawcy.
+- **Silnik OCR:** Wybierz między **Chrome (szybki)** dla błyskawicznych wyników a **AI (zaawansowany)** dla lepszego zachowania układu strony.
+    - *Uwaga:* Jeśli wybierzesz „AI (zaawansowany)", ale dostawcą jest OpenAI/Groq, dodatek inteligentnie skieruje obraz do modelu rozpoznawania obrazów aktywnego dostawcy.
 - **Głos TTS:** Wybierz preferowany styl głosu. Lista aktualizuje się automatycznie na podstawie aktywnego dostawcy.
 - **Kreatywność (temperatura):** Kontroluje losowość odpowiedzi AI. Niższe wartości są lepsze dla tłumaczenia i OCR.
 - **URL serwera proxy:** Skonfiguruj, jeśli usługi AI są ograniczone w twoim regionie (obsługuje lokalne proxy, np. `127.0.0.1`, oraz adresy pośredniczące).
@@ -49,23 +50,25 @@ Aby uniknąć konfliktów z innymi skrótami, dodatek korzysta z **warstwy polec
 1. Naciśnij **NVDA + Shift + V** (klawisz główny), aby aktywować warstwę (usłyszysz sygnał dźwiękowy).
 2. Puść klawisze, a następnie naciśnij jeden z poniższych:
 
-| Klawisz       | Funkcja                  | Opis                                                                        |
-|---------------|--------------------------|-----------------------------------------------------------------------------|
-| **T**         | Tłumacz                  | Tłumaczy tekst pod kursorem nawigatora lub zaznaczenie.                     |
-| **Shift + T** | Tłumaczenie schowka      | Tłumaczy zawartość schowka.                                                |
-| **R**         | Poprawianie tekstu       | Podsumuj, popraw gramatykę, wyjaśnij lub uruchom **niestandardowe polecenie**. |
-| **V**         | Opis obiektu             | Opisuje bieżący obiekt nawigatora.                                          |
-| **O**         | Rozpoznawanie ekranu     | Analizuje układ i zawartość całego ekranu.                                  |
-| **Shift + V** | Analiza wideo online     | Analizuj filmy z **YouTube**, **Instagrama**, **TikToka** lub **Twittera (X)**. |
-| **D**         | Czytnik dokumentów       | Czytnik PDF i obrazów z wyborem zakresu stron.                              |
-| **F**         | OCR pliku                | Rozpoznawanie tekstu z wybranego obrazu, PDF lub TIFF.                      |
-| **A**         | Transkrypcja audio       | Transkrybuje pliki MP3, WAV lub OGG na tekst.                              |
-| **C**         | Rozwiązywanie CAPTCHA    | Przechwytuje i rozwiązuje CAPTCHA.              |
-| **S**         | Dyktowanie               | Zamienia mowę na tekst. Naciśnij raz, aby nagrywać, ponownie, aby zakończyć.  |
-| **L**         | Raport stanu             | Odczytuje bieżący postęp (np. „Skanowanie...", „Bezczynny").               |
-| **U**         | Sprawdzanie aktualizacji | Ręcznie sprawdza najnowszą wersję dodatku na GitHubie.                     |
-| **Spacja**    | Ostatnia odpowiedź AI    | Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub kontynuacji. |
-| **H**         | Pomoc poleceń            | Wyświetla listę wszystkich dostępnych skrótów w warstwie poleceń.           |
+| Klawisz       | Funkcja                       | Opis                                                                        |
+|---------------|-------------------------------|-----------------------------------------------------------------------------|
+| **Shift + A** | **Operator AI**               | **Sterowanie autonomiczne:** Powiedz AI, aby wykonała zadanie na ekranie.   |
+| **E**         | **Eksplorator interfejsu**    | **Interaktywne klikanie:** Identyfikuje i klika elementy interfejsu w dowolnej aplikacji. |
+| **T**         | Tłumacz                       | Tłumaczy tekst pod kursorem nawigatora lub zaznaczenie.                     |
+| **Shift + T** | Tłumaczenie schowka           | Tłumaczy zawartość schowka.                                                 |
+| **R**         | Poprawianie tekstu            | Podsumuj, popraw gramatykę, wyjaśnij lub uruchom **niestandardowe polecenie**. |
+| **V**         | Opis obiektu                  | Opisuje bieżący obiekt nawigatora.                                          |
+| **O**         | Rozpoznawanie ekranu          | Analizuje układ i zawartość całego ekranu.                                  |
+| **Shift + V** | Analiza wideo online          | Analizuj filmy z **YouTube**, **Instagrama**, **TikToka** lub **Twittera (X)**. |
+| **D**         | Czytnik dokumentów            | Czytnik PDF i obrazów z wyborem zakresu stron.                              |
+| **F**         | **Inteligentna akcja na pliku** | Rozpoznawanie zależne od kontekstu z wybranego obrazu, PDF lub TIFF.      |
+| **A**         | Transkrypcja audio            | Transkrybuje pliki MP3, WAV lub OGG na tekst.                               |
+| **C**         | Rozwiązywanie CAPTCHA         | Przechwytuje i rozwiązuje CAPTCHA.                                          |
+| **S**         | Dyktowanie                    | Zamienia mowę na tekst. Naciśnij raz, aby nagrywać, ponownie, aby zakończyć. |
+| **L**         | Raport stanu                  | Odczytuje bieżący postęp (np. „Skanowanie...", „Bezczynny").                |
+| **U**         | Sprawdzanie aktualizacji      | Ręcznie sprawdza najnowszą wersję dodatku na GitHubie.                      |
+| **Spacja**    | Ostatnia odpowiedź AI         | Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub kontynuacji. |
+| **H**         | Pomoc poleceń                 | Wyświetla listę wszystkich dostępnych skrótów w warstwie poleceń.           |
 
 ### 2.1 Skróty czytnika dokumentów (wewnątrz przeglądarki)
 - **Ctrl + PageDown:** Przejdź do następnej strony.
@@ -98,6 +101,22 @@ Bądź na bieżąco z najnowszymi wiadomościami i aktualizacjami:
 - **GitHub Issues:** Zgłaszanie błędów i propozycje nowych funkcji.
 
 ---
+
+## Zmiany w wersji 5.5.2
+
+* **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w którym litera „v" była wpisywana zamiast wklejania tekstu na niektórych systemach. Poprawka usuwa konflikty czasowe występujące przy dużym obciążeniu systemu.
+* **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest tymczasowo zablokowany przez inne aplikacje.
+* **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami schowka.
+
+## Zmiany w wersji 5.5 (Aktualizacja automatyzacji)
+
+* **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.
+    * *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *"Kliknij przycisk Ustawienia"* lub *"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter."* AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.
+    * *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.
+    * **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi „widzieć" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.
+* **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po „nieoznaczonych przyciskach"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak „warstwa dostępności" nałożona na dowolną aplikację.
+* **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz „F" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.
+* **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla wszystkich użytkowników.
 
 ## Zmiany w wersji 5.0
 

--- a/addon/locale/pl/LC_MESSAGES/nvda.po
+++ b/addon/locale/pl/LC_MESSAGES/nvda.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 'VisionAssistant' '5.5'\n"
-"Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-05-02 15:19+0330\n"
+"Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
+"POT-Creation-Date: 2026-05-09 14:51+0200\n"
 "PO-Revision-Date: 2026-05-05 14:50+0200\n"
 "Last-Translator: Oliwia Sobczak <oliwia.sobczak@proton.me>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -22,45 +22,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. Translators: Label for the button to copy the TON cryptocurrency wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:18
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:18
 msgid "Copy TON Address"
 msgstr "Kopiuj adres TON"
 
 #. Translators: Label for the button to copy the USDT (TRC20 network) wallet address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:20
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:20
 msgid "Copy USDT (TRC20) Address"
 msgstr "Kopiuj adres USDT (TRC20)"
 
 #. Translators: Label for the button to copy the support email address for gift cards.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:22
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:22
 msgid "Copy Support Email"
 msgstr "Kopiuj adres e-mail wsparcia"
 
 #. Translators: Button to dismiss the donation dialog without taking any action.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:29
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:29
 msgid "Maybe Later"
 msgstr "Może później"
 
 #. Translators: Success message shown after an address or email is copied to the clipboard.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:40
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:40
 msgid "Copied to clipboard! Your support is greatly appreciated!"
 msgstr "Skopiowano do schowka! Twoje wsparcie jest bardzo ważne!"
 
 #. Translators: Title for the success message box.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:42
-#: addon\globalPlugins\visionAssistant\__init__.py:3486
-#: addon\globalPlugins\visionAssistant\__init__.py:3541
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:42
+#: addon/globalPlugins/visionAssistant/__init__.py:3695
+#: addon/globalPlugins/visionAssistant/__init__.py:3750
 msgid "Success"
 msgstr "Sukces"
 
 #. Translators: Title of the donation request dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:53
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:53
 #, python-brace-format
 msgid "Support the Future of {name}"
 msgstr "Wesprzyj przyszłość {name}"
 
 #. Translators: The main message of the donation dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:56
+#: addon/globalPlugins/visionAssistant/donate_dialog.py:56
 #, python-brace-format
 msgid ""
 "{name} is a project born from a personal vision to bridge the gap between AI "
@@ -102,131 +102,131 @@ msgstr ""
 "zaangażowania. Dziękuję, że jesteś częścią tej misji!"
 
 #. Translators: Label for prompt name input field.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:22
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:22
 msgid "Name:"
 msgstr "Nazwa:"
 
 #. Translators: Label for prompt text input field.
 #. Translators: Label above the prompt editor textarea.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:28
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:189
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:28
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:189
 msgid "Prompt Text:"
 msgstr "Treść Promptu:"
 
 #. Translators: Button label to open the variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:47
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:142
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:47
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:142
 msgid "Variables Guide"
 msgstr "Przewodnik po zmiennych"
 
 #. Translators: Validation error for empty prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:64
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:64
 msgid "Name cannot be empty."
 msgstr "Nazwa nie może być pusta."
 
 #. Translators: Title of validation warning dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:66
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:74
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:361
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:472
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:500
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:66
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:74
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:361
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:472
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:500
 msgid "Validation Error"
 msgstr "Błąd walidacji"
 
 #. Translators: Validation error for empty prompt text.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:72
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:359
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:72
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:359
 msgid "Prompt text cannot be empty."
 msgstr "Treść polecenia nie może być pusta."
 
 #. Translators: Title for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:95
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:95
 msgid "Prompt Variables Guide"
 msgstr "Przewodnik po zmiennych poleceń"
 
 #. Translators: Intro text for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:99
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:99
 msgid "Use these variables inside prompt text:"
 msgstr "Użyj tych zmiennych wewnątrz treści polecenia:"
 
 #. Translators: Button to close chat dialog
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:110
-#: addon\globalPlugins\visionAssistant\__init__.py:2044
-#: addon\globalPlugins\visionAssistant\__init__.py:3141
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:110
+#: addon/globalPlugins/visionAssistant/__init__.py:2154
+#: addon/globalPlugins/visionAssistant/__init__.py:3349
 msgid "Close"
 msgstr "Zamknij"
 
 #. Translators: Title for the prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:120
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:120
 msgid "Prompt Manager"
 msgstr "Menedżer poleceń"
 
 #. Translators: Notebook tab for built-in refine prompts.
 #. Translators: Label above the list of default prompt entries.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:132
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:166
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:132
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:166
 msgid "Default Prompts"
 msgstr "Polecenia domyślne"
 
 #. Translators: Notebook tab for user-defined prompts.
 #. Translators: Label above the list of custom prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:134
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:221
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:134
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:221
 msgid "Custom Prompts"
 msgstr "Polecenia niestandardowe"
 
 #. Translators: Note explaining when prompt changes are persisted.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:146
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:146
 msgid "Changes are applied only when you press OK."
 msgstr "Zmiany zostaną zastosowane dopiero po naciśnięciu OK."
 
 #. Translators: Button label to reset currently selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:178
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:178
 msgid "Reset Selected"
 msgstr "Resetuj wybrane"
 
 #. Translators: Button label to reset all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:183
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:183
 msgid "Reset All"
 msgstr "Resetuj wszystkie"
 
 #. Translators: Button label to apply current editor text to the selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:198
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:198
 msgid "Apply to Selected"
 msgstr "Zastosuj do wybranego"
 
 #. Translators: Button label for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:230
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:230
 msgid "Add"
 msgstr "Dodaj"
 
 #. Translators: Button label for editing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:232
 msgid "Edit"
 msgstr "Edytuj"
 
 #. Translators: Button label for removing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:234
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:234
 msgid "Remove"
 msgstr "Usuń"
 
 #. Translators: Button label for moving selected custom prompt up in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:245
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:245
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
 #. Translators: Button label for moving selected custom prompt down in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:247
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:247
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
 #. Translators: Label above the custom prompt preview area.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:256
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:256
 msgid "Prompt Preview:"
 msgstr "Podgląd polecenia:"
 
 #. Translators: Validation message shown when required text is missing in a guarded prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:318
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:318
 #, python-brace-format
 msgid ""
 "This prompt is used by {feature}. To save it, add the required text below:"
@@ -235,18 +235,18 @@ msgstr ""
 "wymagany tekst poniżej:"
 
 #. Translators: Guidance shown after listing missing required text.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:324
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:324
 msgid "Add these items exactly as written, then try again."
 msgstr ""
 "Dodaj te elementy dokładnie tak, jak podano, a następnie spróbuj ponownie."
 
 #. Translators: Title of validation warning dialog for guarded prompt checks.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:326
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:326
 msgid "Required Text Missing"
 msgstr "Brak wymaganego tekstu"
 
 #. Translators: Confirmation message shown before saving a guarded prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:337
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:337
 #, python-brace-format
 msgid ""
 "You are editing a prompt used by {feature}.\n"
@@ -262,517 +262,548 @@ msgstr ""
 "Czy rozumiesz ryzyko i mimo to chcesz zapisać?"
 
 #. Translators: Title of confirmation dialog shown before saving guarded prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:340
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:340
 msgid "Confirm"
 msgstr "Potwierdź"
 
 #. Translators: Confirm button label for guarded prompt save confirmation.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:344
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:344
 msgid "Yes, Save Anyway"
 msgstr "Tak, zapisz mimo to"
 
 #. Translators: Cancel button label for guarded prompt save confirmation.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:346
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:346
 msgid "No, Go Back"
 msgstr "Nie, wróć"
 
 #. Translators: Message shown after applying changes to the selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:395
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:395
 msgid "Selected prompt updated."
 msgstr "Wybrane polecenie zaktualizowane."
 
 #. Translators: Confirmation text before resetting all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:408
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:408
 msgid "Reset all default prompts to built-in values?"
 msgstr "Przywrócić wszystkie domyślne polecenia do wartości domyślnych?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:410
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:410
 msgid "Confirm Reset"
 msgstr "Potwierdź reset"
 
 #. Translators: Title of dialog for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:465
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:465
 msgid "Add Custom Prompt"
 msgstr "Dodaj polecenie niestandardowe"
 
 #. Translators: Validation error for duplicate custom prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:470
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:498
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:470
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:498
 msgid "A custom prompt with this name already exists."
 msgstr "Polecenie niestandardowe o tej nazwie już istnieje."
 
 #. Translators: Title of the dialog for editing an existing custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:489
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:489
 msgid "Edit Custom Prompt"
 msgstr "Edytuj polecenie niestandardowe"
 
 #. Translators: Confirmation text before deleting a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:513
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:513
 #, python-brace-format
 msgid "Remove custom prompt '{name}'?"
 msgstr "Usunąć polecenie niestandardowe \"{name}\"?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:515
+#: addon/globalPlugins/visionAssistant/prompt_manager_dialog.py:515
 msgid "Confirm Remove"
 msgstr "Potwierdź usunięcie"
 
 #. --- 1. Recommended (Auto-Updating) ---
 #. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest version.
-#: addon\globalPlugins\visionAssistant\__init__.py:68
-#: addon\globalPlugins\visionAssistant\__init__.py:69
+#: addon/globalPlugins/visionAssistant/__init__.py:77
+#: addon/globalPlugins/visionAssistant/__init__.py:78
 msgid "[Auto]"
 msgstr "[Auto]"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:68
-#: addon\globalPlugins\visionAssistant\__init__.py:69
+#: addon/globalPlugins/visionAssistant/__init__.py:77
+#: addon/globalPlugins/visionAssistant/__init__.py:78
 msgid "(Latest)"
 msgstr "(Najnowszy)"
 
 #. --- 2. Current Standard (Free & Fast) ---
 #. Translators: AI Model info. [Free] = Generous usage limits. (Preview) = Experimental or early-access version.
-#: addon\globalPlugins\visionAssistant\__init__.py:73
-#: addon\globalPlugins\visionAssistant\__init__.py:74
-#: addon\globalPlugins\visionAssistant\__init__.py:75
+#: addon/globalPlugins/visionAssistant/__init__.py:82
+#: addon/globalPlugins/visionAssistant/__init__.py:83
+#: addon/globalPlugins/visionAssistant/__init__.py:84
 msgid "[Free]"
 msgstr "[Darmowy]"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:73
-#: addon\globalPlugins\visionAssistant\__init__.py:79
+#: addon/globalPlugins/visionAssistant/__init__.py:82
+#: addon/globalPlugins/visionAssistant/__init__.py:88
 msgid "(Preview)"
 msgstr "(Podgląd)"
 
 #. --- 3. High Intelligence (Paid/Pro/Preview) ---
 #. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview) = Experimental version.
-#: addon\globalPlugins\visionAssistant\__init__.py:79
-#: addon\globalPlugins\visionAssistant\__init__.py:80
+#: addon/globalPlugins/visionAssistant/__init__.py:88
+#: addon/globalPlugins/visionAssistant/__init__.py:89
 msgid "[Pro]"
 msgstr "[Pro]"
 
 #. Translators: Adjective describing a bright AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:85
-#: addon\globalPlugins\visionAssistant\__init__.py:103
+#: addon/globalPlugins/visionAssistant/__init__.py:94
+#: addon/globalPlugins/visionAssistant/__init__.py:112
 msgid "Bright"
 msgstr "Jasny"
 
 #. Translators: Adjective describing an upbeat AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:87
-#: addon\globalPlugins\visionAssistant\__init__.py:121
+#: addon/globalPlugins/visionAssistant/__init__.py:96
+#: addon/globalPlugins/visionAssistant/__init__.py:130
 msgid "Upbeat"
 msgstr "Energiczny"
 
 #. Translators: Adjective describing an informative AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:89
-#: addon\globalPlugins\visionAssistant\__init__.py:119
+#: addon/globalPlugins/visionAssistant/__init__.py:98
+#: addon/globalPlugins/visionAssistant/__init__.py:128
 msgid "Informative"
 msgstr "Informacyjny"
 
 #. Translators: Adjective describing a firm AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:91
-#: addon\globalPlugins\visionAssistant\__init__.py:97
-#: addon\globalPlugins\visionAssistant\__init__.py:125
+#: addon/globalPlugins/visionAssistant/__init__.py:100
+#: addon/globalPlugins/visionAssistant/__init__.py:106
+#: addon/globalPlugins/visionAssistant/__init__.py:134
 msgid "Firm"
 msgstr "Stanowczy"
 
 #. Translators: Adjective describing an excitable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:93
+#: addon/globalPlugins/visionAssistant/__init__.py:102
 msgid "Excitable"
 msgstr "Entuzjastyczny"
 
 #. Translators: Adjective describing a youthful AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:95
+#: addon/globalPlugins/visionAssistant/__init__.py:104
 msgid "Youthful"
 msgstr "Młodzieńczy"
 
 #. Translators: Adjective describing a breezy AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:99
+#: addon/globalPlugins/visionAssistant/__init__.py:108
 msgid "Breezy"
 msgstr "Swobodny"
 
 #. Translators: Adjective describing an easy-going AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:101
-#: addon\globalPlugins\visionAssistant\__init__.py:109
+#: addon/globalPlugins/visionAssistant/__init__.py:110
+#: addon/globalPlugins/visionAssistant/__init__.py:118
 msgid "Easy-going"
 msgstr "Wyluzowany"
 
 #. Translators: Adjective describing a breathy AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:105
+#: addon/globalPlugins/visionAssistant/__init__.py:114
 msgid "Breathy"
 msgstr "Szeptany"
 
 #. Translators: Adjective describing a clear AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:107
-#: addon\globalPlugins\visionAssistant\__init__.py:115
-#: addon\globalPlugins\visionAssistant\__init__.py:165
+#: addon/globalPlugins/visionAssistant/__init__.py:116
+#: addon/globalPlugins/visionAssistant/__init__.py:124
+#: addon/globalPlugins/visionAssistant/__init__.py:174
 msgid "Clear"
 msgstr "Wyraźny"
 
 #. Translators: Adjective describing a smooth AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:111
-#: addon\globalPlugins\visionAssistant\__init__.py:113
+#: addon/globalPlugins/visionAssistant/__init__.py:120
+#: addon/globalPlugins/visionAssistant/__init__.py:122
 msgid "Smooth"
 msgstr "Łagodny"
 
 #. Translators: Adjective describing a gravelly AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:117
+#: addon/globalPlugins/visionAssistant/__init__.py:126
 msgid "Gravelly"
 msgstr "Chropowaty"
 
 #. Translators: Adjective describing a soft AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:123
+#: addon/globalPlugins/visionAssistant/__init__.py:132
 msgid "Soft"
 msgstr "Miękki"
 
 #. Translators: Adjective describing an even AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:127
+#: addon/globalPlugins/visionAssistant/__init__.py:136
 msgid "Even"
 msgstr "Równomierny"
 
 #. Translators: Adjective describing a mature AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:129
+#: addon/globalPlugins/visionAssistant/__init__.py:138
 msgid "Mature"
 msgstr "Dojrzały"
 
 #. Translators: Adjective describing a forward AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:131
+#: addon/globalPlugins/visionAssistant/__init__.py:140
 msgid "Forward"
 msgstr "Bezpośredni"
 
 #. Translators: Adjective describing a friendly AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:133
+#: addon/globalPlugins/visionAssistant/__init__.py:142
 msgid "Friendly"
 msgstr "Przyjacielski"
 
 #. Translators: Adjective describing a casual AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:135
+#: addon/globalPlugins/visionAssistant/__init__.py:144
 msgid "Casual"
 msgstr "Swobodny"
 
 #. Translators: Adjective describing a gentle AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:137
-#: addon\globalPlugins\visionAssistant\__init__.py:163
+#: addon/globalPlugins/visionAssistant/__init__.py:146
+#: addon/globalPlugins/visionAssistant/__init__.py:172
 msgid "Gentle"
 msgstr "Delikatny"
 
 #. Translators: Adjective describing a lively AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:139
+#: addon/globalPlugins/visionAssistant/__init__.py:148
 msgid "Lively"
 msgstr "Żywiołowy"
 
 #. Translators: Adjective describing a knowledgeable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:141
+#: addon/globalPlugins/visionAssistant/__init__.py:150
 msgid "Knowledgeable"
 msgstr "Kompetentny"
 
 #. Translators: Adjective describing a warm AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:143
+#: addon/globalPlugins/visionAssistant/__init__.py:152
 msgid "Warm"
 msgstr "Ciepły"
 
 #. Translators: Adjective describing a neutral AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:147
+#: addon/globalPlugins/visionAssistant/__init__.py:156
 msgid "Neutral"
 msgstr "Neutralny"
 
 #. Translators: Adjective describing a quirky AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:149
+#: addon/globalPlugins/visionAssistant/__init__.py:158
 msgid "Quirky"
 msgstr "Ekscentryczny"
 
 #. Translators: Adjective describing a professional AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:151
+#: addon/globalPlugins/visionAssistant/__init__.py:160
 msgid "Professional"
 msgstr "Profesjonalny"
 
 #. Translators: Adjective describing a cheerful AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:153
+#: addon/globalPlugins/visionAssistant/__init__.py:162
 msgid "Cheerful"
 msgstr "Radosny"
 
 #. Translators: Adjective describing a confident AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:155
+#: addon/globalPlugins/visionAssistant/__init__.py:164
 msgid "Confident"
 msgstr "Pewny siebie"
 
 #. Translators: Adjective describing a British AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:157
+#: addon/globalPlugins/visionAssistant/__init__.py:166
 msgid "British"
 msgstr "Brytyjski"
 
 #. Translators: Adjective describing a pleasant AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:159
+#: addon/globalPlugins/visionAssistant/__init__.py:168
 msgid "Pleasant"
 msgstr "Przyjemny"
 
 #. Translators: Adjective describing a deep AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:161
+#: addon/globalPlugins/visionAssistant/__init__.py:170
 msgid "Deep"
 msgstr "Głęboki"
 
 #. Translators: Adjective describing an expressive AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:167
+#: addon/globalPlugins/visionAssistant/__init__.py:176
 msgid "Expressive"
 msgstr "Ekspresyjny"
 
 #. Translators: Adjective describing a reliable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:169
+#: addon/globalPlugins/visionAssistant/__init__.py:178
 msgid "Reliable"
 msgstr "Niezawodny"
 
 #. Translators: Adjective describing an energetic AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:171
+#: addon/globalPlugins/visionAssistant/__init__.py:180
 msgid "Energetic"
 msgstr "Energiczny"
 
+#: addon/globalPlugins/visionAssistant/__init__.py:202
+msgid "Auto-detect"
+msgstr "Wykryj automatycznie"
+
 #. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\__init__.py:192
+#: addon/globalPlugins/visionAssistant/__init__.py:210
 msgid "Chrome (Fast)"
 msgstr "Chrome (szybki)"
 
 #. Translators: OCR Engine option (Slower but better formatting/AI-driven)
-#: addon\globalPlugins\visionAssistant\__init__.py:194
+#: addon/globalPlugins/visionAssistant/__init__.py:212
 msgid "AI (Advanced)"
 msgstr "AI (zaawansowany)"
 
 #. Translators: Section header for text refinement prompts in Prompt Manager.
 #. Translators: main message of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:274
-#: addon\globalPlugins\visionAssistant\__init__.py:282
-#: addon\globalPlugins\visionAssistant\__init__.py:290
-#: addon\globalPlugins\visionAssistant\__init__.py:298
-#: addon\globalPlugins\visionAssistant\__init__.py:4235
+#: addon/globalPlugins/visionAssistant/__init__.py:298
+#: addon/globalPlugins/visionAssistant/__init__.py:306
+#: addon/globalPlugins/visionAssistant/__init__.py:314
+#: addon/globalPlugins/visionAssistant/__init__.py:322
+#: addon/globalPlugins/visionAssistant/__init__.py:4424
 msgid "Refine"
 msgstr "Poprawianie"
 
 #. Translators: Label for the text summarization prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:276
+#: addon/globalPlugins/visionAssistant/__init__.py:300
 msgid "Summarize"
 msgstr "Podsumuj"
 
 #. Translators: Label for the grammar correction prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:284
+#: addon/globalPlugins/visionAssistant/__init__.py:308
 msgid "Fix Grammar"
 msgstr "Popraw gramatykę"
 
 #. Translators: Label for the grammar correction and translation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:292
+#: addon/globalPlugins/visionAssistant/__init__.py:316
 msgid "Fix Grammar & Translate"
 msgstr "Popraw gramatykę i przetłumacz"
 
 #. Translators: Label for the text explanation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:300
+#: addon/globalPlugins/visionAssistant/__init__.py:324
 msgid "Explain"
 msgstr "Wyjaśnij"
 
 #. Translators: Section header for translation-related prompts in Prompt Manager.
 #. Translators: Box title for translation options
-#: addon\globalPlugins\visionAssistant\__init__.py:306
-#: addon\globalPlugins\visionAssistant\__init__.py:318
-#: addon\globalPlugins\visionAssistant\__init__.py:2890
+#: addon/globalPlugins/visionAssistant/__init__.py:330
+#: addon/globalPlugins/visionAssistant/__init__.py:342
+#: addon/globalPlugins/visionAssistant/__init__.py:3090
 msgid "Translation"
 msgstr "Tłumaczenie"
 
 #. Translators: Label for the smart translation prompt.
 #. Translators: Feature name used in guarded prompt warnings for smart translation.
-#: addon\globalPlugins\visionAssistant\__init__.py:308
-#: addon\globalPlugins\visionAssistant\__init__.py:311
+#: addon/globalPlugins/visionAssistant/__init__.py:332
+#: addon/globalPlugins/visionAssistant/__init__.py:335
 msgid "Smart Translation"
 msgstr "tłumaczenie"
 
 #. Translators: Label for the quick translation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:320
+#: addon/globalPlugins/visionAssistant/__init__.py:344
 msgid "Quick Translation"
 msgstr "szybkie Tłumaczenie"
 
 #. Translators: Section header for document-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:326
-#: addon\globalPlugins\visionAssistant\__init__.py:447
+#: addon/globalPlugins/visionAssistant/__init__.py:350
+#: addon/globalPlugins/visionAssistant/__init__.py:471
 msgid "Document"
 msgstr "Dokument"
 
 #. Translators: Label for the initial context prompt in document chat.
-#: addon\globalPlugins\visionAssistant\__init__.py:328
+#: addon/globalPlugins/visionAssistant/__init__.py:352
 msgid "Document Chat Context"
 msgstr "Kontekst czatu z dokumentem"
 
 #. Translators: Section header for image analysis prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:341
-#: addon\globalPlugins\visionAssistant\__init__.py:355
+#. Translators: Section header for UI Explorer prompts in the Prompt Manager dialog.
+#. Translators: Section header for AI Operator prompts in the Prompt Manager dialog.
+#: addon/globalPlugins/visionAssistant/__init__.py:365
+#: addon/globalPlugins/visionAssistant/__init__.py:379
+#: addon/globalPlugins/visionAssistant/__init__.py:505
+#: addon/globalPlugins/visionAssistant/__init__.py:524
 msgid "Vision"
 msgstr "Rozpoznawanie"
 
 #. Translators: Label for the prompt used to analyze the current navigator object.
-#: addon\globalPlugins\visionAssistant\__init__.py:343
+#: addon/globalPlugins/visionAssistant/__init__.py:367
 msgid "Navigator Object Analysis"
 msgstr "Analiza obiektu nawigatora"
 
 #. Translators: Label for the prompt used to analyze the entire screen.
-#: addon\globalPlugins\visionAssistant\__init__.py:357
+#: addon/globalPlugins/visionAssistant/__init__.py:381
 msgid "Full Screen Analysis"
 msgstr "Analiza pełnego ekranu"
 
 #. Translators: Section header for video analysis prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:383
+#: addon/globalPlugins/visionAssistant/__init__.py:407
 msgid "Video"
 msgstr "Wideo"
 
 #. Translators: Label for the video content analysis prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:385
+#: addon/globalPlugins/visionAssistant/__init__.py:409
 msgid "Video Analysis"
 msgstr "Analiza wideo"
 
 #. Translators: Section header for audio-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:395
-#: addon\globalPlugins\visionAssistant\__init__.py:403
+#: addon/globalPlugins/visionAssistant/__init__.py:419
+#: addon/globalPlugins/visionAssistant/__init__.py:427
 msgid "Audio"
 msgstr "Audio"
 
 #. Translators: Label for the audio file transcription prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:397
+#: addon/globalPlugins/visionAssistant/__init__.py:421
 msgid "Audio Transcription"
 msgstr "Transkrypcja audio"
 
 #. Translators: Label for the smart voice dictation prompt.
 #. Translators: Feature name used in guarded prompt warnings for smart dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:405
-#: addon\globalPlugins\visionAssistant\__init__.py:408
+#: addon/globalPlugins/visionAssistant/__init__.py:429
+#: addon/globalPlugins/visionAssistant/__init__.py:432
 msgid "Smart Dictation"
 msgstr "dyktowanie"
 
 #. Translators: Section header for OCR-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:418
-#: addon\globalPlugins\visionAssistant\__init__.py:430
+#: addon/globalPlugins/visionAssistant/__init__.py:442
+#: addon/globalPlugins/visionAssistant/__init__.py:454
 msgid "OCR"
 msgstr "OCR"
 
 #. Translators: Label for the OCR prompt used for image text extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:420
+#: addon/globalPlugins/visionAssistant/__init__.py:444
 msgid "OCR Image Extraction"
 msgstr "Wyodrębnianie tekstu z obrazu (OCR)"
 
 #. Translators: Label for the OCR prompt used for document text extraction.
 #. Translators: Feature name used in guarded prompt warnings for OCR document extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:432
-#: addon\globalPlugins\visionAssistant\__init__.py:435
+#: addon/globalPlugins/visionAssistant/__init__.py:456
+#: addon/globalPlugins/visionAssistant/__init__.py:459
 msgid "OCR Document Extraction"
 msgstr "Wyodrębnianie tekstu z dokumentu (OCR)"
 
 #. Translators: Label for the combined OCR and translation prompt for documents.
-#: addon\globalPlugins\visionAssistant\__init__.py:449
+#: addon/globalPlugins/visionAssistant/__init__.py:473
 msgid "Document OCR + Translate"
 msgstr "OCR dokumentu + tłumaczenie"
 
 #. Translators: Section header for CAPTCHA-related prompts in Prompt Manager.
 #. --- CAPTCHA Group ---
-#: addon\globalPlugins\visionAssistant\__init__.py:459
-#: addon\globalPlugins\visionAssistant\__init__.py:2429
+#: addon/globalPlugins/visionAssistant/__init__.py:483
+#: addon/globalPlugins/visionAssistant/__init__.py:2562
 msgid "CAPTCHA"
 msgstr "CAPTCHA"
 
 #. Translators: Label for the CAPTCHA solving prompt.
 #. Translators: Feature name used in guarded prompt warnings for CAPTCHA solver.
-#: addon\globalPlugins\visionAssistant\__init__.py:461
-#: addon\globalPlugins\visionAssistant\__init__.py:464
+#: addon/globalPlugins/visionAssistant/__init__.py:485
+#: addon/globalPlugins/visionAssistant/__init__.py:488
 msgid "CAPTCHA Solver"
 msgstr "Rozwiązywanie CAPTCHA"
 
+#. Translators: Label for the UI Explorer system instruction prompt in the Prompt Manager.
+#: addon/globalPlugins/visionAssistant/__init__.py:507
+msgid "UI Explorer Instruction"
+msgstr "Instrukcja Eksploratora interfejsu"
+
+#. Translators: Feature name shown in the warning dialog when a user tries to eid the UI Explorer prompt.
+#: addon/globalPlugins/visionAssistant/__init__.py:510
+msgid "UI Explorer"
+msgstr "Eksplorator interfejsu"
+
+#. Translators: Label for the AI Operator system instruction prompt in the Prompt Manager.
+#: addon/globalPlugins/visionAssistant/__init__.py:526
+msgid "AI Operator Instruction"
+msgstr "Instrukcja Operatora AI"
+
+#. Translators: Feature name shown in the warning dialog when a user tries to edit the AI Operator prompt.
+#: addon/globalPlugins/visionAssistant/__init__.py:529
+#: addon/globalPlugins/visionAssistant/__init__.py:5532
+msgid "AI Operator"
+msgstr "Operator AI"
+
 #. Translators: Description and input type for the [selection] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:482
+#: addon/globalPlugins/visionAssistant/__init__.py:545
 msgid "Currently selected text"
 msgstr "Aktualnie zaznaczony tekst"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:482
-#: addon\globalPlugins\visionAssistant\__init__.py:484
+#: addon/globalPlugins/visionAssistant/__init__.py:545
+#: addon/globalPlugins/visionAssistant/__init__.py:547
 msgid "Text"
 msgstr "Tekst"
 
 #. Translators: Description for the [clipboard] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:484
+#: addon/globalPlugins/visionAssistant/__init__.py:547
 msgid "Clipboard content"
 msgstr "Zawartość schowka"
 
 #. Translators: Description and input type for the [screen_obj] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:486
+#: addon/globalPlugins/visionAssistant/__init__.py:549
 msgid "Screenshot of the navigator object"
 msgstr "Zrzut ekranu obiektu nawigatora"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:486
-#: addon\globalPlugins\visionAssistant\__init__.py:488
+#: addon/globalPlugins/visionAssistant/__init__.py:549
+#: addon/globalPlugins/visionAssistant/__init__.py:551
 msgid "Image"
 msgstr "Obraz"
 
 #. Translators: Description for the [screen_full] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:488
+#: addon/globalPlugins/visionAssistant/__init__.py:551
 msgid "Screenshot of the entire screen"
 msgstr "Zrzut całego ekranu"
 
 #. Translators: Description and input type for the [file_ocr] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:490
+#: addon/globalPlugins/visionAssistant/__init__.py:553
 msgid "Select image/PDF/TIFF for text extraction"
 msgstr "Wybierz obraz/PDF/TIFF do wyodrębnienia tekstu"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:490
+#: addon/globalPlugins/visionAssistant/__init__.py:553
 msgid "Image, PDF, TIFF"
 msgstr "Obraz, PDF, TIFF"
 
 #. Translators: Description and input type for the [file_read] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:492
+#: addon/globalPlugins/visionAssistant/__init__.py:555
 msgid "Select document for reading"
 msgstr "Wybierz dokument do odczytu"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:492
+#: addon/globalPlugins/visionAssistant/__init__.py:555
 msgid "TXT, Code, PDF"
 msgstr "TXT, kod, PDF"
 
 #. Translators: Description and input type for the [file_audio] variable in the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:494
+#: addon/globalPlugins/visionAssistant/__init__.py:557
 msgid "Select audio file for analysis"
 msgstr "Wybierz plik audio do analizy"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:494
+#: addon/globalPlugins/visionAssistant/__init__.py:557
 msgid "MP3, WAV, OGG"
 msgstr "MP3, WAV, OGG"
 
 #. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\__init__.py:782
+#: addon/globalPlugins/visionAssistant/__init__.py:845
 msgid "Custom: "
 msgstr "Niestandardowe: "
 
 #. Translators: Title of the error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:879
+#: addon/globalPlugins/visionAssistant/__init__.py:942
 #, python-brace-format
 msgid "{name} Error"
 msgstr "Błąd {name}"
 
 #. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\__init__.py:1177
+#: addon/globalPlugins/visionAssistant/__init__.py:1239
 msgid "Error 400: Bad Request (Check API Key)"
 msgstr "Błąd 400: nieprawidłowe żądanie (sprawdź klucz API)"
 
 #. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\__init__.py:1179
+#: addon/globalPlugins/visionAssistant/__init__.py:1241
 msgid "Error 403: Forbidden (Check Region)"
 msgstr "Błąd 403: dostęp zabroniony (sprawdź region)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1222
-#: addon\globalPlugins\visionAssistant\__init__.py:1429
+#: addon/globalPlugins/visionAssistant/__init__.py:1284
+#: addon/globalPlugins/visionAssistant/__init__.py:1504
 msgid "Error 429: Quota Exceeded (Try later)"
 msgstr "Błąd 429: przekroczono limit (spróbuj później)"
 
 #. Translators: Message of a dialog which may pop up while performing an AI call
-#: addon\globalPlugins\visionAssistant\__init__.py:1225
-#: addon\globalPlugins\visionAssistant\__init__.py:1432
+#: addon/globalPlugins/visionAssistant/__init__.py:1287
+#: addon/globalPlugins/visionAssistant/__init__.py:1507
 #, python-brace-format
 msgid "Server Error {code}: {reason}"
 msgstr "Błąd serwera {code}: {reason}"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1290
+#. Translators: Error prefix shown when the AI response is blocked by safety filters.
+#: addon/globalPlugins/visionAssistant/__init__.py:1342
 msgid "Blocked by AI Safety Filters: "
 msgstr "Zablokowane przez filtry bezpieczeństwa AI: "
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1291
+#. Translators: Generic error message when Gemini returns an empty response.
+#: addon/globalPlugins/visionAssistant/__init__.py:1344
 msgid ""
 "AI failed to provide a response. This might be due to safety filters or a "
 "temporary server issue."
@@ -780,163 +811,166 @@ msgstr ""
 "AI nie zwróciła odpowiedzi. Powodem mogą być filtry bezpieczeństwa lub "
 "chwilowy problem serwera."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1300
+#. Translators: Error shown when the AI response is blocked during generation.
+#: addon/globalPlugins/visionAssistant/__init__.py:1352
 msgid "The response was blocked mid-generation by safety filters."
 msgstr "Filtry bezpieczeństwa zablokowały odpowiedź w trakcie generowania."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1301
+#. Translators: Error shown when the response structure is unexpected or empty.
+#: addon/globalPlugins/visionAssistant/__init__.py:1354
 msgid "AI returned an empty response structure."
 msgstr "AI zwróciła pustą strukturę odpowiedzi."
 
 #. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:1310
-#: addon\globalPlugins\visionAssistant\__init__.py:1693
-#: addon\globalPlugins\visionAssistant\__init__.py:1788
-#: addon\globalPlugins\visionAssistant\__init__.py:1833
-#: addon\globalPlugins\visionAssistant\__init__.py:3278
-#: addon\globalPlugins\visionAssistant\__init__.py:3396
+#: addon/globalPlugins/visionAssistant/__init__.py:1362
+#: addon/globalPlugins/visionAssistant/__init__.py:1828
+#: addon/globalPlugins/visionAssistant/__init__.py:1899
+#: addon/globalPlugins/visionAssistant/__init__.py:1943
+#: addon/globalPlugins/visionAssistant/__init__.py:3486
+#: addon/globalPlugins/visionAssistant/__init__.py:3604
 msgid "No API Keys configured."
 msgstr "Nie skonfigurowano kluczy API."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1327
+#: addon/globalPlugins/visionAssistant/__init__.py:1379
 msgid "All API Keys failed (Quota/Server)."
 msgstr "Wszystkie klucze API zawiodły (limit/serwer)."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1333
+#. Translators: Generic error message when an operation fails for an unknown reason.
+#: addon/globalPlugins/visionAssistant/__init__.py:1386
 msgid "Unknown error occurred."
 msgstr "Wystąpił nieznany błąd."
 
 #. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\__init__.py:1368
+#: addon/globalPlugins/visionAssistant/__init__.py:1420
 msgid "No API Keys."
 msgstr "Brak kluczy API."
 
 #. Translators: Error message for upload failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1409
-#: addon\globalPlugins\visionAssistant\__init__.py:2978
+#: addon/globalPlugins/visionAssistant/__init__.py:1483
+#: addon/globalPlugins/visionAssistant/__init__.py:3178
 msgid "Upload failed."
 msgstr "Przesyłanie nie powiodło się."
 
 #. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:1439
+#: addon/globalPlugins/visionAssistant/__init__.py:1512
 msgid "All keys failed."
 msgstr "Wszystkie klucze zawiodły."
 
 #. Translators: Error message when speech-to-text fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1820
+#: addon/globalPlugins/visionAssistant/__init__.py:1930
 msgid "Transcription Failed"
 msgstr "Transkrypcja nie powiodła się"
 
 #. Translators: Error message when TTS is not supported by the provider
-#: addon\globalPlugins\visionAssistant\__init__.py:1826
+#: addon/globalPlugins/visionAssistant/__init__.py:1936
 msgid "TTS is not supported by this provider."
 msgstr "Ten dostawca nie obsługuje syntezy mowy."
 
 #. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:1875
+#: addon/globalPlugins/visionAssistant/__init__.py:1985
 msgid "Update Available"
 msgstr "Dostępna jest aktualizacja"
 
 #. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\__init__.py:1882
+#: addon/globalPlugins/visionAssistant/__init__.py:1992
 #, python-brace-format
 msgid "A new version ({version}) of {name} is available."
 msgstr "Dostępna jest nowa wersja ({version}) dodatku {name}."
 
 #. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\__init__.py:1887
+#: addon/globalPlugins/visionAssistant/__init__.py:1997
 msgid "Changes:"
 msgstr "Zmiany:"
 
 #. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\__init__.py:1894
+#: addon/globalPlugins/visionAssistant/__init__.py:2004
 msgid "Download and Install?"
 msgstr "Pobrać i zainstalować?"
 
 #. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\__init__.py:1899
+#: addon/globalPlugins/visionAssistant/__init__.py:2009
 msgid "&Yes"
 msgstr "&Tak"
 
 #. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\__init__.py:1901
+#: addon/globalPlugins/visionAssistant/__init__.py:2011
 msgid "&No"
 msgstr "&Nie"
 
 #. Translators: Error message when an update is found but the addon file is missing from GitHub.
-#: addon\globalPlugins\visionAssistant\__init__.py:1943
+#: addon/globalPlugins/visionAssistant/__init__.py:2053
 msgid "Update found but no .nvda-addon file in release."
 msgstr "Znaleziono aktualizację, ale brak pliku .nvda-addon w wydaniu."
 
 #. Translators: Status message informing the user they are already on the latest version.
-#: addon\globalPlugins\visionAssistant\__init__.py:1947
+#: addon/globalPlugins/visionAssistant/__init__.py:2057
 msgid "You have the latest version."
 msgstr "Masz najnowszą wersję."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:1951
+#: addon/globalPlugins/visionAssistant/__init__.py:2061
 #, python-brace-format
 msgid "Update check failed: {error}"
 msgstr "Sprawdzanie aktualizacji nie powiodło się: {error}"
 
 #. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\__init__.py:1974
+#: addon/globalPlugins/visionAssistant/__init__.py:2084
 msgid "Downloading update..."
 msgstr "Pobieranie aktualizacji..."
 
 #. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\__init__.py:1983
+#: addon/globalPlugins/visionAssistant/__init__.py:2093
 #, python-brace-format
 msgid "Download failed: {error}"
 msgstr "Pobieranie nie powiodło się: {error}"
 
 #. Translators: Label for the AI response text area in a chat dialog
 #. Translators: Label for AI Response Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2003
-#: addon\globalPlugins\visionAssistant\__init__.py:2398
+#: addon/globalPlugins/visionAssistant/__init__.py:2113
+#: addon/globalPlugins/visionAssistant/__init__.py:2531
 msgid "AI Response:"
 msgstr "Odpowiedź AI:"
 
 #. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2013
-#: addon\globalPlugins\visionAssistant\__init__.py:2107
-#: addon\globalPlugins\visionAssistant\__init__.py:2124
+#: addon/globalPlugins/visionAssistant/__init__.py:2123
+#: addon/globalPlugins/visionAssistant/__init__.py:2217
+#: addon/globalPlugins/visionAssistant/__init__.py:2234
 #, python-brace-format
 msgid "AI: {text}\n"
 msgstr "AI: {text}\n"
 
 #. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2024
+#: addon/globalPlugins/visionAssistant/__init__.py:2134
 msgid "Ask:"
 msgstr "Zapytaj:"
 
 #. Translators: Button to send message in a chat dialog
 #. Translators: Button to send message
-#: addon\globalPlugins\visionAssistant\__init__.py:2034
-#: addon\globalPlugins\visionAssistant\__init__.py:2957
+#: addon/globalPlugins/visionAssistant/__init__.py:2144
+#: addon/globalPlugins/visionAssistant/__init__.py:3157
 msgid "Send"
 msgstr "Wyślij"
 
 #. Translators: Button to view the content in a formatted HTML window
 #. Translators: Button to view formatted content
-#: addon\globalPlugins\visionAssistant\__init__.py:2036
-#: addon\globalPlugins\visionAssistant\__init__.py:3110
+#: addon/globalPlugins/visionAssistant/__init__.py:2146
+#: addon/globalPlugins/visionAssistant/__init__.py:3318
 msgid "View Formatted"
 msgstr "Podgląd sformatowany"
 
 #. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:2039
+#: addon/globalPlugins/visionAssistant/__init__.py:2149
 msgid "Save Content"
 msgstr "Zapisz treść odpowiedzi"
 
 #. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2042
+#: addon/globalPlugins/visionAssistant/__init__.py:2152
 msgid "Save Chat"
 msgstr "Zapisz pełny czat"
 
 #. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2077
-#: addon\globalPlugins\visionAssistant\__init__.py:2122
+#: addon/globalPlugins/visionAssistant/__init__.py:2187
+#: addon/globalPlugins/visionAssistant/__init__.py:2232
 #, python-brace-format
 msgid ""
 "\n"
@@ -947,888 +981,925 @@ msgstr ""
 
 #. Translators: Message shown while processing in a chat dialog
 #. Translators: Message showing AI is thinking
-#: addon\globalPlugins\visionAssistant\__init__.py:2081
-#: addon\globalPlugins\visionAssistant\__init__.py:3005
+#: addon/globalPlugins/visionAssistant/__init__.py:2191
+#: addon/globalPlugins/visionAssistant/__init__.py:3205
 msgid "Thinking..."
 msgstr "Przetwarzanie..."
 
 #. Translators: Initial status when the add-on is doing nothing
 #. Translators: Status message when the add-on is doing nothing
 #. Translators: Initial status when the add-on is doing nothing
-#: addon\globalPlugins\visionAssistant\__init__.py:2092
-#: addon\globalPlugins\visionAssistant\__init__.py:3014
-#: addon\globalPlugins\visionAssistant\__init__.py:3030
-#: addon\globalPlugins\visionAssistant\__init__.py:3044
-#: addon\globalPlugins\visionAssistant\__init__.py:3350
-#: addon\globalPlugins\visionAssistant\__init__.py:3384
-#: addon\globalPlugins\visionAssistant\__init__.py:3451
-#: addon\globalPlugins\visionAssistant\__init__.py:3469
-#: addon\globalPlugins\visionAssistant\__init__.py:3483
-#: addon\globalPlugins\visionAssistant\__init__.py:3489
-#: addon\globalPlugins\visionAssistant\__init__.py:3560
-#: addon\globalPlugins\visionAssistant\__init__.py:3763
-#: addon\globalPlugins\visionAssistant\__init__.py:4020
-#: addon\globalPlugins\visionAssistant\__init__.py:4025
-#: addon\globalPlugins\visionAssistant\__init__.py:4029
-#: addon\globalPlugins\visionAssistant\__init__.py:4035
-#: addon\globalPlugins\visionAssistant\__init__.py:4042
-#: addon\globalPlugins\visionAssistant\__init__.py:4094
-#: addon\globalPlugins\visionAssistant\__init__.py:4105
-#: addon\globalPlugins\visionAssistant\__init__.py:4110
-#: addon\globalPlugins\visionAssistant\__init__.py:4416
-#: addon\globalPlugins\visionAssistant\__init__.py:4420
-#: addon\globalPlugins\visionAssistant\__init__.py:4540
-#: addon\globalPlugins\visionAssistant\__init__.py:4568
-#: addon\globalPlugins\visionAssistant\__init__.py:4586
-#: addon\globalPlugins\visionAssistant\__init__.py:4596
-#: addon\globalPlugins\visionAssistant\__init__.py:4715
-#: addon\globalPlugins\visionAssistant\__init__.py:4718
-#: addon\globalPlugins\visionAssistant\__init__.py:4722
-#: addon\globalPlugins\visionAssistant\__init__.py:4889
-#: addon\globalPlugins\visionAssistant\__init__.py:4904
-#: addon\globalPlugins\visionAssistant\__init__.py:4908
-#: addon\globalPlugins\visionAssistant\__init__.py:4913
-#: addon\globalPlugins\visionAssistant\__init__.py:4952
-#: addon\globalPlugins\visionAssistant\__init__.py:4963
-#: addon\globalPlugins\visionAssistant\__init__.py:4989
-#: addon\globalPlugins\visionAssistant\__init__.py:5000
-#: addon\globalPlugins\visionAssistant\__init__.py:5038
-#: addon\globalPlugins\visionAssistant\__init__.py:5044
-#: addon\globalPlugins\visionAssistant\__init__.py:5082
-#: addon\globalPlugins\visionAssistant\__init__.py:5085
-#: addon\globalPlugins\visionAssistant\__init__.py:5093
+#: addon/globalPlugins/visionAssistant/__init__.py:2202
+#: addon/globalPlugins/visionAssistant/__init__.py:3215
+#: addon/globalPlugins/visionAssistant/__init__.py:3238
+#: addon/globalPlugins/visionAssistant/__init__.py:3252
+#: addon/globalPlugins/visionAssistant/__init__.py:3558
+#: addon/globalPlugins/visionAssistant/__init__.py:3592
+#: addon/globalPlugins/visionAssistant/__init__.py:3660
+#: addon/globalPlugins/visionAssistant/__init__.py:3678
+#: addon/globalPlugins/visionAssistant/__init__.py:3692
+#: addon/globalPlugins/visionAssistant/__init__.py:3698
+#: addon/globalPlugins/visionAssistant/__init__.py:3774
+#: addon/globalPlugins/visionAssistant/__init__.py:3979
+#: addon/globalPlugins/visionAssistant/__init__.py:4209
+#: addon/globalPlugins/visionAssistant/__init__.py:4214
+#: addon/globalPlugins/visionAssistant/__init__.py:4218
+#: addon/globalPlugins/visionAssistant/__init__.py:4224
+#: addon/globalPlugins/visionAssistant/__init__.py:4231
+#: addon/globalPlugins/visionAssistant/__init__.py:4283
+#: addon/globalPlugins/visionAssistant/__init__.py:4294
+#: addon/globalPlugins/visionAssistant/__init__.py:4299
+#: addon/globalPlugins/visionAssistant/__init__.py:4605
+#: addon/globalPlugins/visionAssistant/__init__.py:4609
+#: addon/globalPlugins/visionAssistant/__init__.py:4767
+#: addon/globalPlugins/visionAssistant/__init__.py:4795
+#: addon/globalPlugins/visionAssistant/__init__.py:4813
+#: addon/globalPlugins/visionAssistant/__init__.py:4823
+#: addon/globalPlugins/visionAssistant/__init__.py:4942
+#: addon/globalPlugins/visionAssistant/__init__.py:4945
+#: addon/globalPlugins/visionAssistant/__init__.py:4949
+#: addon/globalPlugins/visionAssistant/__init__.py:4971
+#: addon/globalPlugins/visionAssistant/__init__.py:4975
+#: addon/globalPlugins/visionAssistant/__init__.py:5081
+#: addon/globalPlugins/visionAssistant/__init__.py:5096
+#: addon/globalPlugins/visionAssistant/__init__.py:5100
+#: addon/globalPlugins/visionAssistant/__init__.py:5105
+#: addon/globalPlugins/visionAssistant/__init__.py:5144
+#: addon/globalPlugins/visionAssistant/__init__.py:5155
+#: addon/globalPlugins/visionAssistant/__init__.py:5184
+#: addon/globalPlugins/visionAssistant/__init__.py:5195
+#: addon/globalPlugins/visionAssistant/__init__.py:5233
+#: addon/globalPlugins/visionAssistant/__init__.py:5240
+#: addon/globalPlugins/visionAssistant/__init__.py:5275
+#: addon/globalPlugins/visionAssistant/__init__.py:5279
+#: addon/globalPlugins/visionAssistant/__init__.py:5288
+#: addon/globalPlugins/visionAssistant/__init__.py:5609
 msgid "Idle"
 msgstr "Bezczynny"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:2144
+#: addon/globalPlugins/visionAssistant/__init__.py:2254
 msgid "Formatted Conversation"
 msgstr "Sformatowana rozmowa"
 
 #. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:2147
+#: addon/globalPlugins/visionAssistant/__init__.py:2257
 #, python-brace-format
 msgid "Error displaying content: {error}"
 msgstr "Błąd wyświetlania treści: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:2152
+#: addon/globalPlugins/visionAssistant/__init__.py:2262
 msgid "Save Chat Log"
 msgstr "Zapisz dziennik czatu"
 
 #. Translators: Message shown on successful save of a file.
 #. Translators: Message on successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:2157
-#: addon\globalPlugins\visionAssistant\__init__.py:2171
+#: addon/globalPlugins/visionAssistant/__init__.py:2267
+#: addon/globalPlugins/visionAssistant/__init__.py:2281
 msgid "Saved."
 msgstr "Zapisano."
 
 #. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:2160
-#: addon\globalPlugins\visionAssistant\__init__.py:2174
+#: addon/globalPlugins/visionAssistant/__init__.py:2270
+#: addon/globalPlugins/visionAssistant/__init__.py:2284
 #, python-brace-format
 msgid "Save failed: {error}"
 msgstr "Zapisywanie nie powiodło się: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:2165
+#: addon/globalPlugins/visionAssistant/__init__.py:2275
 msgid "Save Result"
 msgstr "Zapisywanie wyniku"
 
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\__init__.py:2185
+#: addon/globalPlugins/visionAssistant/__init__.py:2295
 msgid "Connection"
 msgstr "Połączenie"
 
 #. Translators: Name of the Google Gemini AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2192
+#: addon/globalPlugins/visionAssistant/__init__.py:2302
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
 #. Translators: Name of the OpenAI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2194
+#: addon/globalPlugins/visionAssistant/__init__.py:2304
 msgid "OpenAI"
 msgstr "OpenAI"
 
 #. Translators: Name of the Mistral AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2196
+#: addon/globalPlugins/visionAssistant/__init__.py:2306
 msgid "Mistral AI"
 msgstr "Mistral AI"
 
 #. Translators: Name of the Groq AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2198
+#: addon/globalPlugins/visionAssistant/__init__.py:2308
 msgid "Groq"
 msgstr "Groq"
 
 #. Translators: Option for a user-defined custom AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2200
+#: addon/globalPlugins/visionAssistant/__init__.py:2310
 msgid "Custom"
 msgstr "Niestandardowy"
 
 #. Translators: Label for AI Provider selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2203
+#: addon/globalPlugins/visionAssistant/__init__.py:2313
 msgid "Provider:"
 msgstr "Dostawca:"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\__init__.py:2211
+#: addon/globalPlugins/visionAssistant/__init__.py:2321
 msgid "API Key (Separate multiple keys with comma or newline):"
 msgstr "Klucz API (rozdziel wiele kluczy przecinkiem lub nową linią):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\__init__.py:2222
+#: addon/globalPlugins/visionAssistant/__init__.py:2332
 msgid "Show API Key"
 msgstr "Pokaż klucz API"
 
 #. Custom Fields Box
 #. Translators: Static box title for custom AI provider settings
-#: addon\globalPlugins\visionAssistant\__init__.py:2228
+#: addon/globalPlugins/visionAssistant/__init__.py:2338
 msgid "Custom Provider Settings"
 msgstr "Ustawienia niestandardowego dostawcy"
 
 #. Translators: Label for Custom API URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:2232
+#: addon/globalPlugins/visionAssistant/__init__.py:2342
 msgid "API URL:"
 msgstr "Adres URL API:"
 
 #. Translators: Label for Custom API Type selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2236
+#: addon/globalPlugins/visionAssistant/__init__.py:2346
 msgid "API Type:"
 msgstr "Typ API:"
 
 #. Translators: AI API compatibility types
-#: addon\globalPlugins\visionAssistant\__init__.py:2238
+#: addon/globalPlugins/visionAssistant/__init__.py:2348
 msgid "OpenAI Compatible"
 msgstr "Zgodny z OpenAI"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:2238
+#: addon/globalPlugins/visionAssistant/__init__.py:2348
 msgid "Gemini Compatible"
 msgstr "Zgodny z Gemini"
 
 #. Translators: Label for Custom Model Name input
-#: addon\globalPlugins\visionAssistant\__init__.py:2243
-msgid "Model Name:"
-msgstr "Nazwa modelu:"
+#: addon/globalPlugins/visionAssistant/__init__.py:2354
+msgid "Model Name (Manual):"
+msgstr "Nazwa modelu (ręcznie):"
 
 #. Translators: Checkbox to indicate if custom provider supports file upload
-#: addon\globalPlugins\visionAssistant\__init__.py:2248
+#: addon/globalPlugins/visionAssistant/__init__.py:2360
 msgid "Supports File Upload"
 msgstr "Obsługuje przesyłanie plików"
 
 #. Advanced Endpoints Section
 #. Translators: Checkbox to toggle advanced endpoint URLs
-#: addon\globalPlugins\visionAssistant\__init__.py:2254
+#: addon/globalPlugins/visionAssistant/__init__.py:2366
 msgid "Advanced Endpoint Configuration"
 msgstr "Adresy usług"
 
 #. Translators: Label for Custom Models List URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2263
+#: addon/globalPlugins/visionAssistant/__init__.py:2375
 msgid "Models List URL:"
 msgstr "URL listy modeli:"
 
 #. Translators: Label for Custom OCR URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2268
+#: addon/globalPlugins/visionAssistant/__init__.py:2380
 msgid "OCR Endpoint URL:"
 msgstr "URL punktu końcowego OCR:"
 
 #. Translators: Label for Custom OCR Model
-#: addon\globalPlugins\visionAssistant\__init__.py:2273
+#: addon/globalPlugins/visionAssistant/__init__.py:2385
 msgid "Custom OCR Model (Optional):"
 msgstr "Niestandardowy model OCR (opcjonalnie):"
 
 #. Translators: Label for Custom STT URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2278
+#: addon/globalPlugins/visionAssistant/__init__.py:2391
 msgid "Speech-to-Text (STT) URL:"
 msgstr "URL rozpoznawania mowy (STT):"
 
 #. Translators: Label for Custom STT Model
-#: addon\globalPlugins\visionAssistant\__init__.py:2283
+#: addon/globalPlugins/visionAssistant/__init__.py:2396
 msgid "Custom STT Model (Optional):"
 msgstr "Niestandardowy model STT (opcjonalnie):"
 
 #. Translators: Label for Custom TTS URL
-#: addon\globalPlugins\visionAssistant\__init__.py:2288
+#: addon/globalPlugins/visionAssistant/__init__.py:2402
 msgid "Text-to-Speech (TTS) URL:"
 msgstr "URL syntezy mowy (TTS):"
 
 #. Translators: Label for Custom TTS Model
-#: addon\globalPlugins\visionAssistant\__init__.py:2293
+#: addon/globalPlugins/visionAssistant/__init__.py:2407
 msgid "Custom TTS Model (Optional):"
 msgstr "Niestandardowy model TTS (opcjonalnie):"
 
+#. Translators: Label for a text field in the "Custom Provider Settings" section of settings where the user enters the AI Operator URL.
+#: addon/globalPlugins/visionAssistant/__init__.py:2413
+msgid "AI Operator URL:"
+msgstr "URL Operatora AI:"
+
+#. Translators: Label for a text field in the "Custom Provider Settings" section of settings where the user manually enters the model name for AI Operator.
+#: addon/globalPlugins/visionAssistant/__init__.py:2418
+msgid "Custom Operator Model (Optional):"
+msgstr "Niestandardowy model Operatora (opcjonalne):"
+
 #. Translators: Label for Custom TTS Voice Name
-#: addon\globalPlugins\visionAssistant\__init__.py:2298
+#: addon/globalPlugins/visionAssistant/__init__.py:2424
 msgid "Custom TTS Voice Name (Optional):"
 msgstr "Niestandardowa nazwa głosu TTS (opcjonalnie):"
 
 #. Standard Fetch & Model Logic
 #. Translators: Button to fetch available models from the selected provider
-#: addon\globalPlugins\visionAssistant\__init__.py:2309
+#: addon/globalPlugins/visionAssistant/__init__.py:2435
 msgid "Fetch Models"
 msgstr "Pobierz modele"
 
 #. Translators: Label for AI Model selection choice box
-#: addon\globalPlugins\visionAssistant\__init__.py:2314
+#. Translators: Accessible name for the AI model selection combo box.
+#: addon/globalPlugins/visionAssistant/__init__.py:2440
+#: addon/globalPlugins/visionAssistant/__init__.py:2443
 msgid "AI Model:"
 msgstr "Model AI:"
 
 #. Advanced Model Routing Box
 #. Translators: Checkbox to toggle advanced model routing
-#: addon\globalPlugins\visionAssistant\__init__.py:2322
+#: addon/globalPlugins/visionAssistant/__init__.py:2449
 msgid "Advanced Model Routing (Task-specific)"
 msgstr "Osobny model dla każdego zadania"
 
 #. Translators: Label for OCR model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2329
+#: addon/globalPlugins/visionAssistant/__init__.py:2456
 msgid "OCR / Vision Model:"
 msgstr "Model dla OCR / rozpoznawania obrazów:"
 
 #. Translators: Label for STT model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2335
+#: addon/globalPlugins/visionAssistant/__init__.py:2462
 msgid "Speech-to-Text (STT) Model:"
 msgstr "Model rozpoznawania mowy (STT):"
 
 #. Translators: Label for TTS model selection (Assigning to self to toggle visibility)
-#: addon\globalPlugins\visionAssistant\__init__.py:2341
+#: addon/globalPlugins/visionAssistant/__init__.py:2468
 msgid "Text-to-Speech (TTS) Model:"
 msgstr "Model syntezy mowy (TTS):"
 
+#. Translators: Label for a dropdown menu in the "Advanced Model Routing" section of settings to choose a specific model for AI Operator tasks.
+#: addon/globalPlugins/visionAssistant/__init__.py:2474
+msgid "AI Operator Model:"
+msgstr "Model Operatora AI:"
+
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:2350
+#: addon/globalPlugins/visionAssistant/__init__.py:2483
 msgid "Proxy URL:"
 msgstr "Adres URl servera proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on startup
-#: addon\globalPlugins\visionAssistant\__init__.py:2354
+#: addon/globalPlugins/visionAssistant/__init__.py:2487
 msgid "Check for updates on startup"
 msgstr "Sprawdzaj aktualizacje przy uruchomieniu"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\__init__.py:2357
+#: addon/globalPlugins/visionAssistant/__init__.py:2490
 msgid "Clean Markdown in Chat"
 msgstr "Czyść Markdown w czacie"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:2360
+#: addon/globalPlugins/visionAssistant/__init__.py:2493
 msgid "Copy AI responses to clipboard"
 msgstr "Kopiuj odpowiedzi AI do schowka"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\__init__.py:2363
+#: addon/globalPlugins/visionAssistant/__init__.py:2496
 msgid "Direct Output (No Chat Window)"
 msgstr "Tryb bezpośredni (nie pokazuje okna czatu)"
 
 #. --- AI Behavior Group ---
 #. Translators: Title of the settings group for AI behavior
-#: addon\globalPlugins\visionAssistant\__init__.py:2369
+#: addon/globalPlugins/visionAssistant/__init__.py:2502
 msgid "AI Behavior"
 msgstr "Zachowanie AI"
 
 #. Translators: Label for AI Temperature setting
-#: addon\globalPlugins\visionAssistant\__init__.py:2374
+#: addon/globalPlugins/visionAssistant/__init__.py:2507
 msgid "Creativity (Temperature, does not affect OCR/Translation):"
 msgstr "Kreatywność (temperatura, nie wpływa na OCR/tłumaczenie):"
 
 #. --- Translation Languages Group ---
 #. Translators: Title of the settings group for translation languages configuration
-#: addon\globalPlugins\visionAssistant\__init__.py:2385
+#: addon/globalPlugins/visionAssistant/__init__.py:2518
 msgid "Translation Languages"
 msgstr "Języki tłumaczenia"
 
 #. Translators: Label for Source Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2390
+#: addon/globalPlugins/visionAssistant/__init__.py:2523
 msgid "Source:"
 msgstr "Źródłowy:"
 
 #. Translators: Label for Target Language selection
 #. Translators: Label for target language
-#: addon\globalPlugins\visionAssistant\__init__.py:2394
-#: addon\globalPlugins\visionAssistant\__init__.py:2896
+#: addon/globalPlugins/visionAssistant/__init__.py:2527
+#: addon/globalPlugins/visionAssistant/__init__.py:3096
 msgid "Target:"
 msgstr "Docelowy:"
 
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\__init__.py:2402
+#: addon/globalPlugins/visionAssistant/__init__.py:2535
 msgid "Smart Swap"
 msgstr "Inteligentna zamiana"
 
 #. --- Document Reader Settings ---
 #. Translators: Title of settings group for Document Reader features
 #. Translators: Title of the Document Reader window.
-#: addon\globalPlugins\visionAssistant\__init__.py:2408
-#: addon\globalPlugins\visionAssistant\__init__.py:3049
+#: addon/globalPlugins/visionAssistant/__init__.py:2541
+#: addon/globalPlugins/visionAssistant/__init__.py:3257
 msgid "Document Reader"
 msgstr "Czytnik dokumentów"
 
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2413
+#: addon/globalPlugins/visionAssistant/__init__.py:2546
 msgid "OCR Engine:"
 msgstr "Silnik OCR:"
 
 #. Translators: Label for TTS Voice selection (Assigning to self to toggle visibility)
 #. Translators: Label for TTS Voice selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2421
-#: addon\globalPlugins\visionAssistant\__init__.py:3124
+#: addon/globalPlugins/visionAssistant/__init__.py:2554
+#: addon/globalPlugins/visionAssistant/__init__.py:3332
 msgid "TTS Voice:"
 msgstr "Głos TTS:"
 
 #. Translators: Label for CAPTCHA capture method selection.
-#: addon\globalPlugins\visionAssistant\__init__.py:2434
+#: addon/globalPlugins/visionAssistant/__init__.py:2567
 msgid "Capture Method:"
 msgstr "Metoda przechwytywania:"
 
 #. Translators: A choice for capture method. Captures only the specific object under the cursor.
-#: addon\globalPlugins\visionAssistant\__init__.py:2436
+#: addon/globalPlugins/visionAssistant/__init__.py:2569
 msgid "Navigator Object"
 msgstr "Obiekt nawigatora"
 
 #. Translators: A choice for capture method. Captures the entire visible screen area.
-#: addon\globalPlugins\visionAssistant\__init__.py:2438
+#: addon/globalPlugins/visionAssistant/__init__.py:2571
 msgid "Full Screen"
 msgstr "Cały ekran"
 
 #. --- Prompts Group ---
 #. Translators: Title of the settings group for prompt management.
-#: addon\globalPlugins\visionAssistant\__init__.py:2449
+#: addon/globalPlugins/visionAssistant/__init__.py:2582
 msgid "Prompts"
 msgstr "Polecenia"
 
 #. Translators: Description for the prompt manager button.
-#: addon\globalPlugins\visionAssistant\__init__.py:2454
+#: addon/globalPlugins/visionAssistant/__init__.py:2587
 msgid "Manage default and custom prompts."
 msgstr "Zarządzaj domyślnymi i niestandardowymi poleceniami."
 
 #. Translators: Button label to open prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:2456
+#: addon/globalPlugins/visionAssistant/__init__.py:2589
 msgid "Manage Prompts..."
 msgstr "Zarządzaj poleceniami..."
 
 #. Translators: Summary text for prompt counts in settings.
-#: addon\globalPlugins\visionAssistant\__init__.py:2493
+#: addon/globalPlugins/visionAssistant/__init__.py:2626
 #, python-brace-format
 msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
 msgstr "Polecenia domyślne: {defaultCount}, niestandardowe: {customCount}"
 
 #. Translators: Progress message shown while fetching AI models from the server
-#: addon\globalPlugins\visionAssistant\__init__.py:2592
+#: addon/globalPlugins/visionAssistant/__init__.py:2763
 msgid "Fetching models..."
 msgstr "Pobieranie modeli..."
 
-#. Translators: Default model routing option for advanced mode
-#: addon\globalPlugins\visionAssistant\__init__.py:2608
-#: addon\globalPlugins\visionAssistant\__init__.py:2650
-msgid "Default (Auto)"
-msgstr "Domyślny (auto)"
+#. Translators: Option to follow the main model selected in the primary dropdown
+#. Translators: Option to follow the main model selected in the primary dropdown.
+#: addon/globalPlugins/visionAssistant/__init__.py:2781
+#: addon/globalPlugins/visionAssistant/__init__.py:2835
+msgid "Default (Main Model)"
+msgstr "Domyślny (model główny)"
 
-#. Translators: Success message after AI models are successfully updated
-#: addon\globalPlugins\visionAssistant\__init__.py:2636
+#. Translators: Option for the system to automatically choose the best model for this specific task
+#. Translators: Option for the system to automatically choose the best model for this task.
+#: addon/globalPlugins/visionAssistant/__init__.py:2783
+#: addon/globalPlugins/visionAssistant/__init__.py:2837
+msgid "Auto (Optimized)"
+msgstr "Auto (zoptymalizowane)"
+
+#. Translators: Status message when the AI models list is successfully refreshed.
+#: addon/globalPlugins/visionAssistant/__init__.py:2822
 msgid "Models updated"
 msgstr "Modele zaktualizowane"
 
-#. Translators: Error message shown when models cannot be fetched from the API
-#: addon\globalPlugins\visionAssistant\__init__.py:2639
+#. Translators: Error message shown when the add-on cannot retrieve the list of models from the server.
+#: addon/globalPlugins/visionAssistant/__init__.py:2825
 msgid "Failed to fetch models"
 msgstr "Pobieranie modeli nie powiodło się"
 
 #. Translators: Error message shown when saving settings fails.
 #. Translators: Error message shown when saving a file fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:2822
-#: addon\globalPlugins\visionAssistant\__init__.py:3544
+#: addon/globalPlugins/visionAssistant/__init__.py:3022
+#: addon/globalPlugins/visionAssistant/__init__.py:3753
 #, python-brace-format
 msgid "Save Error: {error}"
 msgstr "Błąd zapisu: {error}"
 
 #. Translators: Status reported when an error occurs
-#: addon\globalPlugins\visionAssistant\__init__.py:2822
-#: addon\globalPlugins\visionAssistant\__init__.py:3278
-#: addon\globalPlugins\visionAssistant\__init__.py:3389
-#: addon\globalPlugins\visionAssistant\__init__.py:3396
-#: addon\globalPlugins\visionAssistant\__init__.py:3449
-#: addon\globalPlugins\visionAssistant\__init__.py:3491
-#: addon\globalPlugins\visionAssistant\__init__.py:3496
-#: addon\globalPlugins\visionAssistant\__init__.py:3544
-#: addon\globalPlugins\visionAssistant\__init__.py:3854
-#: addon\globalPlugins\visionAssistant\__init__.py:3861
-#: addon\globalPlugins\visionAssistant\__init__.py:3930
+#: addon/globalPlugins/visionAssistant/__init__.py:3022
+#: addon/globalPlugins/visionAssistant/__init__.py:3486
+#: addon/globalPlugins/visionAssistant/__init__.py:3597
+#: addon/globalPlugins/visionAssistant/__init__.py:3604
+#: addon/globalPlugins/visionAssistant/__init__.py:3658
+#: addon/globalPlugins/visionAssistant/__init__.py:3700
+#: addon/globalPlugins/visionAssistant/__init__.py:3705
+#: addon/globalPlugins/visionAssistant/__init__.py:3753
+#: addon/globalPlugins/visionAssistant/__init__.py:4119
 msgid "Error"
 msgstr "Błąd"
 
 #. Translators: Notification showing the number of items found after filtering the model list.
-#: addon\globalPlugins\visionAssistant\__init__.py:2865
+#: addon/globalPlugins/visionAssistant/__init__.py:3065
 #, python-brace-format
 msgid "{count} items found"
 msgstr "Pozycje: {count}"
 
-#. Translators: Title of the PDF options dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2870
+#. Translators: Title of the PDF and document options dialog (range, translation, etc.)
+#: addon/globalPlugins/visionAssistant/__init__.py:3070
 msgid "Options"
 msgstr "Opcje"
 
 #. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:2873
+#: addon/globalPlugins/visionAssistant/__init__.py:3073
 #, python-brace-format
 msgid "Total Pages (All Files): {count}"
 msgstr "Łączna liczba stron (wszystkie pliki): {count}"
 
 #. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\__init__.py:2876
+#: addon/globalPlugins/visionAssistant/__init__.py:3076
 msgid "Range"
 msgstr "Zakres"
 
 #. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\__init__.py:2879
+#: addon/globalPlugins/visionAssistant/__init__.py:3079
 msgid "From:"
 msgstr "Od:"
 
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\__init__.py:2883
+#: addon/globalPlugins/visionAssistant/__init__.py:3083
 msgid "To:"
 msgstr "Do:"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\__init__.py:2892
+#: addon/globalPlugins/visionAssistant/__init__.py:3092
 msgid "Translate Output"
 msgstr "Przetłumacz wynik"
 
 #. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\__init__.py:2905
+#: addon/globalPlugins/visionAssistant/__init__.py:3105
 msgid "Start"
 msgstr "Rozpocznij"
 
 #. Translators: Button to cancel
-#: addon\globalPlugins\visionAssistant\__init__.py:2908
+#: addon/globalPlugins/visionAssistant/__init__.py:3108
 msgid "Cancel"
 msgstr "Anuluj"
 
 #. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:2933
+#: addon/globalPlugins/visionAssistant/__init__.py:3133
 msgid "Ask about Document"
 msgstr "Zapytaj o dokument"
 
 #. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\__init__.py:2942
+#: addon/globalPlugins/visionAssistant/__init__.py:3142
 #, python-brace-format
 msgid "File: {name}"
 msgstr "Plik: {name}"
 
 #. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\__init__.py:2947
+#: addon/globalPlugins/visionAssistant/__init__.py:3147
 msgid "Uploading to AI...\n"
 msgstr "Przesyłanie do AI...\n"
 
 #. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\__init__.py:2951
+#: addon/globalPlugins/visionAssistant/__init__.py:3151
 msgid "Your Question:"
 msgstr "Twoje pytanie:"
 
-#. Translators: Message when ready to chat
-#: addon\globalPlugins\visionAssistant\__init__.py:2995
+#. Translators: Message shown in the chat area when the file is uploaded and the AI is ready to answer questions.
+#: addon/globalPlugins/visionAssistant/__init__.py:3195
 msgid "Ready! Ask your questions.\n"
 msgstr "Gotowe! Zadawaj pytania.\n"
 
 #. Translators: Spoken prefix for AI response
-#: addon\globalPlugins\visionAssistant\__init__.py:3040
+#: addon/globalPlugins/visionAssistant/__init__.py:3248
 msgid "AI: "
 msgstr "AI: "
 
 #. Translators: Initial status message
-#: addon\globalPlugins\visionAssistant\__init__.py:3069
+#: addon/globalPlugins/visionAssistant/__init__.py:3277
 msgid "Initializing..."
 msgstr "Inicjowanie..."
 
 #. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\__init__.py:3075
+#: addon/globalPlugins/visionAssistant/__init__.py:3283
 msgid "Previous (Ctrl+PageUp)"
 msgstr "Poprzednia (Ctrl+PageUp)"
 
 #. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\__init__.py:3079
+#: addon/globalPlugins/visionAssistant/__init__.py:3287
 msgid "Next (Ctrl+PageDown)"
 msgstr "Następna (Ctrl+PageDown)"
 
 #. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\__init__.py:3083
+#: addon/globalPlugins/visionAssistant/__init__.py:3291
 msgid "Go to:"
 msgstr "Przejdź do:"
 
 #. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\__init__.py:3094
+#: addon/globalPlugins/visionAssistant/__init__.py:3302
 msgid "Ask AI (Alt+A)"
 msgstr "Zapytaj AI (Alt+A)"
 
 #. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\__init__.py:3099
+#: addon/globalPlugins/visionAssistant/__init__.py:3307
 msgid "Re-scan with AI (Alt+R)"
 msgstr "Ponowne skanowanie AI (Alt+R)"
 
 #. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\__init__.py:3104
+#: addon/globalPlugins/visionAssistant/__init__.py:3312
 msgid "Generate Audio (Alt+G)"
 msgstr "Generuj audio (Alt+G)"
 
 #. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\__init__.py:3115
+#: addon/globalPlugins/visionAssistant/__init__.py:3323
 msgid "Save (Alt+S)"
 msgstr "Zapisz (Alt+S)"
 
 #. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\__init__.py:3177
+#: addon/globalPlugins/visionAssistant/__init__.py:3385
 #, python-brace-format
 msgid "Page {num} ready"
 msgstr "Strona {num} gotowa"
 
 #. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3203
+#: addon/globalPlugins/visionAssistant/__init__.py:3411
 msgid "[OCR failed. Try a different AI model or provider.]"
 msgstr "[OCR nie powiodło się. Spróbuj innego modelu AI lub dostawcy.]"
 
 #. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\__init__.py:3214
+#: addon/globalPlugins/visionAssistant/__init__.py:3422
 msgid "Error processing page."
 msgstr "Błąd przetwarzania strony."
 
 #. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\__init__.py:3219
+#: addon/globalPlugins/visionAssistant/__init__.py:3427
 #, python-brace-format
 msgid "Page {current} of {total}"
 msgstr "Strona {current} z {total}"
 
 #. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\__init__.py:3226
+#: addon/globalPlugins/visionAssistant/__init__.py:3434
 msgid "Processing in background..."
 msgstr "Przetwarzanie w tle..."
 
 #. Translators: Spoken message when switching pages
 #. Translators: Heading for each page in the formatted content view.
-#: addon\globalPlugins\visionAssistant\__init__.py:3237
-#: addon\globalPlugins\visionAssistant\__init__.py:3256
-#: addon\globalPlugins\visionAssistant\__init__.py:3529
+#: addon/globalPlugins/visionAssistant/__init__.py:3445
+#: addon/globalPlugins/visionAssistant/__init__.py:3464
+#: addon/globalPlugins/visionAssistant/__init__.py:3738
 #, python-brace-format
 msgid "Page {num}"
 msgstr "Strona {num}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:3269
+#: addon/globalPlugins/visionAssistant/__init__.py:3477
 msgid "Formatted Content"
 msgstr "Sformatowana treść"
 
 #. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\__init__.py:3282
+#: addon/globalPlugins/visionAssistant/__init__.py:3490
 msgid "Current Page"
 msgstr "Bieżąca strona"
 
 #. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:3284
+#: addon/globalPlugins/visionAssistant/__init__.py:3492
 msgid "All Pages (In Range)"
 msgstr "Wszystkie strony (w zakresie)"
 
 #. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\__init__.py:3294
+#: addon/globalPlugins/visionAssistant/__init__.py:3502
 msgid "Scanning with AI..."
 msgstr "Skanowanie AI..."
 
 #. Translators: Error shown when a specific page scan fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:3310
-#: addon\globalPlugins\visionAssistant\__init__.py:3371
+#: addon/globalPlugins/visionAssistant/__init__.py:3518
+#: addon/globalPlugins/visionAssistant/__init__.py:3579
 #, python-brace-format
 msgid "[Scan failed: {err}]"
 msgstr "[Skanowanie nie powiodło się: {err}]"
 
 #. Translators: Message shown when OCR returns no text for a page.
-#: addon\globalPlugins\visionAssistant\__init__.py:3315
+#: addon/globalPlugins/visionAssistant/__init__.py:3523
 msgid "[No text detected]"
 msgstr "[Nie wykryto tekstu]"
 
 #. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:3320
+#: addon/globalPlugins/visionAssistant/__init__.py:3528
 msgid "Scan complete"
 msgstr "Skanowanie zakończone"
 
 #. Translators: Generic system error message inside the document viewer.
-#: addon\globalPlugins\visionAssistant\__init__.py:3323
+#: addon/globalPlugins/visionAssistant/__init__.py:3531
 #, python-brace-format
 msgid "[Error: {msg}]"
 msgstr "[Błąd: {msg}]"
 
 #. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\__init__.py:3333
+#: addon/globalPlugins/visionAssistant/__init__.py:3541
 msgid "Batch Processing Started"
 msgstr "Rozpoczęto przetwarzanie wsadowe"
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:3348
+#: addon/globalPlugins/visionAssistant/__init__.py:3556
 msgid "Error creating temporary PDF."
 msgstr "Błąd tworzenia tymczasowego pliku PDF."
 
 #. Translators: Message when a single page scan or batch is finished.
-#: addon\globalPlugins\visionAssistant\__init__.py:3364
+#: addon/globalPlugins/visionAssistant/__init__.py:3572
 msgid "Batch Scan Complete"
 msgstr "Skanowanie wsadowe zakończone"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3364
+#: addon/globalPlugins/visionAssistant/__init__.py:3572
 msgid "Scan Complete"
 msgstr "Skanowanie zakończone"
 
 #. Translators: Message when the entire batch processing fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:3369
+#: addon/globalPlugins/visionAssistant/__init__.py:3577
 msgid "Batch Scan Failed"
 msgstr "Skanowanie zbiorcze nie powiodło się"
 
 #. Translators: Spoken message for background batch processing.
-#: addon\globalPlugins\visionAssistant\__init__.py:3381
+#: addon/globalPlugins/visionAssistant/__init__.py:3589
 #, python-brace-format
 msgid "AI is scanning {n} pages in background."
 msgstr "AI skanuje {n} stron w tle."
 
 #. Translators: Error message when trying to use TTS with an unsupported provider
-#: addon\globalPlugins\visionAssistant\__init__.py:3389
+#: addon/globalPlugins/visionAssistant/__init__.py:3597
 msgid "TTS is not supported by the current provider or configuration."
 msgstr "Bieżący dostawca lub konfiguracja nie obsługuje syntezy mowy."
 
 #. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\__init__.py:3401
+#: addon/globalPlugins/visionAssistant/__init__.py:3609
 msgid "Generate for Current Page"
 msgstr "Generuj dla bieżącej strony"
 
 #. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:3403
+#: addon/globalPlugins/visionAssistant/__init__.py:3611
 msgid "Generate for All Pages (In Range)"
 msgstr "Generuj dla wszystkich stron (w zakresie)"
 
 #. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\__init__.py:3413
+#: addon/globalPlugins/visionAssistant/__init__.py:3621
 msgid "No text to read."
 msgstr "Brak tekstu do odczytu."
 
 #. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\__init__.py:3423
+#: addon/globalPlugins/visionAssistant/__init__.py:3631
 msgid "Gathering text for audio..."
 msgstr "Zbieranie tekstu do audio..."
 
 #. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\__init__.py:3433
+#: addon/globalPlugins/visionAssistant/__init__.py:3641
 msgid "Save Audio"
 msgstr "Zapisz audio"
 
 #. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\__init__.py:3440
+#: addon/globalPlugins/visionAssistant/__init__.py:3648
 msgid "Generating Audio..."
 msgstr "Generowanie audio..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3447
+#. Translators: Fallback error message during text-to-speech generation.
+#: addon/globalPlugins/visionAssistant/__init__.py:3656
 msgid "Unknown Error"
 msgstr "Nieznany błąd"
 
 #. Translators: Error message shown when text-to-speech generation fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:3449
-#: addon\globalPlugins\visionAssistant\__init__.py:3491
+#: addon/globalPlugins/visionAssistant/__init__.py:3658
+#: addon/globalPlugins/visionAssistant/__init__.py:3700
 #, python-brace-format
 msgid "TTS Error: {error}"
 msgstr "Błąd TTS: {error}"
 
 #. Translators: Error message when the MP3 encoder (LAME) is missing.
-#: addon\globalPlugins\visionAssistant\__init__.py:3467
+#: addon/globalPlugins/visionAssistant/__init__.py:3676
 msgid "lame.exe not found in lib folder."
 msgstr "Nie znaleziono lame.exe w folderze lib."
 
 #. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:3481
+#: addon/globalPlugins/visionAssistant/__init__.py:3690
 msgid "Audio Saved"
 msgstr "Audio zapisane"
 
 #. Translators: Success message after generating TTS audio.
-#: addon\globalPlugins\visionAssistant\__init__.py:3486
+#: addon/globalPlugins/visionAssistant/__init__.py:3695
 msgid "Audio file generated and saved successfully."
 msgstr "Plik audio został wygenerowany i zapisany."
 
 #. Translators: Warning message when the Gemini key is missing for specific features.
-#: addon\globalPlugins\visionAssistant\__init__.py:3496
+#: addon/globalPlugins/visionAssistant/__init__.py:3705
 msgid "Please configure Gemini API Key."
 msgstr "Skonfiguruj klucz API Gemini."
 
 #. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\__init__.py:3511
+#: addon/globalPlugins/visionAssistant/__init__.py:3720
 msgid "Save"
 msgstr "Zapisz"
 
 #. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\__init__.py:3522
+#: addon/globalPlugins/visionAssistant/__init__.py:3731
 #, python-brace-format
 msgid "Saving Page {num}..."
 msgstr "Zapisywanie strony {num}..."
 
 #. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:3539
+#: addon/globalPlugins/visionAssistant/__init__.py:3748
 msgid "Saved"
 msgstr "Zapisano"
 
 #. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:3541
+#: addon/globalPlugins/visionAssistant/__init__.py:3750
 msgid "File saved successfully."
 msgstr "Plik został zapisany."
 
 #. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:3578
+#: addon/globalPlugins/visionAssistant/__init__.py:3792
 msgid "&Document Reader..."
 msgstr "&Czytnik dokumentów..."
 
 #. Translators: Menu item for Audio Transcription
-#: addon\globalPlugins\visionAssistant\__init__.py:3582
+#: addon/globalPlugins/visionAssistant/__init__.py:3796
 msgid "Transcribe &Audio File..."
 msgstr "Transkrybuj plik &audio..."
 
 #. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:3586
+#: addon/globalPlugins/visionAssistant/__init__.py:3800
 msgid "Analyze &Video URL..."
 msgstr "Analizuj adres URL &wideo..."
 
 #. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:3592
+#: addon/globalPlugins/visionAssistant/__init__.py:3806
 msgid "&Settings..."
 msgstr "&Ustawienia..."
 
 #. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:3596
+#: addon/globalPlugins/visionAssistant/__init__.py:3810
 msgid "Check for &Update"
 msgstr "Sprawdź &aktualizację"
 
 #. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:3600
+#: addon/globalPlugins/visionAssistant/__init__.py:3814
 msgid "Docu&mentation"
 msgstr "Doku&mentacja"
 
 #. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:3604
+#: addon/globalPlugins/visionAssistant/__init__.py:3818
 msgid "D&onate"
 msgstr "W&esprzyj"
 
 #. Translators: Menu item to open the Telegram channel
-#: addon\globalPlugins\visionAssistant\__init__.py:3608
+#: addon/globalPlugins/visionAssistant/__init__.py:3822
 msgid "Telegram &Channel"
 msgstr "Kanał w &Telegramie"
 
 #. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
-#: addon\globalPlugins\visionAssistant\__init__.py:3613
+#: addon/globalPlugins/visionAssistant/__init__.py:3827
 msgid "Vision Assistant"
 msgstr "Vision Assistant"
 
 #. Translators: Standard title for opening a file
-#: addon\globalPlugins\visionAssistant\__init__.py:3628
-#: addon\globalPlugins\visionAssistant\__init__.py:3769
-#: addon\globalPlugins\visionAssistant\__init__.py:4268
+#: addon/globalPlugins/visionAssistant/__init__.py:3842
+#: addon/globalPlugins/visionAssistant/__init__.py:3985
+#: addon/globalPlugins/visionAssistant/__init__.py:4457
 msgid "Open"
 msgstr "Otwórz"
 
 #. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:3636
+#: addon/globalPlugins/visionAssistant/__init__.py:3850
 msgid "Supported Files"
 msgstr "Obsługiwane pliki"
 
 #. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:3643
-#: addon\globalPlugins\visionAssistant\__init__.py:4489
+#: addon/globalPlugins/visionAssistant/__init__.py:3857
+#: addon/globalPlugins/visionAssistant/__init__.py:4686
 msgid "PyMuPDF library is missing."
 msgstr "Brak biblioteki PyMuPDF."
 
 #. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:3649
-#: addon\globalPlugins\visionAssistant\__init__.py:4495
+#: addon/globalPlugins/visionAssistant/__init__.py:3863
+#: addon/globalPlugins/visionAssistant/__init__.py:4692
 msgid "No readable pages found."
 msgstr "Nie znaleziono stron do odczytu."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3687
+#: addon/globalPlugins/visionAssistant/__init__.py:3901
 msgid "Activates the Command Layer for quick access to all features."
 msgstr ""
 "Aktywuje warstwę poleceń umożliwiającą szybki dostęp do wszystkich funkcji."
 
+#: addon/globalPlugins/visionAssistant/__init__.py:3953
+#: addon/globalPlugins/visionAssistant/__init__.py:5526
+msgid "Asks the AI Operator to perform an action or describe the screen."
+msgstr "Aktywuje okno operatora ai."
+
+#: addon/globalPlugins/visionAssistant/__init__.py:3954
+#: addon/globalPlugins/visionAssistant/__init__.py:5451
+msgid "Toggles the interactive UI elements explorer."
+msgstr "Przełącza interaktywny eksplorator elementów interfejsu."
+
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3739
-#: addon\globalPlugins\visionAssistant\__init__.py:4057
+#: addon/globalPlugins/visionAssistant/__init__.py:3955
+#: addon/globalPlugins/visionAssistant/__init__.py:4246
 msgid "Translates the selected text or navigator object."
 msgstr "Tłumaczy zaznaczony tekst lub obiekt nawigatora."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3740
-#: addon\globalPlugins\visionAssistant\__init__.py:5174
+#: addon/globalPlugins/visionAssistant/__init__.py:3956
+#: addon/globalPlugins/visionAssistant/__init__.py:5365
 msgid "Translates the text currently in the clipboard."
 msgstr "Tłumaczy tekst znajdujący się w schowku."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3741
-#: addon\globalPlugins\visionAssistant\__init__.py:4204
+#: addon/globalPlugins/visionAssistant/__init__.py:3957
+#: addon/globalPlugins/visionAssistant/__init__.py:4393
 msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
 msgstr ""
 "Otwiera menu do wyjaśniania, podsumowywania lub poprawiania zaznaczonego "
 "tekstu."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3742
-#: addon\globalPlugins\visionAssistant\__init__.py:4676
+#: addon/globalPlugins/visionAssistant/__init__.py:3958
+#: addon/globalPlugins/visionAssistant/__init__.py:4903
 msgid "Performs OCR and description on the entire screen."
 msgstr "Wykonuje OCR i opis całego ekranu."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3743
-#: addon\globalPlugins\visionAssistant\__init__.py:4682
+#: addon/globalPlugins/visionAssistant/__init__.py:3959
+#: addon/globalPlugins/visionAssistant/__init__.py:4909
 msgid "Describes the current object (Navigator Object)."
 msgstr "Opisuje bieżący obiekt (obiekt nawigatora)."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3744
-#: addon\globalPlugins\visionAssistant\__init__.py:4602
+#: addon/globalPlugins/visionAssistant/__init__.py:3960
+#: addon/globalPlugins/visionAssistant/__init__.py:4829
 msgid ""
 "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
 msgstr ""
 "Otwiera czytnik dokumentów do szczegółowej analizy strona po stronie (PDF/"
 "obrazy)."
 
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3745
-#: addon\globalPlugins\visionAssistant\__init__.py:4476
-msgid "Recognizes text from a selected image or PDF file."
-msgstr "Rozpoznaje tekst z wybranego obrazu lub pliku PDF."
+#: addon/globalPlugins/visionAssistant/__init__.py:3961
+msgid ""
+"Performs smart actions (OCR or Description) on a selected image or PDF file."
+msgstr ""
+"Wykonuje inteligentne akcje (OCR lub opis) na wybranym pliku obrazu lub PDF."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3746
-#: addon\globalPlugins\visionAssistant\__init__.py:4866
+#: addon/globalPlugins/visionAssistant/__init__.py:3962
+#: addon/globalPlugins/visionAssistant/__init__.py:5058
 msgid "Transcribes a selected audio file."
 msgstr "Transkrybuje wybrany plik audio."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3747
-#: addon\globalPlugins\visionAssistant\__init__.py:4916
+#: addon/globalPlugins/visionAssistant/__init__.py:3963
+#: addon/globalPlugins/visionAssistant/__init__.py:5108
 msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
 msgstr "Analizuje adres URL wideo z YouTube, Instagrama, Twittera lub TikToka."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3748
-#: addon\globalPlugins\visionAssistant\__init__.py:5047
+#: addon/globalPlugins/visionAssistant/__init__.py:3964
+#: addon/globalPlugins/visionAssistant/__init__.py:5243
 msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
 msgstr "Próbuje rozwiązać CAPTCHA na ekranie lub w obiekcie nawigatora."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3749
-#: addon\globalPlugins\visionAssistant\__init__.py:3937
+#: addon/globalPlugins/visionAssistant/__init__.py:3965
+#: addon/globalPlugins/visionAssistant/__init__.py:4126
 msgid "Records voice, transcribes it using AI, and types the result."
 msgstr "Nagrywa głos, transkrybuje go przy użyciu AI i wpisuje wynik."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3750
-#: addon\globalPlugins\visionAssistant\__init__.py:3759
+#: addon/globalPlugins/visionAssistant/__init__.py:3966
+#: addon/globalPlugins/visionAssistant/__init__.py:3975
 msgid "Announces the current status of the add-on."
 msgstr "Odczytuje bieżący stan dodatku."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3751
-#: addon\globalPlugins\visionAssistant\__init__.py:5116
+#: addon/globalPlugins/visionAssistant/__init__.py:3967
+#: addon/globalPlugins/visionAssistant/__init__.py:5307
 msgid "Checks for updates manually."
 msgstr "Ręcznie sprawdza dostępność aktualizacji."
 
 #. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3752
-#: addon\globalPlugins\visionAssistant\__init__.py:5189
+#: addon/globalPlugins/visionAssistant/__init__.py:3968
+#: addon/globalPlugins/visionAssistant/__init__.py:5380
 msgid ""
 "Shows the last AI response in a chat dialog for review or follow-up "
 "questions."
@@ -1836,194 +1907,213 @@ msgstr ""
 "Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub zadawania "
 "dodatkowych pytań."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:3753
+#: addon/globalPlugins/visionAssistant/__init__.py:3969
 msgid "Shows a list of available commands in the layer."
 msgstr "Wyświetla listę dostępnych poleceń w warstwie."
 
 #. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:3756
+#: addon/globalPlugins/visionAssistant/__init__.py:3972
 #, python-brace-format
 msgid "{name} Help"
 msgstr "Pomoc {name}"
 
 #. Translators: Message of a dialog which may pop up while trying to upload a file
-#: addon\globalPlugins\visionAssistant\__init__.py:3832
+#: addon/globalPlugins/visionAssistant/__init__.py:4048
 #, python-brace-format
 msgid "File Upload Error: {error}"
 msgstr "Błąd przesyłania pliku: {error}"
 
-#. Translators: Error message when there's no content to send
-#: addon\globalPlugins\visionAssistant\__init__.py:3853
-#: addon\globalPlugins\visionAssistant\__init__.py:3860
-msgid "Nothing to send."
-msgstr "Brak treści do wysłania."
-
 #. Translators: Error message when AI refuses to answer due to safety guidelines
-#: addon\globalPlugins\visionAssistant\__init__.py:3906
+#: addon/globalPlugins/visionAssistant/__init__.py:4095
 msgid "Error: Response blocked by AI safety filters."
 msgstr "Błąd: odpowiedź zablokowana przez filtry bezpieczeństwa AI."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:3948
-#: addon\globalPlugins\visionAssistant\__init__.py:3957
-#: addon\globalPlugins\visionAssistant\__init__.py:3966
+#: addon/globalPlugins/visionAssistant/__init__.py:4137
+#: addon/globalPlugins/visionAssistant/__init__.py:4146
+#: addon/globalPlugins/visionAssistant/__init__.py:4155
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Błąd sprzętu audio: {error}"
 
 #. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:3962
+#: addon/globalPlugins/visionAssistant/__init__.py:4151
 msgid "Listening..."
 msgstr "Nasłuchiwanie..."
 
 #. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\__init__.py:3976
+#: addon/globalPlugins/visionAssistant/__init__.py:4165
 msgid "Typing..."
 msgstr "Wpisywanie..."
 
 #. Translators: Message in an error dialog which can pop up while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:3981
+#: addon/globalPlugins/visionAssistant/__init__.py:4170
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Błąd zapisu nagrania: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\__init__.py:3996
-#: addon\globalPlugins\visionAssistant\__init__.py:4023
+#: addon/globalPlugins/visionAssistant/__init__.py:4185
+#: addon/globalPlugins/visionAssistant/__init__.py:4212
 msgid "No speech detected."
 msgstr "Nie wykryto mowy."
 
 #. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:4033
+#: addon/globalPlugins/visionAssistant/__init__.py:4222
 msgid "No speech recognized or Error."
 msgstr "Nie rozpoznano mowy lub wystąpił błąd."
 
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:4052
+#: addon/globalPlugins/visionAssistant/__init__.py:4241
 #, python-brace-format
 msgid "Typed: {text}"
 msgstr "Wpisano: {text}"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:4064
+#: addon/globalPlugins/visionAssistant/__init__.py:4253
 msgid "No text found."
 msgstr "Brak tekstu."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:4069
+#: addon/globalPlugins/visionAssistant/__init__.py:4258
 msgid "Translating..."
 msgstr "Tłumaczenie..."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:4114
+#: addon/globalPlugins/visionAssistant/__init__.py:4303
 #, python-brace-format
 msgid "Translated: {text}"
 msgstr "Przetłumaczono: {text}"
 
 #. Translators: Dialog title for Translation results
-#: addon\globalPlugins\visionAssistant\__init__.py:4139
+#: addon/globalPlugins/visionAssistant/__init__.py:4328
 #, python-brace-format
 msgid "{name} - Translation"
 msgstr "{name} - Tłumaczenie"
 
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4233
+#: addon/globalPlugins/visionAssistant/__init__.py:4422
+#: addon/globalPlugins/visionAssistant/__init__.py:4706
 msgid "Choose action:"
 msgstr "Wybierz czynność:"
 
 #. Translators: Message while processing request of the refine text command
-#: addon\globalPlugins\visionAssistant\__init__.py:4278
+#. Translators: Status reported when AI starts processing a command
+#: addon/globalPlugins/visionAssistant/__init__.py:4467
+#: addon/globalPlugins/visionAssistant/__init__.py:5543
 msgid "Processing..."
 msgstr "Przetwarzanie..."
 
 #. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\__init__.py:4335
+#: addon/globalPlugins/visionAssistant/__init__.py:4524
 msgid "Uploading file..."
 msgstr "Przesyłanie pliku..."
 
 #. Translators: Message reported when executing the refine command
 #. Translators: Message reported when calling the audio transcription command
 #. Translators: Message reported when AI is analyzing the video
-#: addon\globalPlugins\visionAssistant\__init__.py:4408
-#: addon\globalPlugins\visionAssistant\__init__.py:4897
-#: addon\globalPlugins\visionAssistant\__init__.py:5010
+#: addon/globalPlugins/visionAssistant/__init__.py:4597
+#: addon/globalPlugins/visionAssistant/__init__.py:5089
+#: addon/globalPlugins/visionAssistant/__init__.py:5205
 msgid "Analyzing..."
 msgstr "Analizowanie..."
 
 #. Translators: Title of Refine Result dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4464
+#: addon/globalPlugins/visionAssistant/__init__.py:4655
 #, python-brace-format
 msgid "{name} - Refine Result"
 msgstr "{name} - Wynik poprawiania"
 
+#. Translators: Script description for Input Gestures dialog
+#: addon/globalPlugins/visionAssistant/__init__.py:4667
+msgid "Performs smart actions on a selected image or PDF file."
+msgstr "Wykonuje inteligentne akcje na wybranym pliku obrazu lub PDF."
+
+#. Translators: Options for the image file action menu
+#: addon/globalPlugins/visionAssistant/__init__.py:4703
+msgid "Extract Text (OCR)"
+msgstr "Wyodrębnij tekst (OCR)"
+
+#: addon/globalPlugins/visionAssistant/__init__.py:4703
+msgid "Describe Image"
+msgstr "Opisz obraz"
+
+#: addon/globalPlugins/visionAssistant/__init__.py:4706
+msgid "Image File"
+msgstr "Plik obrazu"
+
+#. Translators: Status reported when an image file is being analyzed
+#: addon/globalPlugins/visionAssistant/__init__.py:4716
+msgid "Analyzing Image File..."
+msgstr "Analizowanie pliku obrazu..."
+
 #. Translators: Message reported when extracting text from a file
-#: addon\globalPlugins\visionAssistant\__init__.py:4521
+#: addon/globalPlugins/visionAssistant/__init__.py:4748
 msgid "Extracting Text..."
 msgstr "Wyodrębnianie tekstu..."
 
 #. Translators: Error message if PDF creation fails
-#: addon\globalPlugins\visionAssistant\__init__.py:4528
-#: addon\globalPlugins\visionAssistant\__init__.py:4579
+#: addon/globalPlugins/visionAssistant/__init__.py:4755
+#: addon/globalPlugins/visionAssistant/__init__.py:4806
 msgid "Error creating PDF."
 msgstr "Błąd tworzenia pliku PDF."
 
 #. Translators: Error shown when OCR finds no text in the selected files
-#: addon\globalPlugins\visionAssistant\__init__.py:4571
+#: addon/globalPlugins/visionAssistant/__init__.py:4798
 msgid "No text detected or error occurred."
 msgstr "Nie wykryto tekstu lub wystąpił błąd."
 
 #. Translators: Dialog title for a Chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4664
-#: addon\globalPlugins\visionAssistant\__init__.py:4854
+#: addon/globalPlugins/visionAssistant/__init__.py:4891
 #, python-brace-format
 msgid "{name} - Chat"
 msgstr "{name} - Czat"
 
 #. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\__init__.py:4692
+#: addon/globalPlugins/visionAssistant/__init__.py:4919
 msgid "Scanning..."
 msgstr "Skanowanie..."
 
 #. Translators: Message reported when calling an image analysis command
-#. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:4697
-#: addon\globalPlugins\visionAssistant\__init__.py:5067
+#. Translators: Error message reported when screen or object capture fails for CAPTCHA solving.
+#: addon/globalPlugins/visionAssistant/__init__.py:4924
+#: addon/globalPlugins/visionAssistant/__init__.py:5263
 msgid "Capture failed."
 msgstr "Przechwytywanie nie powiodło się."
 
 #. Translators: Dialog title for Image Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:4790
+#: addon/globalPlugins/visionAssistant/__init__.py:5045
 #, python-brace-format
 msgid "{name} - Image Analysis"
 msgstr "{name} - Analiza obrazu"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\__init__.py:4878
+#: addon/globalPlugins/visionAssistant/__init__.py:5070
 msgid "Uploading..."
 msgstr "Przesyłanie..."
 
 #. Translators: Error message when video analysis is attempted with a non-Gemini provider.
-#: addon\globalPlugins\visionAssistant\__init__.py:4924
+#: addon/globalPlugins/visionAssistant/__init__.py:5116
 msgid "Video analysis is only supported by Gemini providers."
 msgstr "Analiza wideo jest obsługiwana wyłącznie przez dostawcę Gemini."
 
 #. Translators: Title for the video URL entry dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4929
+#: addon/globalPlugins/visionAssistant/__init__.py:5121
 msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 msgstr "Analiza YouTube / Instagram / Twitter / TikTok"
 
 #. Translators: Label for the text entry in video dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4931
+#: addon/globalPlugins/visionAssistant/__init__.py:5123
 msgid "Enter Video URL (YouTube/Instagram/Twitter/TikTok):"
 msgstr "Podaj adres URL wideo (YouTube/Instagram/Twitter/TikTok):"
 
 #. Translators: Error message when the URL is invalid
-#: addon\globalPlugins\visionAssistant\__init__.py:4951
+#: addon/globalPlugins/visionAssistant/__init__.py:5143
 msgid "Error: Invalid URL."
 msgstr "Błąd: nieprawidłowy adres URL."
 
 #. Translators: Error message when the platform is not supported
-#: addon\globalPlugins\visionAssistant\__init__.py:4962
+#: addon/globalPlugins/visionAssistant/__init__.py:5154
 msgid ""
 "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
 "are supported."
@@ -2032,91 +2122,155 @@ msgstr ""
 "Twitter i TikTok."
 
 #. Translators: Message reported when processing video link
-#: addon\globalPlugins\visionAssistant\__init__.py:4967
+#: addon/globalPlugins/visionAssistant/__init__.py:5159
 msgid "Processing Video..."
 msgstr "Przetwarzanie wideo..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:4978
+#. Translators: Error message when the add-on fails to get a direct download link for an Instagram video.
+#: addon/globalPlugins/visionAssistant/__init__.py:5171
 msgid "Error: Could not extract Instagram video."
 msgstr "Błąd: nie udało się pobrać wideo z Instagrama."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:4981
+#. Translators: Error message when the add-on fails to get a direct download link for a Twitter/X video.
+#: addon/globalPlugins/visionAssistant/__init__.py:5175
 msgid "Error: Could not extract Twitter video."
 msgstr "Błąd: nie udało się pobrać wideo z Twittera."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:4984
+#. Translators: Error message when the add-on fails to get a direct download link for a TikTok video.
+#: addon/globalPlugins/visionAssistant/__init__.py:5179
 msgid "Error: Could not extract TikTok video."
 msgstr "Błąd: nie udało się pobrać wideo z TikToka."
 
 #. Translators: Message reported when downloading video
-#: addon\globalPlugins\visionAssistant\__init__.py:4993
+#: addon/globalPlugins/visionAssistant/__init__.py:5188
 msgid "Downloading Video..."
 msgstr "Pobieranie wideo..."
 
 #. Translators: Error message when video download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:4999
+#: addon/globalPlugins/visionAssistant/__init__.py:5194
 msgid "Error: Download failed."
 msgstr "Błąd: pobieranie nie powiodło się."
 
 #. Translators: Message reported when uploading video to AI
-#: addon\globalPlugins\visionAssistant\__init__.py:5004
+#: addon/globalPlugins/visionAssistant/__init__.py:5199
 msgid "Uploading to AI..."
 msgstr "Przesyłanie do AI..."
 
 #. Translators: Message reported when analyzing YouTube video
-#: addon\globalPlugins\visionAssistant\__init__.py:5027
+#: addon/globalPlugins/visionAssistant/__init__.py:5222
 msgid "Analyzing YouTube..."
 msgstr "Analizowanie YouTube..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:5042
+#. Translators: Generic error message when something goes wrong during the online video analysis process.
+#: addon/globalPlugins/visionAssistant/__init__.py:5238
 msgid "Error processing video."
 msgstr "Błąd przetwarzania wideo."
 
-#. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:5062
+#. Translators: Message reported by NVDA when the user triggers the CAPTCHA solving command.
+#: addon/globalPlugins/visionAssistant/__init__.py:5258
 msgid "Solving..."
 msgstr "Rozwiązywanie..."
 
-#. Translators: Message reported when AI cannot find any CAPTCHA in the image
-#: addon\globalPlugins\visionAssistant\__init__.py:5088
+#. Translators: Message reported by NVDA when the AI cannot detect any CAPTCHA in the captured image.
+#: addon/globalPlugins/visionAssistant/__init__.py:5283
 msgid "No CAPTCHA detected."
 msgstr "Nie wykryto CAPTCHA."
 
-#. Translators: Message reported when calling the CAPTCHA solving command
-#: addon\globalPlugins\visionAssistant\__init__.py:5108
+#. Translators: Message reported by NVDA after successfully solving a text CAPTCHA, announcing the characters found.
+#: addon/globalPlugins/visionAssistant/__init__.py:5302
 #, python-brace-format
 msgid "Captcha: {text}"
 msgstr "Captcha: {text}"
 
 #. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:5120
+#: addon/globalPlugins/visionAssistant/__init__.py:5311
 msgid "Checking for updates..."
 msgstr "Sprawdzanie aktualizacji..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:5180
+#: addon/globalPlugins/visionAssistant/__init__.py:5371
 msgid "Translating Clipboard..."
 msgstr "Tłumaczenie schowka..."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:5185
+#: addon/globalPlugins/visionAssistant/__init__.py:5376
 msgid "Clipboard empty."
 msgstr "Schowek jest pusty."
 
 #. Translators: Message reported when the user tries to show the last result but none is stored.
-#: addon\globalPlugins\visionAssistant\__init__.py:5194
+#: addon/globalPlugins/visionAssistant/__init__.py:5385
 msgid "No previous result to show."
 msgstr "Brak poprzedniego wyniku do wyświetlenia."
 
 #. Translators: Message when opening documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:5232
+#: addon/globalPlugins/visionAssistant/__init__.py:5423
 msgid "Opening documentation..."
 msgstr "Otwieranie dokumentacji..."
 
 #. Translators: Error when help file is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:5242
+#: addon/globalPlugins/visionAssistant/__init__.py:5433
 msgid "Documentation file not found."
 msgstr "Nie znaleziono pliku dokumentacji."
+
+#. Translators: Status message when UI Explorer starts
+#: addon/globalPlugins/visionAssistant/__init__.py:5457
+msgid "UI Explorer Active"
+msgstr "Eksplorator interfejsu aktywny"
+
+#. Translators: Status message when UI Explorer stops
+#: addon/globalPlugins/visionAssistant/__init__.py:5462
+#: addon/globalPlugins/visionAssistant/__init__.py:5524
+msgid "UI Explorer Stopped"
+msgstr "Eksplorator interfejsu zatrzymany"
+
+#. Translators: Generic error message for AI failures
+#: addon/globalPlugins/visionAssistant/__init__.py:5480
+msgid "Unknown AI Error"
+msgstr "Nieznany błąd AI"
+
+#. Translators: Error shown when AI fails to find UI elements
+#: addon/globalPlugins/visionAssistant/__init__.py:5495
+msgid "AI failed to identify UI elements."
+msgstr "AI nie rozpoznało elementów interfejsu."
+
+#. Translators: Instruction for the elements list dialog
+#: addon/globalPlugins/visionAssistant/__init__.py:5510
+msgid "Select an element to click:"
+msgstr "Wybierz element do kliknięcia:"
+
+#: addon/globalPlugins/visionAssistant/__init__.py:5510
+msgid "UI Elements Explorer"
+msgstr "Eksplorator elementów interfejsu"
+
+#. Translators: Title and message for AI Operator command dialog
+#: addon/globalPlugins/visionAssistant/__init__.py:5532
+msgid "What should I do or what is your question?"
+msgstr "Co mam zrobić lub jakie jest twoje pytanie?"
+
+#. Translators: Fallback error message shown in the AI Operator if the server returns an empty or invalid response.
+#: addon/globalPlugins/visionAssistant/__init__.py:5576
+msgid "AI Error"
+msgstr "Błąd AI"
+
+#. Translators: Internal history label for user actions in operator sessions
+#: addon/globalPlugins/visionAssistant/__init__.py:5582
+msgid "Action performed. Checking result..."
+msgstr "Akcja wykonana. Sprawdzanie wyniku..."
+
+#. Translators: The title of the interactive chat dialog for the AI Operator feature.
+#: addon/globalPlugins/visionAssistant/__init__.py:5634
+#, python-brace-format
+msgid "{name} - AI Operator"
+msgstr "{name} – Operator AI"
+
+#. Translators: Labels for the AI and User in chat history
+#: addon/globalPlugins/visionAssistant/__init__.py:5645
+msgid "Operator"
+msgstr "Operator"
+
+#: addon/globalPlugins/visionAssistant/__init__.py:5645
+msgid "You"
+msgstr "Ty"
 
 #. Add-on summary/title, usually the user visible name of the add-on
 #. Translators: Summary/title for this add-on
@@ -2165,201 +2319,218 @@ msgstr ""
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:32
 msgid ""
-"## Changes for 5.5 (The Automation Update)\n"
+"## Changes for 5.5.2\n"
 "\n"
-"*   **AI Operator (Autonomous Control - Shift+A):** This is the crown jewel "
-"of v5.5. Vision Assistant Pro has graduated from being a passive assistant "
-"to becoming your personal **AI Operator**. It doesn't just describe the "
-"screen—it takes command.\n"
-"    *   *How it works:* You can now give verbal instructions to operate your "
-"PC. For example, in a completely inaccessible application where your screen "
-"reader stays silent, you can press **Shift+A** and type: *\"Click on the "
-"Settings button\"* or *\"Find the search field, type 'Latest News' and press "
-"enter.\"* The AI visually identifies the elements, moves the mouse, and "
-"executes the task for you.\n"
-"    *   *Performance Note:* This feature is optimized for **Gemini 3.0 Flash "
-"(Preview)**, delivering incredibly fast and intelligent responses that can "
-"handle even the most complex UI layouts.\n"
-"    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" "
-"exactly what's happening to be accurate, it sends a high-resolution "
-"screenshot with every step. Please note that frequent use will consume your "
-"API quota much faster than standard text-based tasks.\n"
-"*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled "
-"buttons\"? Press **E** to activate the UI Explorer. The AI will scan the "
-"entire window and generate a list of every clickable element it sees—"
-"including icons, graphics, and menus. Simply pick an item from the list, and "
-"the AI Operator will click it for you. It’s like having an \"accessible "
-"layer\" on top of any app.\n"
-"*   **Context-Aware Smart File Action (F):** The \"F\" key has been "
-"completely overhauled. It no longer assumes you only want OCR. When you "
-"select a single image, it now intelligently asks for your intent: you can "
-"choose a **Detailed Visual Description** to understand the scene or a "
-"**Structured Text Extraction (OCR)** for reading. The menu adapts "
-"dynamically based on the file type and your active AI engine.\n"
-"*   **Core Optimization:** We've performed a deep cleanup of the add-on’s "
-"internal logic, removing unused legacy functions and redundant code. This "
-"results in a leaner, faster, and more reliable experience for all users."
+"*   **Fixed AI Operator Typing Issue:** Resolved a bug where the letter 'v' "
+"was typed instead of pasting text on certain systems. This fix addresses "
+"timing conflicts that occurred during high system load.\n"
+"*   **Enhanced Stability:** Added robust error handling for clipboard "
+"operations to prevent addon crashes when the system clipboard is temporarily "
+"locked by other applications.\n"
+"*   **Timing Optimization:** Adjusted internal delays for keyboard events to "
+"ensure higher reliability across different system speeds and better "
+"compatibility with third-party Clipboard Managers."
 msgstr ""
-"## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
+"## Zmiany w 5.5.2\n"
 "\n"
-"*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.\n"
-"    *   *Jak to działa:* Możesz teraz wydawać polecenia głosowe dla obsługi swojego komputera. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
-"    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.\n"
-"    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi \"widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.\n"
-"*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po \"nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak \"warstwa dostępności\" nałożona na dowolną aplikację.\n"
-"*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz \"F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
-"*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla wszystkich użytkowników."
+"*   **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w którym "
+"litera „v\" była wpisywana zamiast wklejania tekstu na niektórych systemach. "
+"Poprawka usuwa konflikty czasowe występujące przy dużym obciążeniu systemu.\n"
+"*   **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na "
+"schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest tymczasowo "
+"zablokowany przez inne aplikacje.\n"
+"*   **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia "
+"zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych "
+"prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami "
+"schowka."
 
-#. Translators: Label for the UI Explorer system instruction prompt in the Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:492
-msgid "UI Explorer Instruction"
-msgstr "Instrukcja Eksploratora interfejsu"
+#~ msgid ""
+#~ "## Changes for 5.5.2\n"
+#~ "\n"
+#~ "*   **Fixed AI Operator Typing Issue:** Resolved a bug where the letter "
+#~ "'v' was typed instead of pasting text on certain systems. This fix "
+#~ "addresses timing conflicts that occurred during high system load.\n"
+#~ "*   **Enhanced Stability:** Added robust error handling for clipboard "
+#~ "operations to prevent addon crashes when the system clipboard is "
+#~ "temporarily locked by other applications.\n"
+#~ "*   **Timing Optimization:** Adjusted internal delays for keyboard events "
+#~ "to ensure higher reliability across different system speeds and better "
+#~ "compatibility with third-party Clipboard Managers.\n"
+#~ "\n"
+#~ "## Changes for 5.5 (The Automation Update)\n"
+#~ "\n"
+#~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown "
+#~ "jewel of v5.5. Vision Assistant Pro has graduated from being a passive "
+#~ "assistant to becoming your personal **AI Operator**. It doesn't just "
+#~ "describe the screen—it takes command.\n"
+#~ "    *   *How it works:* You can now give verbal instructions to operate "
+#~ "your PC. For example, in a completely inaccessible application where your "
+#~ "screen reader stays silent, you can press **Shift+A** and type: *\"Click "
+#~ "on the Settings button\"* or *\"Find the search field, type 'Latest News' "
+#~ "and press enter.\"* The AI visually identifies the elements, moves the "
+#~ "mouse, and executes the task for you.\n"
+#~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 "
+#~ "Flash (Preview)**, delivering incredibly fast and intelligent responses "
+#~ "that can handle even the most complex UI layouts.\n"
+#~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" "
+#~ "exactly what's happening to be accurate, it sends a high-resolution "
+#~ "screenshot with every step. Please note that frequent use will consume "
+#~ "your API quota much faster than standard text-based tasks.\n"
+#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled "
+#~ "buttons\"? Press **E** to activate the UI Explorer. The AI will scan the "
+#~ "entire window and generate a list of every clickable element it sees—"
+#~ "including icons, graphics, and menus. Simply pick an item from the list, "
+#~ "and the AI Operator will click it for you. It's like having an "
+#~ "\"accessible layer\" on top of any app.\n"
+#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been "
+#~ "completely overhauled. It no longer assumes you only want OCR. When you "
+#~ "select a single image, it now intelligently asks for your intent: you can "
+#~ "choose a **Detailed Visual Description** to understand the scene or a "
+#~ "**Structured Text Extraction (OCR)** for reading. The menu adapts "
+#~ "dynamically based on the file type and your active AI engine.\n"
+#~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on's "
+#~ "internal logic, removing unused legacy functions and redundant code. This "
+#~ "results in a leaner, faster, and more reliable experience for all users."
+#~ msgstr ""
+#~ "## Zmiany w 5.5.2\n"
+#~ "\n"
+#~ "*   **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w "
+#~ "którym litera „v\" była wpisywana zamiast wklejania tekstu na niektórych "
+#~ "systemach. Poprawka usuwa konflikty czasowe występujące przy dużym "
+#~ "obciążeniu systemu.\n"
+#~ "*   **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na "
+#~ "schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest "
+#~ "tymczasowo zablokowany przez inne aplikacje.\n"
+#~ "*   **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia "
+#~ "zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych "
+#~ "prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami "
+#~ "schowka.\n"
+#~ "\n"
+#~ "## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
+#~ "\n"
+#~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w "
+#~ "koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w "
+#~ "Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz "
+#~ "przejmuje sterowanie.\n"
+#~ "    *   *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby "
+#~ "obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej "
+#~ "aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i "
+#~ "wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole "
+#~ "wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI "
+#~ "wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za "
+#~ "Ciebie.\n"
+#~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini "
+#~ "3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych "
+#~ "odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami "
+#~ "interfejsu.\n"
+#~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi "
+#~ "„widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła "
+#~ "zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie "
+#~ "znacznie szybciej zużyje Twój limit API niż standardowe zadania "
+#~ "tekstowe.\n"
+#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po "
+#~ "„nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator "
+#~ "interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego "
+#~ "klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z "
+#~ "listy, a Operator AI kliknie go za Ciebie. To jak „warstwa dostępności\" "
+#~ "nałożona na dowolną aplikację.\n"
+#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz "
+#~ "„F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko "
+#~ "OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją "
+#~ "intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć "
+#~ "scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu "
+#~ "dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
+#~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie "
+#~ "wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny "
+#~ "kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla "
+#~ "wszystkich użytkowników."
 
-#. Translators: Feature name shown in the warning dialog when a user tries to eid the UI Explorer prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:495
-msgid "UI Explorer"
-msgstr "Eksplorator interfejsu"
+#~ msgid "Model Name:"
+#~ msgstr "Nazwa modelu:"
 
-#. Translators: Label for the AI Operator system instruction prompt in the Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:511
-msgid "AI Operator Instruction"
-msgstr "Instrukcja Operatora AI"
+#~ msgid "Default (Auto)"
+#~ msgstr "Domyślny (auto)"
 
-#. Translators: Feature name shown in the warning dialog when a user tries to edit the AI Operator prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:514
-#: addon\globalPlugins\visionAssistant\__init__.py:5388
-msgid "AI Operator"
-msgstr "Operator AI"
+#~ msgid "Recognizes text from a selected image or PDF file."
+#~ msgstr "Rozpoznaje tekst z wybranego obrazu lub pliku PDF."
 
-#. Translators: Label for a text field in the "Custom Provider Settings" section of settings where the user enters the AI Operator URL.
-#: addon\globalPlugins\visionAssistant\__init__.py:2332
-msgid "AI Operator URL:"
-msgstr "URL Operatora AI:"
+#~ msgid "Nothing to send."
+#~ msgstr "Brak treści do wysłania."
 
-#. Translators: Label for a text field in the "Custom Provider Settings" section of settings where the user manually enters the model name for AI Operator.
-#: addon\globalPlugins\visionAssistant\__init__.py:2337
-msgid "Custom Operator Model (Optional):"
-msgstr "Niestandardowy model Operatora (opcjonalne):"
+#~ msgid ""
+#~ "## Changes for 5.5 (The Automation Update)\n"
+#~ "\n"
+#~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown "
+#~ "jewel of v5.5. Vision Assistant Pro has graduated from being a passive "
+#~ "assistant to becoming your personal **AI Operator**. It doesn't just "
+#~ "describe the screen—it takes command.\n"
+#~ "    *   *How it works:* You can now give verbal instructions to operate "
+#~ "your PC. For example, in a completely inaccessible application where your "
+#~ "screen reader stays silent, you can press **Shift+A** and type: *\"Click "
+#~ "on the Settings button\"* or *\"Find the search field, type 'Latest News' "
+#~ "and press enter.\"* The AI visually identifies the elements, moves the "
+#~ "mouse, and executes the task for you.\n"
+#~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 "
+#~ "Flash (Preview)**, delivering incredibly fast and intelligent responses "
+#~ "that can handle even the most complex UI layouts.\n"
+#~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" "
+#~ "exactly what's happening to be accurate, it sends a high-resolution "
+#~ "screenshot with every step. Please note that frequent use will consume "
+#~ "your API quota much faster than standard text-based tasks.\n"
+#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled "
+#~ "buttons\"? Press **E** to activate the UI Explorer. The AI will scan the "
+#~ "entire window and generate a list of every clickable element it sees—"
+#~ "including icons, graphics, and menus. Simply pick an item from the list, "
+#~ "and the AI Operator will click it for you. It’s like having an "
+#~ "\"accessible layer\" on top of any app.\n"
+#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been "
+#~ "completely overhauled. It no longer assumes you only want OCR. When you "
+#~ "select a single image, it now intelligently asks for your intent: you can "
+#~ "choose a **Detailed Visual Description** to understand the scene or a "
+#~ "**Structured Text Extraction (OCR)** for reading. The menu adapts "
+#~ "dynamically based on the file type and your active AI engine.\n"
+#~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on’s "
+#~ "internal logic, removing unused legacy functions and redundant code. This "
+#~ "results in a leaner, faster, and more reliable experience for all users."
+#~ msgstr ""
+#~ "## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
+#~ "\n"
+#~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w "
+#~ "koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w "
+#~ "Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz "
+#~ "przejmuje sterowanie.\n"
+#~ "    *   *Jak to działa:* Możesz teraz wydawać polecenia głosowe dla "
+#~ "obsługi swojego komputera. Na przykład w całkowicie niedostępnej "
+#~ "aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i "
+#~ "wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole "
+#~ "wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI "
+#~ "wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za "
+#~ "Ciebie.\n"
+#~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini "
+#~ "3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych "
+#~ "odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami "
+#~ "interfejsu.\n"
+#~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi "
+#~ "\"widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła "
+#~ "zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie "
+#~ "znacznie szybciej zużyje Twój limit API niż standardowe zadania "
+#~ "tekstowe.\n"
+#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po "
+#~ "\"nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator "
+#~ "interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego "
+#~ "klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z "
+#~ "listy, a Operator AI kliknie go za Ciebie. To jak \"warstwa dostępności\" "
+#~ "nałożona na dowolną aplikację.\n"
+#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz "
+#~ "\"F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko "
+#~ "OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją "
+#~ "intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć "
+#~ "scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu "
+#~ "dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
+#~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie "
+#~ "wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny "
+#~ "kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla "
+#~ "wszystkich użytkowników."
 
-#. Translators: Label for a dropdown menu in the "Advanced Model Routing" section of settings to choose a specific model for AI Operator tasks.
-#: addon\globalPlugins\visionAssistant\__init__.py:2391
-msgid "AI Operator Model:"
-msgstr "Model Operatora AI:"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:2598
-msgid "Model Name (Manual):"
-msgstr "Nazwa modelu (ręcznie):"
-
-#. Translators: Option to follow the main model selected in the primary dropdown
-#. Translators: Option to follow the main model selected in the primary dropdown.
-#: addon\globalPlugins\visionAssistant\__init__.py:2674
-#: addon\globalPlugins\visionAssistant\__init__.py:2716
-msgid "Default (Main Model)"
-msgstr "Domyślny (model główny)"
-
-#. Translators: Option for the system to automatically choose the best model for this specific task
-#. Translators: Option for the system to automatically choose the best model for this task.
-#: addon\globalPlugins\visionAssistant\__init__.py:2676
-#: addon\globalPlugins\visionAssistant\__init__.py:2718
-msgid "Auto (Optimized)"
-msgstr "Auto (zoptymalizowane)"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:3826
-msgid ""
-"Performs smart actions (OCR or Description) on a selected image or PDF file."
-msgstr "Wykonuje inteligentne akcje (OCR lub opis) na wybranym pliku obrazu lub PDF."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4532
-msgid "Performs smart actions on a selected image or PDF file."
-msgstr "Wykonuje inteligentne akcje na wybranym pliku obrazu lub PDF."
-
-#. Translators: Options for the image file action menu
-#: addon\globalPlugins\visionAssistant\__init__.py:4568
-msgid "Extract Text (OCR)"
-msgstr "Wyodrębnij tekst (OCR)"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:4568
-msgid "Describe Image"
-msgstr "Opisz obraz"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:4571
-msgid "Image File"
-msgstr "Plik obrazu"
-
-#. Translators: Status reported when an image file is being analyzed
-#: addon\globalPlugins\visionAssistant\__init__.py:4581
-msgid "Analyzing Image File..."
-msgstr "Analizowanie pliku obrazu..."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:5307
-msgid "Toggles the interactive UI elements explorer."
-msgstr "Przełącza interaktywny eksplorator elementów interfejsu."
-
-#. Translators: Status message when UI Explorer starts
-#: addon\globalPlugins\visionAssistant\__init__.py:5313
-msgid "UI Explorer Active"
-msgstr "Eksplorator interfejsu aktywny"
-
-#. Translators: Status message when UI Explorer stops
-#: addon\globalPlugins\visionAssistant\__init__.py:5318
-#: addon\globalPlugins\visionAssistant\__init__.py:5380
-msgid "UI Explorer Stopped"
-msgstr "Eksplorator interfejsu zatrzymany"
-
-#. Translators: Generic error message for AI failures
-#: addon\globalPlugins\visionAssistant\__init__.py:5336
-msgid "Unknown AI Error"
-msgstr "Nieznany błąd AI"
-
-#. Translators: Error shown when AI fails to find UI elements
-#: addon\globalPlugins\visionAssistant\__init__.py:5351
-msgid "AI failed to identify UI elements."
-msgstr "AI nie rozpoznało elementów interfejsu."
-
-#. Translators: Instruction for the elements list dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:5366
-msgid "Select an element to click:"
-msgstr "Wybierz element do kliknięcia:"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:5366
-msgid "UI Elements Explorer"
-msgstr "Eksplorator elementów interfejsu"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:5382
-msgid "Asks the AI Operator to perform an action or describe the screen."
-msgstr "Prosi Operatora AI o wykonanie akcji lub opisanie ekranu."
-
-#. Translators: Title and message for AI Operator command dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:5388
-msgid "What should I do or what is your question?"
-msgstr "Co mam zrobić lub jakie jest twoje pytanie?"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:5429
-msgid "AI Error"
-msgstr "Błąd AI"
-
-#. Translators: Internal history label for user actions in operator sessions
-#: addon\globalPlugins\visionAssistant\__init__.py:5432
-msgid "Action performed. Checking result..."
-msgstr "Akcja wykonana. Sprawdzanie wyniku..."
-
-#. Translators: The title of the interactive chat dialog for the AI Operator feature.
-#: addon\globalPlugins\visionAssistant\__init__.py:5481
-#, python-brace-format
-msgid "{name} - AI Operator"
-msgstr "{name} – Operator AI"
-
-#. Translators: Labels for the AI and User in chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:5492
-msgid "Operator"
-msgstr "Operator"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:5492
-msgid "You"
-msgstr "Ty"
-
-#. Translators: Default text for successful AI action
-#: addon\globalPlugins\visionAssistant\__init__.py:5519
-msgid "Action performed"
-msgstr "Akcja wykonana"
+#~ msgid "Action performed"
+#~ msgstr "Akcja wykonana"


### PR DESCRIPTION
## Summary

Refreshes the Polish translation pack for 5.5.2:

- `addon/doc/pl/readme.md` — synced with 5.5 features (AI Operator, Visual UI Explorer, Smart File Action), section 1.4 updated to "AI (zaawansowany)", section 2 shortcut table updated (Shift+A operator, E explorer, F smart file action). 5.5 and 5.5.2 changelogs appended.
- `addon/locale/pl/LC_MESSAGES/nvda.po` — adds two new PL strings: `Auto-detect` → `Wykryj automatycznie`, and the AI Operator action description (`Aktywuje okno operatora ai.`). Other entries refreshed via `msgmerge` against the current `.pot`.
- `.gitignore` — ignore `.vibe/` workspace and `*.po~` backup files generated locally.

`buildVars.py` is intentionally untouched: per-version changelog convention is preserved (5.5.2 only), consistent with how the other locale changelogs in the repo are structured.

## Test plan

- [x] `scons pot` regenerates clean `.pot`
- [x] `msgmerge addon/locale/pl/LC_MESSAGES/nvda.po addon/locale/nvda.pot` clean
- [x] `scons` builds `VisionAssistant-5.5.2.nvda-addon` with the PL `manifest.ini` containing the translated `summary` / `description` / `changelog`
- [x] PL `readme.html` renders with the new sections and changelogs