### PR TITLE
Fix Italian translation catalog compilation

### DIFF
--- a/addon/locale/it/LC_MESSAGES/nvda.po
+++ b/addon/locale/it/LC_MESSAGES/nvda.po
@@ -2815,8 +2815,6 @@ msgstr ""
 #, python-brace-format
 #~ msgid "AI is scanning {n} pages in background."
 #~ msgstr "L'IA sta scansionando {n} pagine in background."
-msgid ""
-msgstr ""
 
 #~ msgid "Nothing to send."
 #~ msgstr "Niente da inviare."
@@ -2860,14 +2858,10 @@ msgstr ""
 #, python-brace-format
 #~ msgid "Upload Connection Error: {reason}"
 #~ msgstr "Errore di connessione durante il caricamento: {reason}"
-msgid ""
-msgstr ""
 
 #, python-brace-format
 #~ msgid "Upload Server Error {code}: {reason}"
 #~ msgstr "Errore del server di caricamento {code}: {reason}"
-msgid ""
-msgstr ""
 
 #~ msgid "Failed."
 #~ msgstr "Fallito."
@@ -2917,8 +2911,6 @@ msgstr ""
 #, python-brace-format
 #~ msgid "Connection Error: {reason}"
 #~ msgstr "Errore di connessione: {reason}"
-msgid ""
-msgstr ""
 
 #~ msgid "Uploading & Analyzing..."
 #~ msgstr "Caricamento e analisi..."
@@ -2987,6 +2979,3 @@ msgstr ""
 
 #~ msgid "Select an audio file..."
 #~ msgstr "Seleziona un file audio..."
-
-#~ msgid "Please configure Gemini API Key."
-#~ msgstr "Per favore, configura la chiave api."


### PR DESCRIPTION
## Summary

- remove four stray empty `msgid`/`msgstr` blocks that were interpreted as duplicate catalog headers
- remove the obsolete duplicate of `Please configure Gemini API Key.`
- preserve the valid UTF-8 header and legitimate obsolete (`#~`) entries

## Root cause

The main PO header already declares `charset=UTF-8`. The charset warnings were emitted for the later empty blocks because `msgfmt` interpreted each one as another header without charset metadata. Those blocks also caused the duplicate empty-message errors.

## Validation

- `msgfmt --check --check-format`: passed
- 478 translated messages compiled successfully
- the Italian catalog compiles during the SCons add-on build

The complete repository build proceeds past Italian and later stops on existing parse errors in `pt_BR`, which are unrelated to this change.

Fixes the Italian translation build problem reported in #251.