### PR TITLE
Fix lock screen errors

### DIFF
--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -1174,6 +1174,17 @@ def get_file_path(title, wildcard, mode="open", multiple=False):
         gui.mainFrame.postPopup()
     return None
 
+def get_object_location(obj):
+    """Get object location or retourn None if no location can be retrieved.
+    """
+    if obj is None:
+        return None
+    try:
+        return obj.location
+    except NotImplementedError:
+        return None
+
+
 class VirtualDocument:
     def __init__(self, file_paths):
         self.file_paths = file_paths
@@ -3885,7 +3896,7 @@ class CustomLabelOverlay(NVDAObjects.NVDAObject):
     def name(self):
         instance = _vision_assistant_instance
         uniqueId = instance._getAppId(self) if instance else self.appModule.appName
-        loc = self.location
+        loc = get_object_location(self)
         if not loc: return super().name
         key = f"{int(self.role)}:{loc.left},{loc.top}"
         cache = getattr(instance, "labels_cache", {})
@@ -6178,11 +6189,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         if not hasattr(self, "labels_cache"):
             return
         
-        if obj.windowClassName == "Internet Explorer_Server" or obj.appModule.appName.lower() in ["chrome", "msedge", "firefox", "opera", "brave"]:
+        if getattr(obj, "windowClassName", None) == "Internet Explorer_Server" or obj.appModule.appName.lower() in ["chrome", "msedge", "firefox", "opera", "brave"]:
             return
 
         uniqueId = self._getAppId(obj)
-        loc = obj.location
+        loc = get_object_location(obj)
         if not loc:
             return
         
@@ -6198,7 +6209,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     def script_labelObject(self, gesture):
         if self.toggling: self.finish()
         obj = api.getNavigatorObject()
-        if not obj or not obj.location: return
+        if not obj or not get_object_location(obj): return
         if obj.appModule.appName.lower() in ["chrome", "msedge", "firefox", "opera", "brave"]:
             # Translators: Message shown when a user tries to use AI labeling in a web browser.
             ui.message(_("AI Labeling is currently not supported in web browsers."))


### PR DESCRIPTION
### Issue

When locking the screen with 6.0.2, the following errors may be logged:


```
ERROR - NVDAObjects.__call__ (15:24:01.046) - MainThread (19404):
Exception in chooseNVDAObjectOverlayClasses for GlobalPlugin ('globalPlugins.visionAssistant')
Traceback (most recent call last):
  File "NVDAObjects\__init__.pyc", line 128, in __call__
  File "C:\Users\cyril\AppData\Roaming\nvda\addons\VisionAssistant\globalPlugins\visionAssistant\__init__.py", line 6192, in chooseNVDAObjectOverlayClasses
    if obj.windowClassName == "Internet Explorer_Server" or obj.appModule.appName.lower() in ["chrome", "msedge", "firefox", "opera", "brave"]:
       ^^^^^^^^^^^^^^^^^^^
AttributeError: '_SecureDesktopNVDAObject' object has no attribute 'windowClassName'
```

With 6.0, another attribute error related to location was logged.

### Solution

The `location`  or `windowClassName` attributes do not always exist for any `NVDAObject`. When needed, test their existence before using them.
I have added these checks where it seems to me that they may be required.

### Tests

* Tested that no error occurs when locking the computer.

Warning: No other tests performed: I do not know the tagging code enough to be able to test it. @mahmoodhozhabri can you test what is relevant?

### Additional notes

@mahmoodhozhabri please review this code carefully, especially to confirm where .location were needed or not. Thanks.
Let me know if I need to modify something.
