### PR TITLE
Fix install task import issue

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,5 +1,6 @@
 import addonHandler
 import gui
+import config
 import os.path
 import sys
 import wx


### PR DESCRIPTION
### Issue

Installer of the add-on correctly installs it.
But when checking for an API key to remind the user to configure one, the following error occurs:

```
ERROR - unhandled exception (18:55:07.293) - MainThread (9840):
Traceback (most recent call last):
  File "wx\core.pyc", line 3425, in <lambda>
  File "C:\Users\cyril\AppData\Roaming\nvda\addons\VisionAssistant.pendingInstall\installTasks.py", line 26, in _doPostInstall
    conf = config.conf["VisionAssistant"]
           ^^^^^^
NameError: name 'config' is not defined
I
```

### Solution

Added the missing import

### Tests
Done with and without API key already configured.
