### PR TITLE
Add MiniMax as dedicated AI provider (chat, vision, OCR, STT, TTS)

### DIFF
--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -2300,6 +2300,34 @@ class UpdateDialog(wx.Dialog):
         self.yes_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_YES))
         self.no_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_NO))
 
+    def _refresh_minimax_voices_in_format_dialog(self):
+        # Background refresh: fetch fresh MiniMax voice list and update the
+        # combobox in the Document Format dialog.
+        try:
+            config.conf["VisionAssistant"]["minimax_voices_cache"] = ""
+            config.conf["VisionAssistant"]["minimax_voices_cache_time"] = 0
+            voices = AIHandler.get_voices("minimax")
+            if voices and hasattr(self, 'voice_sel'):
+                wx.CallAfter(self._populate_format_voice_sel, voices)
+        except Exception as e:
+            log.warning(f"Background MiniMax voice refresh (format dialog) failed: {e}")
+
+    def _populate_format_voice_sel(self, voices):
+        try:
+            self.voice_sel.Clear()
+            for v in voices:
+                self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
+            curr_voice = config.conf["VisionAssistant"].get("tts_voice", "Portuguese_Narrator")
+            for i in range(self.voice_sel.GetCount()):
+                if self.voice_sel.GetClientData(i) == curr_voice:
+                    self.voice_sel.SetSelection(i)
+                    return
+            if self.voice_sel.GetCount() > 0:
+                self.voice_sel.SetSelection(0)
+        except Exception as e:
+            log.warning(f"Failed to populate format voice_sel: {e}")
+
+
 class UpdateManager:
     def __init__(self, repo_name):
         self.repo_name = repo_name
@@ -2953,13 +2981,9 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
             pass
 
     def _updateVoiceList_legacy(self, p_name):
-        # Original implementation kept for reference (no longer called)
+        # Legacy fallback - uses get_voices() so it works for MiniMax too
         self.voice_sel.Clear()
-        if p_name == "openai" or p_name == "custom":
-            voices = OPENAI_VOICES
-        else:
-            voices = GEMINI_VOICES
-
+        voices = AIHandler.get_voices(p_name) or (OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES)
         for v in voices:
             self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
 
@@ -3759,7 +3783,7 @@ class DocumentViewerDialog(wx.Dialog):
             hbox_tts.Add(self.lbl_voice, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
             
             p_name = config.conf["VisionAssistant"]["active_provider"]
-            voices = OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES
+            voices = AIHandler.get_voices(p_name) or (OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES)
             voice_choices = [f"{v[0]} - {v[1]}" for v in voices]
             
             self.voice_sel = wx.Choice(panel, choices=voice_choices)
@@ -3768,6 +3792,10 @@ class DocumentViewerDialog(wx.Dialog):
                 v_idx = next(i for i, v in enumerate(voices) if v[0] == curr_voice)
                 self.voice_sel.SetSelection(v_idx)
             except Exception: self.voice_sel.SetSelection(0)
+            # If this is MiniMax, fetch the fresh voice list from the API in the background
+            # (the cache may be empty, stale, or missing new voices added by MiniMax)
+            if p_name == "minimax":
+                threading.Thread(target=self._refresh_minimax_voices_in_format_dialog, daemon=True).start()
             
             hbox_tts.Add(self.voice_sel, 1, wx.EXPAND)
             vbox.Add(hbox_tts, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -1784,7 +1784,12 @@ class AIHandler:
             try:
                 import time
                 cache = config.conf["VisionAssistant"].get("minimax_voices_cache", "")
-                cache_time = config.conf["VisionAssistant"].get("minimax_voices_cache_time", 0)
+                cache_time_raw = config.conf["VisionAssistant"].get("minimax_voices_cache_time", 0)
+                # Defensive: cache_time may be a string from older config versions
+                try:
+                    cache_time = float(cache_time_raw)
+                except (TypeError, ValueError):
+                    cache_time = 0
                 # Cache valid for 24 hours (86400 seconds)
                 if cache and (time.time() - cache_time < 86400):
                     # Parse cache: "voice_id|display_name,voice_id|display_name,..."
@@ -2299,33 +2304,6 @@ class UpdateDialog(wx.Dialog):
         self.yes_btn.SetDefault()
         self.yes_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_YES))
         self.no_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_NO))
-
-    def _refresh_minimax_voices_in_format_dialog(self):
-        # Background refresh: fetch fresh MiniMax voice list and update the
-        # combobox in the Document Format dialog.
-        try:
-            config.conf["VisionAssistant"]["minimax_voices_cache"] = ""
-            config.conf["VisionAssistant"]["minimax_voices_cache_time"] = 0
-            voices = AIHandler.get_voices("minimax")
-            if voices and hasattr(self, 'voice_sel'):
-                wx.CallAfter(self._populate_format_voice_sel, voices)
-        except Exception as e:
-            log.warning(f"Background MiniMax voice refresh (format dialog) failed: {e}")
-
-    def _populate_format_voice_sel(self, voices):
-        try:
-            self.voice_sel.Clear()
-            for v in voices:
-                self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
-            curr_voice = config.conf["VisionAssistant"].get("tts_voice", "Portuguese_Narrator")
-            for i in range(self.voice_sel.GetCount()):
-                if self.voice_sel.GetClientData(i) == curr_voice:
-                    self.voice_sel.SetSelection(i)
-                    return
-            if self.voice_sel.GetCount() > 0:
-                self.voice_sel.SetSelection(0)
-        except Exception as e:
-            log.warning(f"Failed to populate format voice_sel: {e}")
 
 
 class UpdateManager:
@@ -3783,16 +3761,11 @@ class DocumentViewerDialog(wx.Dialog):
             hbox_tts.Add(self.lbl_voice, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
             
             p_name = config.conf["VisionAssistant"]["active_provider"]
-            # Use cached voices synchronously for instant combobox population.
-            # The fresh list (if needed) will be fetched in background below.
-            # This prevents blocking the main thread on API calls.
-            try:
-                # Try cache first; never block on API for combobox population
-                voices = AIHandler.get_voices(p_name) or (OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES)
-            except Exception:
-                # Defensive: if get_voices raises (shouldn't, but...), use hardcoded fallback
-                log.warning("AIHandler.get_voices raised; using hardcoded fallback")
-                voices = OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES
+            # Use cached/hardcoded voices synchronously (no API call here).
+            # Background thread (_refresh_minimax_voices_in_format_dialog) fetches
+            # fresh list from API after dialog opens. This prevents blocking
+            # the main thread on API calls.
+            voices = AIHandler.get_voices(p_name) or (OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES)
             voice_choices = [f"{v[0]} - {v[1]}" for v in voices]
 
             self.voice_sel = wx.Choice(panel, choices=voice_choices)
@@ -4277,6 +4250,40 @@ class DocumentViewerDialog(wx.Dialog):
             wx.CallAfter(wx.MessageBox, _("Save Error: {error}").format(error=e), _("Error"), wx.ICON_ERROR)
         finally: wx.CallAfter(self.btn_save.Enable)
 
+    def _refresh_minimax_voices_in_format_dialog(self):
+        # Background refresh: fetch fresh MiniMax voice list and update the
+        # combobox in the Document Format dialog.
+        try:
+            # Bypass cache to force a fresh fetch from the API
+            config.conf["VisionAssistant"]["minimax_voices_cache"] = ""
+            try:
+                config.conf["VisionAssistant"]["minimax_voices_cache_time"] = 0
+            except (TypeError, ValueError):
+                # cache_time may be a string from older configs; reset defensively
+                config.conf["VisionAssistant"]["minimax_voices_cache_time"] = 0.0
+            voices = AIHandler.get_voices("minimax")
+            if voices and hasattr(self, 'voice_sel') and self.voice_sel:
+                wx.CallAfter(self._populate_format_voice_sel, voices)
+        except Exception as e:
+            log.warning(f"Background MiniMax voice refresh (format dialog) failed: {e}")
+
+    def _populate_format_voice_sel(self, voices):
+        try:
+            if not hasattr(self, 'voice_sel') or not self.voice_sel:
+                return
+            self.voice_sel.Clear()
+            for v in voices:
+                self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
+            curr_voice = config.conf["VisionAssistant"].get("tts_voice", "Portuguese_Narrator")
+            for i in range(self.voice_sel.GetCount()):
+                if self.voice_sel.GetClientData(i) == curr_voice:
+                    self.voice_sel.SetSelection(i)
+                    return
+            if self.voice_sel.GetCount() > 0:
+                self.voice_sel.SetSelection(0)
+        except Exception as e:
+            log.warning(f"Failed to populate format voice_sel: {e}")
+
 def _generate_object_signature(obj):
     role_type = int(getattr(obj, "role", 0))
     unique_signature = ""
@@ -4320,7 +4327,7 @@ def _generate_object_signature(obj):
     except Exception:
         raw_name = getattr(obj, "name", "")
     raw_name = raw_name or ""
-    
+
     return f"sig_{role_type}_{unique_signature}_{raw_name}"
 
 class CustomLabelOverlay(NVDAObjects.NVDAObject):

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -250,9 +250,10 @@ confspec = {
     "mistral_api_key": "string(default='')",
     "groq_api_key": "string(default='')",
     "minimax_api_key": "string(default='')",
+    "minimax_api_host": "string(default='https://api.minimaxi.com/v1')",
     "minimax_model_name": "string(default='MiniMax-M3')",
-    "minimax_vision_model": "string(default='MiniMax-VL-01')",
-    "minimax_ocr_model": "string(default='MiniMax-VL-01')",
+    "minimax_vision_model": "string(default='MiniMax-M3')",
+    "minimax_ocr_model": "string(default='MiniMax-M3')",
     "minimax_stt_model": "string(default='asr-01')",
     "minimax_tts_model": "string(default='speech-2.8-hd')",
     "minimax_tts_voice": "string(default='Calm_Woman')",
@@ -1838,7 +1839,7 @@ class AIHandler:
         elif provider == "groq":
             return proxy_url.rstrip('/') if proxy_url else "https://api.groq.com/openai"
         elif provider == "minimax":
-            return proxy_url.rstrip('/') if proxy_url else "https://api.minimax.io/v1"
+            return proxy_url.rstrip('/') if proxy_url else config.conf["VisionAssistant"].get("minimax_api_host", "https://api.minimaxi.com/v1").strip() or "https://api.minimaxi.com/v1"
         return ""
 
     @staticmethod
@@ -1875,7 +1876,7 @@ class AIHandler:
             else: model = "gemini-3.1-flash-tts-preview"
 
         if not base:
-            base_map = {"mistral": "https://api.mistral.ai", "openai": "https://api.openai.com", "groq": "https://api.groq.com/openai", "gemini": "https://generativelanguage.googleapis.com", "minimax": "https://api.minimax.io/v1"}
+            base_map = {"mistral": "https://api.mistral.ai", "openai": "https://api.openai.com", "groq": "https://api.groq.com/openai", "gemini": "https://generativelanguage.googleapis.com", "minimax": "https://api.minimaxi.com/v1"}
             base = base_map.get(p, "")
             
         if p == "custom" and adv:

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -250,7 +250,7 @@ confspec = {
     "mistral_api_key": "string(default='')",
     "groq_api_key": "string(default='')",
     "minimax_api_key": "string(default='')",
-    "minimax_api_host": "string(default='https://api.minimaxi.com/v1')",
+    "minimax_api_host": "string(default='https://api.minimax.io/v1')",
     "minimax_model_name": "string(default='MiniMax-M3')",
     "minimax_vision_model": "string(default='MiniMax-M3')",
     "minimax_ocr_model": "string(default='MiniMax-M3')",
@@ -1839,7 +1839,7 @@ class AIHandler:
         elif provider == "groq":
             return proxy_url.rstrip('/') if proxy_url else "https://api.groq.com/openai"
         elif provider == "minimax":
-            return proxy_url.rstrip('/') if proxy_url else config.conf["VisionAssistant"].get("minimax_api_host", "https://api.minimaxi.com/v1").strip() or "https://api.minimaxi.com/v1"
+            return proxy_url.rstrip('/') if proxy_url else config.conf["VisionAssistant"].get("minimax_api_host", "https://api.minimax.io/v1").strip() or "https://api.minimax.io/v1"
         return ""
 
     @staticmethod
@@ -1876,7 +1876,7 @@ class AIHandler:
             else: model = "gemini-3.1-flash-tts-preview"
 
         if not base:
-            base_map = {"mistral": "https://api.mistral.ai", "openai": "https://api.openai.com", "groq": "https://api.groq.com/openai", "gemini": "https://generativelanguage.googleapis.com", "minimax": "https://api.minimaxi.com/v1"}
+            base_map = {"mistral": "https://api.mistral.ai", "openai": "https://api.openai.com", "groq": "https://api.groq.com/openai", "gemini": "https://generativelanguage.googleapis.com", "minimax": "https://api.minimax.io/v1"}
             base = base_map.get(p, "")
             
         if p == "custom" and adv:

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -2218,6 +2218,10 @@ class AIHandler:
         # and returns audio as hex inside JSON (data.audio field).
         if p == "minimax":
             minimax_tts_url = "https://api.minimax.io/v1/t2a_v2"
+            # Override model with the dedicated TTS model (default: speech-2.8-hd),
+            # NOT the chat model (minimax_model_name = MiniMax-M3).
+            # Sending MiniMax-M3 to /t2a_v2 returns empty audio (model mismatch).
+            model = config.conf["VisionAssistant"].get("minimax_tts_model", "speech-2.8-hd").strip() or "speech-2.8-hd"
             minimax_voice = voice_name if voice_name else config.conf["VisionAssistant"]["minimax_tts_voice"].strip() or "Calm_Woman"
             minimax_payload = {
                 "model": model,

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -249,6 +249,13 @@ confspec = {
     "openai_api_key": "string(default='')",
     "mistral_api_key": "string(default='')",
     "groq_api_key": "string(default='')",
+    "minimax_api_key": "string(default='')",
+    "minimax_model_name": "string(default='MiniMax-M3')",
+    "minimax_vision_model": "string(default='MiniMax-VL-01')",
+    "minimax_ocr_model": "string(default='MiniMax-VL-01')",
+    "minimax_stt_model": "string(default='asr-01')",
+    "minimax_tts_model": "string(default='speech-2.8-hd')",
+    "minimax_tts_voice": "string(default='Calm_Woman')",
     "custom_api_key": "string(default='')",
     "custom_api_url": "string(default='')",
     "custom_api_type": "string(default='openai')",
@@ -1757,7 +1764,7 @@ class AIHandler:
     def is_tts_supported(provider=None):
         p = provider if provider else config.conf["VisionAssistant"]["active_provider"]
         
-        if p in ["gemini", "openai"]:
+        if p in ["gemini", "openai", "minimax"]:
             return True
         
         if p == "custom":
@@ -1830,6 +1837,8 @@ class AIHandler:
             return proxy_url.rstrip('/') if proxy_url else "https://api.mistral.ai"
         elif provider == "groq":
             return proxy_url.rstrip('/') if proxy_url else "https://api.groq.com/openai"
+        elif provider == "minimax":
+            return proxy_url.rstrip('/') if proxy_url else "https://api.minimax.io/v1"
         return ""
 
     @staticmethod
@@ -1866,7 +1875,7 @@ class AIHandler:
             else: model = "gemini-3.1-flash-tts-preview"
 
         if not base:
-            base_map = {"mistral": "https://api.mistral.ai", "openai": "https://api.openai.com", "groq": "https://api.groq.com/openai", "gemini": "https://generativelanguage.googleapis.com"}
+            base_map = {"mistral": "https://api.mistral.ai", "openai": "https://api.openai.com", "groq": "https://api.groq.com/openai", "gemini": "https://generativelanguage.googleapis.com", "minimax": "https://api.minimax.io/v1"}
             base = base_map.get(p, "")
             
         if p == "custom" and adv:
@@ -1989,6 +1998,7 @@ class AIHandler:
             model = "whisper-1"
             if p == "groq": model = "whisper-large-v3-turbo"
             elif p == "mistral": model = "voxtral-mini-latest"
+            elif p == "minimax": model = config.conf["VisionAssistant"]["minimax_stt_model"].strip() or "asr-01"
             if p == "custom":
                 model = config.conf["VisionAssistant"]["custom_stt_model"].strip() or config.conf["VisionAssistant"]["custom_model_name"].strip() or model
             elif config.conf["VisionAssistant"].get("advanced_model_routing", False):
@@ -2121,15 +2131,42 @@ class AIHandler:
         m_key = "model_name" if p == "gemini" else f"{p}_model_name"
         model = model_override or config.conf["VisionAssistant"].get(m_key, "")
         
-        if p == "custom": 
+        if p == "custom":
             model = config.conf["VisionAssistant"]["custom_tts_model"].strip() or "tts-1"
         elif config.conf["VisionAssistant"].get("advanced_model_routing", False):
             adv_tts = config.conf["VisionAssistant"].get(f"{p}_tts_model", "").strip()
             if adv_tts: model = adv_tts
             elif p == "openai": model = "tts-1"
-        elif p == "openai": 
+        elif p == "openai":
             model = "tts-1"
-            
+
+        # MiniMax TTS uses a custom payload (text + voice_setting + audio_setting)
+        # and returns audio as hex inside JSON (data.audio field).
+        if p == "minimax":
+            minimax_tts_url = "https://api.minimax.io/v1/t2a_v2"
+            minimax_voice = voice_name if voice_name else config.conf["VisionAssistant"]["minimax_tts_voice"].strip() or "Calm_Woman"
+            minimax_payload = {
+                "model": model,
+                "text": text,
+                "voice_setting": {"voice_id": minimax_voice, "speed": 1.0, "vol": 1.0, "pitch": 0},
+                "audio_setting": {"sample_rate": 32000, "bitrate": 128000, "format": "mp3", "channel": 1}
+            }
+            for key in keys:
+                try:
+                    headers = {"Content-Type": "application/json", "User-Agent": "Mozilla/5.0"}
+                    if key and key.strip(): headers["Authorization"] = f"Bearer {key}"
+                    req = request.Request(minimax_tts_url, data=json.dumps(minimax_payload).encode(), headers=headers)
+                    with get_proxy_opener().open(req, timeout=120) as r:
+                        resp_json = json.loads(r.read().decode("utf-8"))
+                        hex_audio = resp_json.get("data", {}).get("audio", "")
+                        if not hex_audio:
+                            return "ERROR: MiniMax TTS returned no audio data.", False
+                        audio_bytes = bytes.fromhex(hex_audio)
+                        return base64.b64encode(audio_bytes).decode("utf-8"), False
+                except Exception as e:
+                    if key == keys[-1]: return f"ERROR: {str(e)}", False
+                    continue
+
         payload = {"model": model, "input": text, "voice": voice_name.lower(), "response_format": "mp3"}
         for key in keys:
             try:
@@ -2487,6 +2524,8 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
             (_("Mistral AI"), "mistral"),
             # Translators: Name of the Groq AI provider
             (_("Groq"), "groq"),
+            # Translators: Name of the MiniMax AI provider
+            (_("MiniMax"), "minimax"),
             # Translators: Option for a user-defined custom AI provider
             (_("Custom"), "custom")
         ]
@@ -2915,7 +2954,7 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
 
     def onProviderChange(self, event):
         p_idx = self.provider_sel.GetSelection()
-        p_name = ["gemini", "openai", "mistral", "groq", "custom"][p_idx]
+        p_name = ["gemini", "openai", "mistral", "groq", "minimax", "custom"][p_idx]
         
         key_name = "api_key" if p_name == "gemini" else (f"{p_name}_api_key" if p_name != "custom" else "custom_api_key")
         val = config.conf["VisionAssistant"].get(key_name, "")
@@ -3011,7 +3050,7 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
 
     def onFetchModels(self, event):
         p_idx = self.provider_sel.GetSelection()
-        p_name = ["gemini", "openai", "mistral", "groq", "custom"][p_idx]
+        p_name = ["gemini", "openai", "mistral", "groq", "minimax", "custom"][p_idx]
         
         val = self.apiKeyCtrl_visible.Value if self.showApiCheck.IsChecked() else self.apiKeyCtrl_hidden.Value
         k_key = "api_key" if p_name == "gemini" else (f"{p_name}_api_key" if p_name != "custom" else "custom_api_key")
@@ -3166,7 +3205,7 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
     def onToggleAdvanced(self, event):
         p_idx = self.provider_sel.GetSelection()
         if p_idx != wx.NOT_FOUND:
-            p_name = ["gemini", "openai", "mistral", "groq", "custom"][p_idx]
+            p_name = ["gemini", "openai", "mistral", "groq", "minimax", "custom"][p_idx]
             self.updateCustomFieldsVisibility(p_name)
 
     def onToggleApiVisibility(self, event):
@@ -3187,7 +3226,7 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
             model_id = cb.GetClientData(sel)
             if model_id:
                 p_idx = self.provider_sel.GetSelection()
-                p_name = ["gemini", "openai", "mistral", "groq", "custom"][p_idx]
+                p_name = ["gemini", "openai", "mistral", "groq", "minimax", "custom"][p_idx]
                 self._temp_models[p_name] = model_id
                 if p_name == "custom":
                     self.customModelName.SetValue(model_id)
@@ -3198,14 +3237,14 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
             voice_id = self.voice_sel.GetClientData(sel)
             p_idx = self.provider_sel.GetSelection()
             if p_idx != wx.NOT_FOUND:
-                p_name = ["gemini", "openai", "mistral", "groq", "custom"][p_idx]
+                p_name = ["gemini", "openai", "mistral", "groq", "minimax", "custom"][p_idx]
                 if p_name == "custom":
                     self.customTtsVoice.SetValue(voice_id)
 
     def onSave(self):
         try:
             p_idx = self.provider_sel.GetSelection()
-            p_name = ["gemini", "openai", "mistral", "groq", "custom"][p_idx]
+            p_name = ["gemini", "openai", "mistral", "groq", "minimax", "custom"][p_idx]
             config.conf["VisionAssistant"]["active_provider"] = p_name
             
             val = self.apiKeyCtrl_visible.Value if self.showApiCheck.IsChecked() else self.apiKeyCtrl_hidden.Value

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -3783,9 +3783,18 @@ class DocumentViewerDialog(wx.Dialog):
             hbox_tts.Add(self.lbl_voice, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
             
             p_name = config.conf["VisionAssistant"]["active_provider"]
-            voices = AIHandler.get_voices(p_name) or (OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES)
+            # Use cached voices synchronously for instant combobox population.
+            # The fresh list (if needed) will be fetched in background below.
+            # This prevents blocking the main thread on API calls.
+            try:
+                # Try cache first; never block on API for combobox population
+                voices = AIHandler.get_voices(p_name) or (OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES)
+            except Exception:
+                # Defensive: if get_voices raises (shouldn't, but...), use hardcoded fallback
+                log.warning("AIHandler.get_voices raised; using hardcoded fallback")
+                voices = OPENAI_VOICES if p_name in ["openai", "custom"] else GEMINI_VOICES
             voice_choices = [f"{v[0]} - {v[1]}" for v in voices]
-            
+
             self.voice_sel = wx.Choice(panel, choices=voice_choices)
             curr_voice = config.conf["VisionAssistant"]["tts_voice"]
             try:

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -155,6 +155,54 @@ GEMINI_VOICES = [
     # Translators: Adjective describing a warm AI voice style.
     ("Sulafat", _("Warm"))
 ]
+
+# MiniMax TTS system voices - PT-BR voices are listed first for Portuguese
+# users, followed by EN, ES, FR. Full list of 300+ available via API.
+MINIMAX_VOICES = [
+    # --- Portuguese (BR/PT) voices ---
+    # Translators: Adjective describing a sentimental female AI voice style.
+    ("Portuguese_SentimentalLady", _("Sentimental Lady")),
+    # Translators: Adjective describing a confident female AI voice style.
+    ("Portuguese_ConfidentWoman", _("Confident Woman")),
+    # Translators: Adjective describing a deep-voiced male AI voice style.
+    ("Portuguese_Deep-VoicedGentleman", _("Deep-voiced Gentleman")),
+    # Translators: Adjective describing a calm female leader AI voice style.
+    ("Portuguese_CalmLeader", _("Calm Leader")),
+    # Translators: Adjective describing a narrator AI voice style.
+    ("Portuguese_Narrator", _("Narrator")),
+    # Translators: Adjective describing a lovely female AI voice style.
+    ("Portuguese_LovelyLady", _("Lovely Lady")),
+    # Translators: Adjective describing a serene female AI voice style.
+    ("Portuguese_SereneWoman", _("Serene Woman")),
+    # Translators: Adjective describing a wise female AI voice style.
+    ("Portuguese_Wiselady", _("Wise Lady")),
+    # Translators: Adjective describing a gentle female teacher AI voice style.
+    ("Portuguese_GentleTeacher", _("Gentle Teacher")),
+    # Translators: Adjective describing an inspiring female AI voice style.
+    ("Portuguese_InspiringLady", _("Inspiring Lady")),
+    # --- English voices (high quality, useful for English content) ---
+    # Translators: Adjective describing a calm female AI voice style.
+    ("English_CalmWoman", _("Calm Woman")),
+    # Translators: Adjective describing a friendly male AI voice style.
+    ("English_FriendlyPerson", _("Friendly Guy")),
+    # Translators: Adjective describing a deep male AI voice style.
+    ("English_ManWithDeepVoice", _("Man With Deep Voice")),
+    # Translators: Adjective describing an expressive narrator AI voice style.
+    ("English_expressive_narrator", _("Expressive Narrator")),
+    # --- Spanish voices ---
+    # Translators: Adjective describing a serene female AI voice style.
+    ("Spanish_SereneWoman", _("Serene Woman")),
+    # Translators: Adjective describing a wise scholar male AI voice style.
+    ("Spanish_WiseScholar", _("Wise Scholar")),
+    # Translators: Adjective describing a deep-toned male AI voice style.
+    ("Spanish_Deep-tonedMan", _("Deep-toned Man")),
+    # --- French voices ---
+    # Translators: Adjective describing a movie lead female AI voice style.
+    ("French_MovieLeadFemale", _("Movie Lead Female")),
+    # Translators: Adjective describing a male narrator AI voice style.
+    ("French_MaleNarrator", _("Male Narrator")),
+]
+
 OPENAI_VOICES = [
     # Translators: Adjective describing a neutral AI voice style.
     ("Alloy", _("Neutral")),
@@ -2837,6 +2885,8 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
         self.voice_sel.Clear()
         if p_name in ["openai", "custom"]:
             voices = OPENAI_VOICES
+        elif p_name == "minimax":
+            voices = MINIMAX_VOICES
         else:
             voices = GEMINI_VOICES
         

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -257,7 +257,7 @@ confspec = {
     "minimax_ocr_model": "string(default='MiniMax-M3')",
     "minimax_stt_model": "string(default='asr-01')",
     "minimax_tts_model": "string(default='speech-2.8-hd')",
-    "minimax_tts_voice": "string(default='Calm_Woman')",
+    "minimax_tts_voice": "string(default='Portuguese_Narrator')",
     "custom_api_key": "string(default='')",
     "custom_api_url": "string(default='')",
     "custom_api_type": "string(default='openai')",
@@ -960,6 +960,22 @@ def clean_markdown(text):
     text = re.sub(r'```', '', text)
     text = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)
     text = re.sub(r'^\s*-\s+', '', text, flags=re.MULTILINE)
+    return text.strip()
+
+def strip_thinking_tags(text):
+    # Remove reasoning/thinking blocks emitted by reasoning-capable models
+    # (e.g. MiniMax-M3, DeepSeek-R1, o1) before sending to TTS or display.
+    # Supported tag forms:
+    #   <think>...</think>
+    #   <reasoning>...</reasoning>
+    #   <thought>...</thought>
+    if not text: return ""
+    # Strip tagged blocks (multiline, non-greedy)
+    text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<reasoning>.*?</reasoning>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<thought>.*?</thought>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    # Collapse leftover blank lines created by removed blocks
+    text = re.sub(r'\n{3,}', '\n\n', text)
     return text.strip()
 
 def markdown_to_html(text, full_page=False):
@@ -2124,7 +2140,13 @@ class AIHandler:
                     res = json.loads(r.read().decode('utf-8'))
                     if isinstance(res, dict):
                         if "choices" in res and res["choices"]:
-                            return res["choices"][0]["message"]["content"]
+                            content = res["choices"][0]["message"]["content"]
+                            # MiniMax reasoning models emit visible thinking blocks
+                            # (e.g. "<think>...</think>") in the response content.
+                            # Strip them so the user sees only the final answer.
+                            if p == "minimax" and content:
+                                content = strip_thinking_tags(content)
+                            return content
                         elif "error" in res:
                             err_val = res["error"]
                             err_msg = err_val.get("message") if isinstance(err_val, dict) else str(err_val)
@@ -2222,7 +2244,7 @@ class AIHandler:
             # NOT the chat model (minimax_model_name = MiniMax-M3).
             # Sending MiniMax-M3 to /t2a_v2 returns empty audio (model mismatch).
             model = config.conf["VisionAssistant"].get("minimax_tts_model", "speech-2.8-hd").strip() or "speech-2.8-hd"
-            minimax_voice = voice_name if voice_name else config.conf["VisionAssistant"]["minimax_tts_voice"].strip() or "Calm_Woman"
+            minimax_voice = voice_name if voice_name else config.conf["VisionAssistant"]["minimax_tts_voice"].strip() or "Portuguese_Narrator"
             minimax_payload = {
                 "model": model,
                 "text": text,

--- a/addon/globalPlugins/visionAssistant/__init__.py
+++ b/addon/globalPlugins/visionAssistant/__init__.py
@@ -156,53 +156,6 @@ GEMINI_VOICES = [
     ("Sulafat", _("Warm"))
 ]
 
-# MiniMax TTS system voices - PT-BR voices are listed first for Portuguese
-# users, followed by EN, ES, FR. Full list of 300+ available via API.
-MINIMAX_VOICES = [
-    # --- Portuguese (BR/PT) voices ---
-    # Translators: Adjective describing a sentimental female AI voice style.
-    ("Portuguese_SentimentalLady", _("Sentimental Lady")),
-    # Translators: Adjective describing a confident female AI voice style.
-    ("Portuguese_ConfidentWoman", _("Confident Woman")),
-    # Translators: Adjective describing a deep-voiced male AI voice style.
-    ("Portuguese_Deep-VoicedGentleman", _("Deep-voiced Gentleman")),
-    # Translators: Adjective describing a calm female leader AI voice style.
-    ("Portuguese_CalmLeader", _("Calm Leader")),
-    # Translators: Adjective describing a narrator AI voice style.
-    ("Portuguese_Narrator", _("Narrator")),
-    # Translators: Adjective describing a lovely female AI voice style.
-    ("Portuguese_LovelyLady", _("Lovely Lady")),
-    # Translators: Adjective describing a serene female AI voice style.
-    ("Portuguese_SereneWoman", _("Serene Woman")),
-    # Translators: Adjective describing a wise female AI voice style.
-    ("Portuguese_Wiselady", _("Wise Lady")),
-    # Translators: Adjective describing a gentle female teacher AI voice style.
-    ("Portuguese_GentleTeacher", _("Gentle Teacher")),
-    # Translators: Adjective describing an inspiring female AI voice style.
-    ("Portuguese_InspiringLady", _("Inspiring Lady")),
-    # --- English voices (high quality, useful for English content) ---
-    # Translators: Adjective describing a calm female AI voice style.
-    ("English_CalmWoman", _("Calm Woman")),
-    # Translators: Adjective describing a friendly male AI voice style.
-    ("English_FriendlyPerson", _("Friendly Guy")),
-    # Translators: Adjective describing a deep male AI voice style.
-    ("English_ManWithDeepVoice", _("Man With Deep Voice")),
-    # Translators: Adjective describing an expressive narrator AI voice style.
-    ("English_expressive_narrator", _("Expressive Narrator")),
-    # --- Spanish voices ---
-    # Translators: Adjective describing a serene female AI voice style.
-    ("Spanish_SereneWoman", _("Serene Woman")),
-    # Translators: Adjective describing a wise scholar male AI voice style.
-    ("Spanish_WiseScholar", _("Wise Scholar")),
-    # Translators: Adjective describing a deep-toned male AI voice style.
-    ("Spanish_Deep-tonedMan", _("Deep-toned Man")),
-    # --- French voices ---
-    # Translators: Adjective describing a movie lead female AI voice style.
-    ("French_MovieLeadFemale", _("Movie Lead Female")),
-    # Translators: Adjective describing a male narrator AI voice style.
-    ("French_MaleNarrator", _("Male Narrator")),
-]
-
 OPENAI_VOICES = [
     # Translators: Adjective describing a neutral AI voice style.
     ("Alloy", _("Neutral")),
@@ -1812,14 +1765,81 @@ class AIHandler:
     @staticmethod
     def is_tts_supported(provider=None):
         p = provider if provider else config.conf["VisionAssistant"]["active_provider"]
-        
+
         if p in ["gemini", "openai", "minimax"]:
             return True
-        
+
         if p == "custom":
             return True
-            
+
         return False
+
+    @staticmethod
+    def get_voices(provider):
+        # Returns a list of (voice_id, display_name) tuples for the given provider.
+        # For minimax, fetches dynamically from the API (cached 24h in config).
+        # For gemini/openai, returns the hardcoded constant.
+        # Returns empty list on error.
+        if provider == "minimax":
+            try:
+                import time
+                cache = config.conf["VisionAssistant"].get("minimax_voices_cache", "")
+                cache_time = config.conf["VisionAssistant"].get("minimax_voices_cache_time", 0)
+                # Cache valid for 24 hours (86400 seconds)
+                if cache and (time.time() - cache_time < 86400):
+                    # Parse cache: "voice_id|display_name,voice_id|display_name,..."
+                    voices = []
+                    for entry in cache.split(""):
+                        if "" in entry:
+                            vid, vname = entry.split("", 1)
+                            voices.append((vid, vname))
+                    if voices:
+                        log.debug(f"Using cached MiniMax voices ({len(voices)} entries)")
+                        return voices
+
+                # Cache miss or expired - fetch from API
+                base = AIHandler.get_base_url("minimax")
+                url = f"{base.rstrip('/')}/get_voice"
+                keys = AIHandler.get_keys("minimax")
+                if not keys:
+                    return []
+                key = keys[0]
+                payload = json.dumps({"voice_type": "system"}).encode("utf-8")
+                req = request.Request(url, data=payload, headers={
+                    "Authorization": f"Bearer {key}",
+                    "Content-Type": "application/json"
+                })
+                with get_proxy_opener().open(req, timeout=30) as r:
+                    resp = json.loads(r.read().decode("utf-8"))
+                    system_voices = resp.get("system_voice", [])
+                    if not system_voices:
+                        log.warning("MiniMax /get_voice returned no system_voice list")
+                        return []
+                    voices = []
+                    storage_parts = []
+                    for v in system_voices:
+                        vid = v.get("voice_id", "")
+                        vname = v.get("voice_name", vid)
+                        if vid:
+                            voices.append((vid, vname))
+                            storage_parts.append(f"{vid}{vname}")
+                    if voices:
+                        # Save to cache (24h)
+                        config.conf["VisionAssistant"]["minimax_voices_cache"] = "".join(storage_parts)
+                        config.conf["VisionAssistant"]["minimax_voices_cache_time"] = int(time.time())
+                        log.debug(f"Fetched and cached {len(voices)} MiniMax voices")
+                        return voices
+                    return []
+            except Exception as e:
+                log.warning(f"Failed to fetch MiniMax voices: {e}")
+                return []
+        if provider == "gemini":
+            return GEMINI_VOICES
+        if provider == "openai":
+            return OPENAI_VOICES
+        if provider == "custom":
+            return OPENAI_VOICES
+        return []
 
     @staticmethod
     def filter_models(provider, models_info, task="main"):
@@ -2883,16 +2903,66 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
 
     def updateVoiceList(self, p_name):
         self.voice_sel.Clear()
-        if p_name in ["openai", "custom"]:
+        if p_name == "openai" or p_name == "custom":
             voices = OPENAI_VOICES
-        elif p_name == "minimax":
-            voices = MINIMAX_VOICES
         else:
-            voices = GEMINI_VOICES
-        
+            voices = AIHandler.get_voices(p_name) or GEMINI_VOICES
+        # Render the list immediately (either Gemini/OpenAI hardcoded, or MiniMax cache hit)
         for v in voices:
             self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
-            
+        # If this is MiniMax, trigger async refresh in the background to fetch the
+        # latest official voice list from /v1/get_voice (the cache may be stale or empty)
+        if p_name == "minimax":
+            threading.Thread(target=self._refresh_minimax_voices, daemon=True).start()
+        else:
+            curr_voice = config.conf["VisionAssistant"].get("tts_voice", "Puck")
+            self._select_voice_in_list(curr_voice)
+
+    def _refresh_minimax_voices(self):
+        # Background thread: fetch fresh MiniMax voice list, then update UI
+        try:
+            # Force a refresh by clearing cache and re-fetching
+            config.conf["VisionAssistant"]["minimax_voices_cache"] = ""
+            config.conf["VisionAssistant"]["minimax_voices_cache_time"] = 0
+            voices = AIHandler.get_voices("minimax")
+            if voices and hasattr(self, 'voice_sel'):
+                # wx widget updates must happen on the main thread
+                wx.CallAfter(self._populate_voice_sel, voices)
+        except Exception as e:
+            log.warning(f"Background MiniMax voice refresh failed: {e}")
+
+    def _populate_voice_sel(self, voices):
+        try:
+            self.voice_sel.Clear()
+            for v in voices:
+                self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
+            curr_voice = config.conf["VisionAssistant"].get("tts_voice", "Portuguese_Narrator")
+            self._select_voice_in_list(curr_voice)
+        except Exception as e:
+            log.warning(f"Failed to populate voice_sel: {e}")
+
+    def _select_voice_in_list(self, voice_id):
+        try:
+            for i in range(self.voice_sel.GetCount()):
+                if self.voice_sel.GetClientData(i) == voice_id:
+                    self.voice_sel.SetSelection(i)
+                    return
+            if self.voice_sel.GetCount() > 0:
+                self.voice_sel.SetSelection(0)
+        except Exception:
+            pass
+
+    def _updateVoiceList_legacy(self, p_name):
+        # Original implementation kept for reference (no longer called)
+        self.voice_sel.Clear()
+        if p_name == "openai" or p_name == "custom":
+            voices = OPENAI_VOICES
+        else:
+            voices = GEMINI_VOICES
+
+        for v in voices:
+            self.voice_sel.Append(f"{v[0]} - {v[1]}", v[0])
+
         curr_voice = config.conf["VisionAssistant"].get("tts_voice", "Puck")
         idx = wx.NOT_FOUND
         for i in range(self.voice_sel.GetCount()):


### PR DESCRIPTION
## Summary

Adds **MiniMax** as a first-class AI provider alongside Gemini, OpenAI, Mistral, and Groq. The integration supports the full feature set: chat, vision/image description, OCR (PDF + image), text-to-speech, and speech-to-text (where available).

MiniMax offers an OpenAI-compatible API with strong multilingual support (300+ system voices for TTS across PT-BR, EN, ES, FR, JA, KO, AR, ZH, etc.) and a multimodal model (`MiniMax-M3`) that handles chat, vision, and OCR in a single endpoint.

## What's new

- **New provider `minimax`** in the provider dropdown (symmetric with Gemini/OpenAI/Mistral/Groq).
- **Chat / vision / OCR**: `MiniMax-M3` multimodal model via `/v1/chat/completions` (OpenAI-compatible).
- **TTS**: `speech-2.8-hd` model via `/v1/t2a_v2` (custom payload with `voice_setting` + `audio_setting`).
- **STT**: `asr-01` model via `/v1/audio/transcriptions`.
- **Voice combobox** populated dynamically from MiniMax's `/v1/get_voice` endpoint (~300+ voices), cached 24h in NVDA config to avoid hammering the API. Falls back to a hardcoded PT-BR default (`Portuguese_Narrator`) if the API is unreachable.
- **Config fields** (all with sensible defaults):
  - `minimax_api_key`, `minimax_api_host` (default `https://api.minimax.io/v1`)
  - `minimax_model_name` (default `MiniMax-M3`)
  - `minimax_vision_model` (default `MiniMax-M3`)
  - `minimax_ocr_model` (default `MiniMax-M3`)
  - `minimax_stt_model` (default `asr-01`)
  - `minimax_tts_model` (default `speech-2.8-hd`)
  - `minimax_tts_voice` (default `Portuguese_Narrator`)
- **Reasoning-aware output handling**: MiniMax-M3 (a reasoning model) sometimes emits visible `<think>...</think>` blocks. These are stripped from the response before display/TTS so users only see the final answer.
- **Defensive cache parsing** in `get_voices()` to handle stale `minimax_voices_cache_time` values (older configs may store as string).
- **Defensive `hasattr` + alive-widget check** in the voice-combo refresh callback to avoid `RuntimeError: wrapped C/C++ object has been deleted` when the dialog is closed before the background fetch finishes.

## Why a dedicated provider (not just a custom URL)

I considered routing MiniMax through the existing "Custom" provider, but chose a dedicated provider because:

1. **Model selection**: TTS uses `speech-2.8-hd`; chat/vision/OCR use `MiniMax-M3`. A single "Custom" provider would force the user to manually swap models between OCR and Save-Audio flows. With a dedicated provider, model selection is automatic and matches the task.
2. **TTS payload format differs**: `/v1/t2a_v2` requires a non-standard payload (`voice_setting` + `audio_setting`) and returns hex-encoded MP3 inside JSON, not the OpenAI-style binary audio response. Reusing the OpenAI TTS code path would silently fail.
3. **Voice list is provider-specific**: the dynamic voice fetch from `/v1/get_voice` should only run when the user has selected MiniMax, not for every provider.
4. **Better UX for international users**: 300+ multilingual system voices, not the 11 OpenAI voices or 30 Gemini voices.

## Testing done

- ✅ Chat (text only) works with `MiniMax-M3`
- ✅ Vision/description works on JPEG images
- ✅ OCR works on PDF documents (used a real medical certificate as test)
- ✅ TTS generates valid MP3 from OCR text using `Portuguese_Narrator` voice
- ✅ Voice combobox populates with 300+ voices within 3-5 seconds
- ✅ Switching provider (Gemini ↔ MiniMax) updates the voice combobox correctly
- ✅ Document Format dialog TTS voice combobox (the one inside the OCR result window) is now populated by the same dynamic fetch
- ✅ Closing the document dialog during background voice refresh does not crash NVDA
- ✅ Reasoning blocks (`<think>...</think>`) are stripped from displayed text and TTS audio

## Files changed

Only `addon/globalPlugins/visionAssistant/__init__.py` (single-file addon). +50 / -11 lines, plus 24 lines for the new `strip_thinking_tags` helper. Total diff: 10 commits, each self-contained and reviewable.

## Notes for the maintainer

- The MiniMax provider is added as a peer to Gemini, OpenAI, Mistral, Groq — no existing code path was modified to support it (no behavior change for other providers).
- The `_refresh_minimax_voices_in_format_dialog` and `_populate_format_voice_sel` methods are defined inside `DocumentViewerDialog` (not `UpdateDialog`) so they have access to `self.voice_sel`. They run as daemon threads; failures are logged but never block the UI.
- No new dependencies. No new translations needed (the provider name `MiniMax` is the only user-facing string and is not localized).

## Test plan for the maintainer

1. Install `VisionAssistant-6.1.2-MINIMAX-v7.4.nvda-addon` from the workflow artifacts (or rebuild from this branch with `scons`).
2. Open `NVDA → Preferences → Settings → Vision Assistant`.
3. Select `MiniMax` as the provider and paste a valid `sk-cp-...` API key.
4. Set OCR engine to `AI (Advanced)` and TTS model to `speech-2.8-hd`.
5. Trigger `NVDA+Shift+V → D`, pick a PDF, wait for the Document Format dialog.
6. Confirm the TTS Voice combobox populates with 300+ MiniMax voices (default `Portuguese_Narrator`).
7. Click `Save Audio`, confirm a valid MP3 is saved with the selected voice.