### PR TITLE
Update Polish translation for Vision Assistant Pro 2026.08.06

### DIFF
--- a/addon/doc/pl/readme.md
+++ b/addon/doc/pl/readme.md
@@ -1,121 +1,307 @@
 # Pomoc Vision Assistant Pro
 
-**Vision Assistant Pro** to wielofunkcyjny asystent AI dla NVDA wykorzystujący silniki AI do odczytywania ekranu, tłumaczenia, dyktowania głosowego i analizy dokumentów.
+<!-- DOWNLOAD_COUNT_START --> Pobrań łącznie: 61 000+ <!-- DOWNLOAD_COUNT_END -->
 
-_Ten dodatek został udostępniony społeczności z okazji Międzynarodowego Dnia Osób z Niepełnosprawnościami._
+**Vision Assistant Pro** to wielomodalny asystent AI dla NVDA. Korzysta z czołowych silników AI, żeby odczytywać ekran, tłumaczyć, zapisywać mowę i analizować dokumenty.
+
+_Dodatek trafił do społeczności z okazji Międzynarodowego Dnia Osób z Niepełnosprawnościami._
 
 ## 1. Konfiguracja
 
-Przejdź do **Menu NVDA > Preferencje > Ustawienia > Vision Assistant Pro**.
+Przejdź do **menu NVDA > Preferencje > Ustawienia > Vision Assistant Pro**. Okno ustawień jest podzielone na 8 zakładek: **Połączenie**, **Zachowanie AI**, **Języki tłumaczenia**, **Czytnik dokumentów**, **Wideo**, **CAPTCHA**, **Polecenia** i **Zaawansowane**.
 
-### 1.1 Ustawienia połączenia
-- **Dostawca:** Wybierz preferowaną usługę AI. Obsługiwani dostawcy to **Google Gemini**, **OpenAI**, **Mistral**, **Groq**, **MiniMax** oraz **Niestandardowy** (serwery zgodne z OpenAI, np. Ollama/LM Studio).
-- **Ważne:** Zalecamy korzystanie z **Google Gemini**, który zapewnia najlepszą jakość (szczególnie przy analizie obrazów i plików).
-- **Klucz API:** Wymagany. Można podać wiele kluczy (rozdzielonych przecinkami lub w osobnych wierszach), aby dodatek rotował je automatycznie.
-- **Pobierz modele:** Po wprowadzeniu klucza API naciśnij ten przycisk, aby pobrać aktualną listę dostępnych modeli od dostawcy.
-- **Model AI:** Wybierz główny model używany do czatu i analizy.
+### 1.1 Zakładka Połączenie
+- **Dostawca:** wybór usługi AI. Obsługiwani dostawcy to **Google Gemini**, **OpenAI**, **Mistral**, **Groq**, **MiniMax** oraz **Niestandardowy** (serwery zgodne z OpenAI, na przykład Ollama, LM Studio, Jan.ai albo KoboldCPP).
+- **Klucz API:** jeden klucz albo kilka (rozdzielonych przecinkami lub nowymi wierszami) do automatycznej rotacji.
+- **Pobierz modele:** po wpisaniu klucza ten przycisk pobiera od dostawcy aktualną listę modeli.
+- **Model AI:** główny model używany do rozmowy i analizy.
+- **Ustawienia niestandardowego dostawcy:** konfiguracja lokalnych i własnych adresów usług. Są tu dwie rzeczy: przycisk **Konfiguracja lokalnej AI**, który jednym kliknięciem ustawia Ollama, LM Studio, Jan.ai albo KoboldCPP, oraz **Adresy usług** do ręcznego wpisania własnego adresu.
+- **Osobny model dla każdego zadania:** można wskazać osobne modele dla OCR, STT, TTS, Operatora AI, wideo i asystenta głosowego.
+- **Opcje połączenia i wyjścia:** adres proxy, sprawdzanie aktualizacji przy starcie, czyszczenie Markdownu w czacie, kopiowanie odpowiedzi AI do schowka, tryb bezpośredni (nie pokazuje okna czatu) oraz tryb bezpośredni asystenta głosowego.
 
-### 1.2 Osobny model dla każdego zadania
-*Dostępne dla wszystkich dostawców, w tym Gemini, OpenAI, Groq, Mistral i Niestandardowy.*
+### 1.2 Zakładka Zachowanie AI
+- **Kreatywność (temperatura):** steruje losowością odpowiedzi (od 0,0 do 2,0). Niższe wartości dają bardziej przewidywalne odpowiedzi. Nie wpływa na OCR ani na tłumaczenie.
 
-> **⚠️ Uwaga:** Te ustawienia są przeznaczone wyłącznie dla **doświadczonych użytkowników**. Jeśli nie wiesz, do czego służy dany model, zostaw tę opcję **odznaczoną**. Wybranie nieodpowiedniego modelu (np. modelu tekstowego dla zadań wizualnych) spowoduje błędy i zatrzyma działanie dodatku.
+### 1.3 Zakładka Języki tłumaczenia
+- **Język źródłowy:** domyślny język wejściowy.
+- **Język docelowy:** główny język tłumaczenia.
+- **Język odpowiedzi AI:** język ogólnych odpowiedzi AI.
+- **Zamiana:** automatycznie zamienia język źródłowy z docelowym na podstawie wykrytego wejścia.
 
-Zaznacz **„Osobny model dla każdego zadania"**, aby uzyskać szczegółową kontrolę. Pozwala to wybrać konkretne modele z listy rozwijanej dla różnych zadań:
-- **Model dla OCR / rozpoznawania obrazów:** Wyspecjalizowany model do analizy obrazów.
-- **Rozpoznawanie mowy (STT):** Konkretny model do dyktowania.
-- **Synteza mowy (TTS):** Model do generowania audio.
-- **Model Operatora AI:** Konkretny model do zadań autonomicznego sterowania komputerem.
-*Uwaga: Nieobsługiwane funkcje (np. TTS dla Groq) zostaną automatycznie ukryte.*
+### 1.4 Zakładka Czytnik dokumentów
+- **Silnik OCR:** do wyboru **Chrome (szybki)** dla szybkich wyników albo **AI (zaawansowany)** dla lepszego zachowania układu strony.
+- **Porcja OCR:** liczba stron na jedno żądanie (0 wyłącza dzielenie i wysyła wszystko w jednym żądaniu).
+- **Wplataj opisy obrazów w tekst:** przy wyodrębnianiu treści dokumentu opis obrazu ląduje dokładnie tam, gdzie w dokumencie znajduje się obraz, a nie osobno na końcu.
+- **Numery stron przy eksporcie:** włącza numery stron i separatory w dokumentach wielostronicowych.
+- **Głos TTS:** domyślny styl głosu przy generowaniu mowy.
 
-### 1.3 Adresy usług (niestandardowy dostawca)
-*Dostępne tylko przy wybranym dostawcy „Niestandardowy".*
+### 1.5 Zakładka Wideo
+- **Rozmiar fragmentu wideo:** długość odcinka w minutach przy generowaniu audiodeskrypcji (0 wyłącza dzielenie i przetwarza cały plik).
+- **Dodaj listę postaci:** wstawia listę postaci jako pierwszy napis.
+- **Dodaj informację o AI:** wstawia informację o udziale AI na początku napisów SRT do wideo.
 
-> **⚠️ Uwaga:** Ta sekcja umożliwia ręczną konfigurację API i jest przeznaczona dla **zaawansowanych użytkowników** prowadzących lokalne serwery lub proxy. Błędne adresy URL lub nazwy modeli uniemożliwią połączenie. Jeśli nie wiesz dokładnie, do czego służą te pola, zostaw tę opcję **odznaczoną**.
+### 1.6 Zakładka CAPTCHA
 
-Zaznacz **„Adresy usług"**, aby ręcznie podać dane serwera. W przeciwieństwie do natywnych dostawców, tutaj trzeba **wpisać** konkretne adresy URL i nazwy modeli:
-- **URL listy modeli:** Adres do pobrania dostępnych modeli.
-- **URL dla OCR/STT/TTS:** Pełne adresy usług (np. `http://localhost:11434/v1/audio/speech`).
-- **Niestandardowe modele:** Wpisz ręcznie nazwę modelu (np. `llama3:8b`) dla każdego zadania.
+Dodatek radzi sobie z **dwoma rodzajami CAPTCHA**, a wybiera między nimi sam. Obsługuje je jeden skrót — **C** w warstwie poleceń — i nie trzeba z góry wiedzieć, na którą się trafiło.
 
-### 1.4 Preferencje ogólne
-- **Silnik OCR:** Wybierz między **Chrome (szybki)** dla błyskawicznych wyników a **AI (zaawansowany)** dla lepszego zachowania układu strony.
-    - *Uwaga:* Jeśli wybierzesz „AI (zaawansowany)", ale dostawcą jest OpenAI/Groq, dodatek inteligentnie skieruje obraz do modelu rozpoznawania obrazów aktywnego dostawcy.
-- **Głos TTS:** Wybierz preferowany styl głosu. Lista aktualizuje się automatycznie na podstawie aktywnego dostawcy.
-- **Kreatywność (temperatura):** Kontroluje losowość odpowiedzi AI. Niższe wartości są lepsze dla tłumaczenia i OCR.
-- **URL serwera proxy:** Skonfiguruj, jeśli usługi AI są ograniczone w twoim regionie (obsługuje lokalne proxy, np. `127.0.0.1`, oraz adresy pośredniczące).
+- **Klasyczna CAPTCHA tekstowa** to zniekształcony ciąg liter i cyfr do przepisania. AI odczytuje znaki z obrazu i wpisuje je za Ciebie.
+- **CAPTCHA obrazkowa** to zagadka, w której trzeba klikać w obrazki o zadanych cechach: „zaznacz wszystkie pola z sygnalizatorem świetlnym”, „wybierz koty bez ogona”.
+
+Po naciśnięciu **C** dodatek sprawdza, z czym ma do czynienia. Jeśli wykryje zagadkę obrazkową, mówi o tym i przechodzi w tryb rozwiązywania — to trwa dłużej niż odczytanie kodu. Jeśli obrazkowa jest wyłączona w ustawieniach, usłyszysz o tym.
+
+Ustawienia:
+- **Włącz rozwiązywanie CAPTCHA obrazkowej:** włącza i wyłącza obsługę zagadek obrazkowych (hCaptcha, reCAPTCHA). Wyłączenie nie rusza CAPTCHA tekstowej — ta działa dalej.
+- **Metoda dla CAPTCHA tekstowej:** przechwytywanie **obiektu nawigatora** albo **całego ekranu**. Dotyczy wyłącznie kodów do przepisania.
+
+### 1.7 Zakładka Polecenia
+- **Zarządzaj poleceniami:** otwiera osobne okno, w którym można zmienić domyślne polecenia systemowe albo tworzyć, edytować, porządkować i podglądać własne polecenia ze zmiennymi (na przykład `[selection]`, `[screen_fg_obj]`).
+
+### 1.8 Zakładka Zaawansowane i globalny dziennik
+W zakładce **Zaawansowane** konfiguruje się globalny dziennik dodatku:
+- **Włącz osobny plik dziennika:** zapisuje zdarzenia, ruch do API i błędy ze wszystkich modułów dodatku do osobnego pliku (`vision_assistant.log`).
+- **Poziom szczegółowości dziennika:** **Diagnostyka (wszystkie szczegóły)**, **Informacje (ogólne)**, **Ostrzeżenia (tylko ostrzeżenia)** albo **Błędy (tylko błędy)**.
+- **Przechowuj dziennik przez:** automatyczne czyszczenie starszych wpisów, od godziny do 90 dni.
+- **Zarządzanie dziennikiem:** **Otwórz plik dziennika**, **Otwórz folder dziennika** i **Wyczyść plik dziennika** pozwalają zajrzeć do danych albo je usunąć bez restartu NVDA i bez mieszania się do standardowego dziennika NVDA.
 
 ## 2. Warstwa poleceń i skróty
 
-Aby uniknąć konfliktów z innymi skrótami, dodatek korzysta z **warstwy poleceń**.
-1. Naciśnij **NVDA + Shift + V** (klawisz główny), aby aktywować warstwę (usłyszysz sygnał dźwiękowy).
-2. Puść klawisze, a następnie naciśnij jeden z poniższych:
+Aby uniknąć konfliktów skrótów klawiszowych, dodatek używa **warstwy poleceń**.
+1. Naciśnij **NVDA + Shift + V** (klawisz główny), żeby włączyć warstwę (usłyszysz sygnał).
+2. Puść klawisze, a potem naciśnij jeden z poniższych:
 
-| Klawisz       | Funkcja                       | Opis                                                                        |
-|---------------|-------------------------------|-----------------------------------------------------------------------------|
-| **Shift + A** | **Operator AI**               | **Sterowanie autonomiczne:** Powiedz AI, aby wykonała zadanie na ekranie.   |
-| **E**         | **Eksplorator interfejsu**    | **Interaktywne klikanie:** Identyfikuje i klika elementy interfejsu w dowolnej aplikacji. |
-| **T**         | Tłumacz                       | Tłumaczy tekst pod kursorem nawigatora lub zaznaczenie.                     |
-| **Shift + T** | Tłumaczenie schowka           | Tłumaczy zawartość schowka.                                                 |
-| **R**         | Poprawianie tekstu            | Podsumuj, popraw gramatykę, wyjaśnij lub uruchom **niestandardowe polecenie**. |
-| **V**         | Opis obiektu                  | Opisuje bieżący obiekt nawigatora.                                          |
-| **O**         | Rozpoznawanie ekranu          | Analizuje układ i zawartość całego ekranu.                                  |
-| **Shift + V** | Analiza wideo online          | Analizuj filmy z **YouTube**, **Instagrama**, **TikToka** lub **Twittera (X)**, a także lokalne pliki wideo. |
-| **Control + V** | Nagrywanie ekranu           | **Analiza lokalnego nagrania:** Nagrywa bezgłośny film z ekranu, po czym AI opisuje scenę, układ i akcję. |
-| **D**         | Czytnik dokumentów            | Czytnik PDF i obrazów z wyborem zakresu stron.                              |
-| **F**         | **Akcja na pliku**            | Rozpoznawanie zależne od kontekstu z wybranego obrazu, PDF lub TIFF.        |
-| **A**         | Transkrypcja audio            | Transkrybuje pliki MP3, WAV lub OGG na tekst.                               |
-| **C**         | Rozwiązywanie CAPTCHA         | Przechwytuje i rozwiązuje CAPTCHA.                                          |
-| **S**         | Dyktowanie                    | Zamienia mowę na tekst. Naciśnij raz, aby nagrywać, ponownie, aby zakończyć. |
-| **Control+L** | **Asystent głosowy**          | **W czasie rzeczywistym (tylko Gemini):** Rozpoczyna lub kończy rozmowę głosową i ekranową z asystentem AI. |
-| **I**         | Raport stanu                  | Odczytuje bieżący postęp (np. „Skanowanie...", „Bezczynny").                |
-| **L**         | **Oznacz obiekt**             | **Semantyczne etykietowanie AI:** Trwale oznacza bieżący element/ikonę.     |
-| **Shift + L** | **Zarządzaj / Skanuj etykiety** | Otwiera Menedżer etykiet (jeśli istnieją) lub skanuje aplikację w poszukiwaniu nieoznaczonych elementów. |
-| **U**         | Sprawdzanie aktualizacji      | Ręcznie sprawdza najnowszą wersję dodatku na GitHubie.                      |
-| **Spacja**    | Ostatnia odpowiedź AI         | Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub kontynuacji. |
-| **H**         | Pomoc poleceń                 | Wyświetla listę wszystkich dostępnych skrótów w warstwie poleceń.           |
+| Klawisz | Funkcja | Opis |
+|---------------|--------------------------|-----------------------------------------------------------------------------|
+| **Shift + A** | **Operator AI** | **Działanie autonomiczne:** zlecasz AI wykonanie zadania na ekranie. Ponowne naciśnięcie natychmiast przerywa trwającą operację. |
+| **E** | **Eksplorator interfejsu** | **Kliknięcie interaktywne:** rozpoznaje i klika elementy interfejsu w dowolnej aplikacji. |
+| **T** | Tłumacz | Tłumaczy tekst z obiektu nawigatora albo zaznaczenie. |
+| **Shift + T** | Tłumacz schowka | Tłumaczy zawartość schowka. |
+| **R** | Poprawianie tekstu | Streszcza, poprawia gramatykę, wyjaśnia albo uruchamia **polecenia niestandardowe**. |
+| **V** | Opis obiektu | Opisuje bieżący obiekt nawigatora. |
+| **O** | Opis całego ekranu | Analizuje układ i zawartość całego ekranu. |
+| **Shift + V** | Analiza wideo | Analizuje lokalne pliki wideo oraz filmy z **YouTube**, **Instagrama**, **TikToka** i **Twittera (X)**. |
+| **Control + V** | Nagrywanie ekranu | Nagrywa bezgłośne wideo z ekranu i analizuje przebieg oraz układ. |
+| **D** | Czytnik dokumentów | Zaawansowany czytnik PDF i obrazów z wyborem zakresu stron. |
+| **F** | **Akcja na pliku** | Rozpoznawanie zależne od kontekstu dla zaznaczonego obrazu, pliku PDF albo TIFF. |
+| **M** | Transkrypcja i dubbing mediów | Transkrybuje albo dubbinguje pliki dźwiękowe i wideo (MP3, WAV, MP4 i inne) na język docelowy. |
+| **C** | Rozwiązywanie CAPTCHA | Przechwytuje i rozwiązuje CAPTCHA — **tekstową i obrazkową, jednym skrótem**; rodzaj rozpoznaje sam. |
+| **Shift + C** | Czat | Otwiera okno rozmowy tekstowej z AI. |
+| **S** | Dyktowanie | Zamienia mowę na tekst. Naciśnij, żeby zacząć nagrywanie, i ponownie, żeby zakończyć i wpisać. |
+| **Control + T** | Tłumaczenie mowy | transkrybuje wypowiedź, tłumaczy ją i wpisuje wynik zgodnie z ustawieniami języków. |
+| **Control + L** | **Asystent głosowy** | **Rozmowa w czasie rzeczywistym (tylko Gemini):** rozpoczyna albo kończy rozmowę głosową i ekranową z asystentem. |
+| **I** | Ogłoś stan | Ogłasza bieżący postęp (na przykład „Skanowanie...”, „Bezczynny”). |
+| **L** | **Etykietuj obiekt** | **Etykietowanie semantyczne:** trwale nazywa bieżący element albo ikonę. |
+| **Shift + L** | **Zarządzaj/skanuj etykiety** | Otwiera menedżera etykiet (jeśli etykiety istnieją) albo skanuje aplikację w poszukiwaniu nienazwanych elementów. |
+| **U** | Sprawdź aktualizację | Ręcznie sprawdza na GitHubie najnowszą wersję dodatku. |
+| **Spacja** | Przywołaj ostatni wynik | Pokazuje ostatnią odpowiedź AI w oknie rozmowy do przejrzenia albo dopytania. |
+| **H** | Pomoc poleceń | Wyświetla listę wszystkich dostępnych skrótów. |
+| **Alt + S** | Ustawienia | Otwiera okno ustawień Vision Assistant Pro. |
+| **Alt + Q** | Raport kluczy z wyczerpanym limitem | Podaje liczbę kluczy Gemini, które przekroczyły dzienny limit, wraz z czasem odnowienia. |
+| **Alt + M** | Audyt przydziału modeli | Podaje modele AI wybrane obecnie w osobnym przydziale dla zadań. |
+| **Góra / Dół** | Nawigacja po szybkich ustawieniach | Przechodzi między kategoriami szybkich ustawień (dostawca, model i inne) w warstwie. |
+| **Lewo / Prawo** | Zmiana szybkiego ustawienia | Zmienia wartość wybranego szybkiego ustawienia. |
 
-### 2.1 Skróty czytnika dokumentów (wewnątrz przeglądarki)
-- **Ctrl + PageDown:** Przejdź do następnej strony.
-- **Ctrl + PageUp:** Przejdź do poprzedniej strony.
-- **Alt + A:** Otwórz okno czatu, aby zadać pytanie o dokument.
-- **Alt + R:** Wymuś **ponowne skanowanie AI** przy użyciu aktywnego dostawcy.
-- **Alt + G:** Wygeneruj i zapisz plik audio (WAV/MP3). *Ukryte, jeśli dostawca nie obsługuje TTS.*
-- **Alt + S / Ctrl + S:** Zapisz wyodrębniony tekst jako plik TXT lub HTML.
+## 3. Operator AI — autonomiczne sterowanie komputerem
 
-## 3. Polecenia niestandardowe i zmienne
+**Operator AI** zamienia Vision Assistant Pro z czytnika w asystenta, który działa na komputerze w Twoim imieniu. Można poprosić go o opis ekranu, o odpowiedź na pytanie o to, co widzi, albo oddać mu sterowanie: klikanie przycisków, przeciąganie elementów, wpisywanie tekstu i poruszanie się po aplikacjach zwykłym językiem.
 
-Tymi poleceniami można zarządzać w **Ustawienia > Polecenia > Zarządzaj poleceniami...**.
+Największa zaleta? Działa w oprogramowaniu całkowicie niedostępnym. Jeśli firmowa aplikacja, pulpit zdalny albo strona nie dają się obsłużyć, bo czytnik ekranu przy nich milczy, operatorowi to nie przeszkadza. Ponieważ „widzi” ekran wizualnie, potrafi znaleźć, odczytać i obsłużyć elementy pozbawione jakichkolwiek etykiet dostępności.
+
+### Jak to działa
+1. Naciśnij **NVDA + Shift + V**, potem **Shift + A** (albo użyj skrótu bezpośredniego), żeby otworzyć okno Operatora AI.
+2. Napisz zwykłym językiem, co ma zrobić (na przykład „Kliknij przycisk Zapisz”, „Co mówi komunikat błędu?”, „Zmień nazwę pliku na final.pdf”).
+3. AI przeanalizuje ekran, rozpozna właściwe elementy i wykona zadanie albo poda odpowiedź. Jeśli zadanie wymaga kilku kroków, operator pracuje aż do końca.
+4. Ponowne **Shift + A** w dowolnym momencie natychmiast przerywa trwającą operację.
+
+### Obsługiwane działania
+Operator rozumie szeroki zakres poleceń:
+- **Opis i odpowiedź**: „Opisz układ ekranu” albo „Co mówi komunikat błędu?”
+- **Kliknięcie**: „Kliknij przycisk Zapisz”
+- **Kliknięcie prawym przyciskiem**: „Kliknij plik prawym przyciskiem”
+- **Dwukrotne kliknięcie**: „Kliknij dwukrotnie dokument”
+- **Przeciągnij i upuść**: „Przeciągnij dokument do folderu Archiwum”
+- **Wpisywanie**: „Wpisz »Witaj świecie« w polu wyszukiwania”
+- **Przewijanie**: „Przewiń trzy razy w dół”
+- **Naciśnięcie klawisza**: „Naciśnij Enter”, „Naciśnij Tab”, „Naciśnij Escape”
+- **Zadania wieloetapowe**: „Otwórz Eksplorator plików, znajdź raport i zmień jego nazwę na final.pdf”
+
+### Ważne uwagi
+- **⚠️ Ostrzeżenie o zużyciu API**: operator musi „widzieć” dokładnie to, co dzieje się na ekranie, więc przy każdym kroku wysyła zrzut ekranu w wysokiej rozdzielczości. Częste korzystanie zużywa limit API dużo szybciej niż zwykłe funkcje tekstowe.
+- **Aplikacje administracyjne**: jeśli NVDA nie działa z uprawnieniami administratora, operator może nie obsłużyć okien wymagających podwyższonych uprawnień. To ograniczenie bezpieczeństwa Windows, nie błąd dodatku.
+- **Dobre praktyki**: najlepiej działają polecenia konkretne. „Kliknij niebieski przycisk Wyślij na dole formularza” zadziała prawie zawsze lepiej niż samo „Kliknij przycisk”.
+
+## 4. Analiza wideo i audiodeskrypcja
+
+> **Uwaga:** analiza wideo i audiodeskrypcja działają wyłącznie na dostawcy **Google Gemini**. Upewnij się, że w ustawieniach dodatku aktywnym dostawcą jest Google Gemini.
+
+Vision Assistant Pro przetwarza wideo z myślą o osobach niewidomych. Analizuje zarówno filmy online, jak i lokalne nagrania ekranu, dając szczegółowe opisy wizualne oraz gotowe skrypty audiodeskrypcji w formacie SRT.
+
+### 4.1 Nagrywanie ekranu (Control + V)
+Jeśli trafisz na bezgłośne wideo, animację albo poradnik na ekranie, możesz nagrać go bezpośrednio:
+1. Naciśnij **NVDA + Shift + V**, żeby wejść w warstwę poleceń, potem **Control + V**.
+2. Dodatek zacznie po cichu nagrywać ekran w tle.
+3. Ponowne **Control + V** kończy nagrywanie.
+4. AI przeanalizuje nagrany fragment i szczegółowo opisze scenę, postacie i przebieg zdarzeń.
+
+### 4.2 Analiza wideo (Shift + V)
+Analizować można zarówno lokalne pliki, jak i filmy online. Wystarczy zaznaczyć plik wideo w Eksploratorze Windows albo skopiować link do schowka. Można też nacisnąć **Shift + V** w dowolnym miejscu (na przykład w odtwarzaczu), żeby otworzyć okno, w którym wskazuje się plik albo wkleja adres ręcznie.
+- **Obsługiwane serwisy:** YouTube, Instagram, TikTok i Twitter (X).
+- Dodatek sam rozpozna plik lokalny albo adres, przetworzy wideo i poda pełny opis wizualny oraz podsumowanie dźwięku.
+
+### 4.3 Generowanie audiodeskrypcji (SRT)
+Dodatek tworzy skrypty audiodeskrypcji w standardowym formacie SubRip (SRT).
+- **Dopasowanie do pauz:** AI słucha ścieżki dźwiękowej i zaczepia opisy o naturalne pauzy i ciszę, żeby jak najmniej nachodziły na dialog.
+- **Śledzenie postaci:** silnik najpierw wyodrębnia poszczególne postacie po niezmiennych cechach twarzy. Buduje globalny słownik, dzięki czemu rozpoznaje i nazywa te same osoby w różnych scenach bez pomyłek.
+- **Dosłowny OCR tekstu:** każdy tekst pojawiający się na ekranie, taki jak np. napisy końcowe jest cytowany dosłownie.
+- **Jak z tego skorzystać:** żeby odsłuchać wygenerowane napisy, umieść plik `.srt` w tym samym folderze co wideo i nadaj mu dokładnie tę samą nazwę. Potem ustaw w odtwarzaczu (na przykład VLC albo PotPlayer) przekazywanie tekstu napisów wprost do czytnika ekranu albo silnika TTS podczas odtwarzania.
+
+### 4.4 Zsynchronizowana narracja dźwiękowa (eksport MP3)
+Dodatek nie kończy na plikach SRT — jest pełnym narzędziem produkcyjnym audiodeskrypcji: syntezuje opisy na mowę i miksuje je z wideo. Jako silnik głosu można teraz wybrać **Gemini Live TTS**, który przez Gemini Live API tworzy bardzo naturalną narrację bez ograniczeń długości. Przy generowaniu MP3 dla plików lokalnych dostępnych jest kilka trybów miksowania:
+- **Standardowa audiodeskrypcja (miks głosu):** narracja nakłada się bezpośrednio na dźwięk wideo. Pojawi się pytanie, czy zastosować **przyciszanie tła** podczas opisów, żeby narracja była wyraźna.
+- **Rozszerzona audiodeskrypcja (pauza dźwięku):** silnik zatrzymuje oryginalny dźwięk na czas opisu, dzięki czemu nie umknie ani słowo dialogu, ani narracji.
+- **Filmy z YouTube:** dla źródeł z YouTube (które nie są pobierane lokalnie) eksport MP3 zawiera wyłącznie zsynchronizowaną ścieżkę głosu AI, bez dźwięku tła.
+
+## 5. Transkrypcja i dubbing mediów (M)
+Moduł transkrypcji został napisany od nowa i obsługuje zarówno pliki dźwiękowe, jak i wideo (MP3, WAV, MP4, MKV i inne). Naciśnij **M** w warstwie poleceń, żeby wybrać plik i jeden z trzech trybów pracy:
+1. **Transkrybuj (język oryginału)**: dokładnie transkrybuje wypowiedź w języku oryginału.
+2. **Transkrybuj i przetłumacz (język docelowy)**: transkrybuje wypowiedź i tłumaczy ją na ustawiony język docelowy.
+3. **Zdubbinguj i przetłumacz (język docelowy)** *(tylko Gemini)*: transkrybuje wypowiedź, tłumaczy ją na język docelowy i tworzy mówioną ścieżkę dźwiękową silnikiem TTS dodatku.
+
+## 6. Zaawansowany czytnik dokumentów i obrazów
+
+Vision Assistant Pro ma zoptymalizowany czytnik dokumentów przygotowany pod wielostronicowe pliki PDF, złożone obrazy, a nawet format HEIC z iPhone'a.
+
+### 6.1 Przetwarzanie wsadowe i wznawianie
+Nie trzeba czytać wielkiego dokumentu za jednym razem. Podaj zakres stron (na przykład `1-20`), a AI przetworzy je w tle. Jeśli NVDA ulegnie awarii albo przerwiesz skanowanie, dodatek zapamięta postęp i zaproponuje **wznowienie** dokładnie w miejscu przerwania.
+
+### 6.2 Akcja na pliku
+Nie zawsze trzeba najpierw otwierać dokument. W Eksploratorze plików Windows wystarczy zaznaczyć plik PDF albo obraz i w warstwie poleceń nacisnąć **D** (czytnik dokumentów) albo **F** (akcja na pliku). Dodatek pominie okno wyboru pliku i od razu zacznie przetwarzanie zaznaczonego dokumentu.
+
+### 6.3 Skróty czytnika dokumentów
+Gdy okno czytnika jest otwarte, działają następujące skróty:
+- **Ctrl + PageDown:** następna strona.
+- **Ctrl + PageUp:** poprzednia strona.
+- **Alt + A:** okno rozmowy z pytaniami o dokument.
+- **Alt + R:** wymuszenie **ponownego skanowania przez AI** aktywnym dostawcą.
+- **Alt + G:** wygenerowanie i zapisanie pliku dźwiękowego wysokiej jakości (WAV/MP3). *(Ukryte, jeśli dostawca nie obsługuje TTS).*
+- **Alt + S / Ctrl + S:** zapis wyodrębnionego tekstu jako plik TXT albo HTML.
+
+## 7. Etykietowanie semantyczne i Eksplorator interfejsu
+
+Aplikacja, w której wszędzie słychać „nieoznaczony przycisk”? Silnik etykietowania semantycznego rozwiązuje to na stałe.
+
+### 7.1 Trwałe etykietowanie obiektu (L)
+Ustaw czytnik na nieoznaczonej grafice albo przycisku i naciśnij **L** w warstwie poleceń. AI obejrzy przycisk, rozpozna jego funkcję i nada mu trwałą etykietę.
+*W odróżnieniu od starszych narzędzi do etykietowania, ten dodatek korzysta z hybrydowego systemu „sygnatury obiektu” (AutomationId/ControlID). Własne etykiety przetrwają zmianę rozmiaru okna, przełączenie monitora i aktualizację aplikacji.*
+
+### 7.2 Skanowanie całej aplikacji (Shift + L)
+Naciśnij **Shift + L**, żeby przeskanować całe aktywne okno naraz. AI znajdzie wszystkie nieoznaczone elementy i nazwie je za jednym razem. Etykiety można potem przeglądać, zmieniać i usuwać zbiorczo we wbudowanym menedżerze etykiet.
+
+### 7.3 Eksplorator interfejsu (E)
+Chcesz obsłużyć element bez ręcznego docierania do niego? Naciśnij **E**, żeby uruchomić Eksplorator interfejsu. AI przeskanuje ekran i utworzy dostępną listę wszystkich klikalnych elementów (pomijając szum systemowy w rodzaju paska zadań). Wybierz pozycję z listy, a dodatek od razu ją kliknie.
+
+## 8. Asystent głosowy
+
+Asystent głosowy zamienia Vision Assistant Pro w interaktywnego pomocnika działającego w czasie rzeczywistym.
+*(Uwaga: funkcja dostępna wyłącznie w Google Gemini i w niestandardowych dostawcach zgodnych z Gemini).*
+
+- **Uruchomienie:** naciśnij **Control + L** w warstwie poleceń, żeby otworzyć okno asystenta głosowego.
+- **Rozmowa w czasie rzeczywistym:** mów swobodnie do mikrofonu. AI jednocześnie słucha i patrzy na aktywny ekran. Można pytać na przykład „Na co teraz patrzę?” albo „Przeczytaj mi trzeci akapit”.
+- **Dostosowanie:** w oknie można zmienić styl głosu AI (na przykład profesjonalny, przyjazny, energiczny) oraz **głębię myślenia**, czyli to, jak dokładnie AI rozważa odpowiedź.
+
+## 9. Polecenia niestandardowe i zmienne
+
+Poleceniami zarządza się w **Ustawienia > Polecenia > Zarządzaj poleceniami...**.
 
 ### Obsługiwane zmienne
-- `[selection]`: Aktualnie zaznaczony tekst.
-- `[clipboard]`: Zawartość schowka.
-- `[screen_obj]`: Zrzut ekranu obiektu nawigatora.
-- `[screen_fg_obj]`: Zrzut ekranu aktywnego okna pierwszoplanowego.
-- `[screen_full]`: Zrzut całego ekranu.
-- `[file_ocr]`: Wybierz obraz/PDF do wyodrębnienia tekstu.
-- `[file_read]`: Wybierz dokument do odczytu (TXT, kod, PDF).
-- `[file_audio]`: Wybierz plik audio do analizy (MP3, WAV, OGG).
+- `[selection]`: zaznaczony tekst.
+- `[clipboard]`: zawartość schowka.
+- `[clipboard_image]`: obraz w schowku.
+- `[screen_obj]`: zrzut obiektu nawigatora.
+- `[screen_fg_obj]`: zrzut aktywnego okna pierwszoplanowego.
+- `[screen_full]`: zrzut całego ekranu.
+- `[file_ocr]`: wybór obrazu albo pliku PDF do wyodrębnienia tekstu.
+- `[file_read]`: wybór dokumentu do odczytu (TXT, kod, PDF).
+- `[file_audio]`: wybór pliku dźwiękowego do analizy (MP3, WAV, OGG).
+- `{target_lang}`: bieżący język docelowy.
+- `{source_lang}`: bieżący język źródłowy.
+- `{response_lang}`: bieżący język odpowiedzi AI.
+- `{swap_target}`: język zapasowy przy tłumaczeniu z zamianą.
+- `{swap_instruction}`: blok instrukcji tłumaczenia z zamianą.
+
+## 10. Zastosowania w praktyce (której funkcji użyć?)
+
+Vision Assistant Pro ma dużo narzędzi. Poniżej typowe sytuacje, które pomogą wybrać właściwe:
+
+- **Sytuacja: chcesz zrozumieć układ skomplikowanego okna albo niedostępnej aplikacji.**
+  *Rozwiązanie:* naciśnij **O** (opis całego ekranu). AI przeanalizuje ekran i opisze, gdzie dokładnie znajdują się elementy, teksty i przyciski.
+
+- **Sytuacja: na stronie jest obraz albo w dokumencie nieoznaczona grafika.**
+  *Rozwiązanie:* ustaw obiekt nawigatora na grafice i naciśnij **V** (opis obiektu). AI opisze, co konkretnie ten obraz przedstawia.
+
+- **Sytuacja: chcesz obejrzeć film z audiodeskrypcją.**
+  *Rozwiązanie:* naciśnij **Shift + V** na filmie i wybierz **„Generuj audiodeskrypcję (plik SRT)”**. Po zakończeniu kliknij **„Generuj zsynchronizowaną narrację (MP3)”** i wybierz **„Rozszerzona AD”**. Dodatek utworzy ścieżkę, która zatrzymuje dialog filmu na czas opisu scen.
+
+- **Sytuacja: aplikacja jest pełna „nieoznaczonych przycisków”.**
+  *Rozwiązanie:* naciśnij **L**, żeby trwale nazwać konkretny przycisk przy pomocy AI. Albo **Shift + L**, żeby przeskanować i nazwać całe okno naraz. Jeśli chcesz tylko szybko coś kliknąć, naciśnij **E** (Eksplorator interfejsu) po listę wszystkich klikalnych elementów.
+
+- **Sytuacja: musisz przejść przez niedostępną CAPTCHA.**
+  *Rozwiązanie:* naciśnij **C** (rozwiązywanie CAPTCHA) — **ten sam skrót niezależnie od rodzaju zagadki**. Przy kodzie do przepisania AI odczyta znaki i wpisze je w pole. Przy zagadce obrazkowej w rodzaju „zaznacz wszystkie sygnalizatory” rozpozna obrazki i sam poklika, co trzeba; usłyszysz wtedy, że wszedł w tryb rozwiązywania, bo to trwa dłużej.
+
+- **Sytuacja: chcesz przeczytać długi, pięćdziesięciostronicowy dokument PDF.**
+  *Rozwiązanie:* naciśnij **D** (czytnik dokumentów), ustaw dostawcę na Google Gemini i podaj zakres stron `1-50`. Dodatek dokładnie wyodrębni tekst w tle.
+
+- **Sytuacja: oglądasz bezgłośny poradnik wideo albo animację.**
+  *Rozwiązanie:* naciśnij **Control + V**, żeby zacząć nagrywanie ekranu. Pozwól poradnikowi się odtworzyć i naciśnij **Control + V** ponownie. AI wyjaśni dokładnie, co zostało pokazane.
+
+- **Sytuacja: pojawia się nieoczekiwany błąd, nie działa połączenie z API albo chcesz zdiagnozować własny serwer lokalny.**
+  *Rozwiązanie:* przejdź do **Ustawienia > Zaawansowane**, zaznacz **„Włącz osobny plik dziennika”** i ustaw **poziom szczegółowości** na **„Diagnostyka”**. Powtórz czynność, a potem kliknij **„Otwórz plik dziennika”**, żeby obejrzeć szczegóły techniczne albo dołączyć `vision_assistant.log` do zgłoszenia.
 
 ***
-**Uwaga:** Wszystkie funkcje AI wymagają aktywnego połączenia z internetem. Dokumenty wielostronicowe są przetwarzane automatycznie.
+**Uwaga:** wszystkie funkcje AI wymagają aktywnego połączenia z internetem. Dokumenty wielostronicowe są przetwarzane automatycznie.
 
-## 4. Wsparcie i społeczność
+## 11. Wsparcie i społeczność
 
-Bądź na bieżąco z najnowszymi wiadomościami i aktualizacjami:
-- **Kanał w Telegramie:** [t.me/VisionAssistantPro](https://t.me/VisionAssistantPro)
-- **GitHub Issues:** Zgłaszanie błędów i propozycje nowych funkcji.
+Bądź na bieżąco z nowościami, funkcjami i wydaniami:
+- **Kanał na Telegramie:** [t.me/VisionAssistantPro](https://t.me/VisionAssistantPro)
+- **GitHub Issues:** zgłoszenia błędów i propozycje funkcji.
 
-## 5. Patroni projektu
+### Zgłaszanie błędów i dzienniki
+Otwierając zgłoszenie na GitHubie albo prosząc o pomoc, podaj aktywnego dostawcę AI, model i wersję NVDA. Jeśli masz problemy z połączeniem albo nieoczekiwane awarie, włącz osobny plik dziennika w **Ustawienia > Zaawansowane**, powtórz sytuację i dołącz plik `vision_assistant.log` — to znacznie przyspieszy rozwiązanie problemu.
 
-Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładami finansowymi wspierają ciągły rozwój i utrzymanie tego projektu:
+## 12. Patroni projektu
+
+Serdecznie dziękujemy osobom ze społeczności, które wspierają rozwój i utrzymanie tego projektu swoim wkładem finansowym:
 
 *   **@Alyabani94**
 *   **Ali Alamri**
-*   **Anonimowy wspierający** (`UQDd...CnMY`)
+*   **Ilya**
+*   **Anonimowy darczyńca** (`UQDd...CnMY`)
 *   **leonardo0216**
+*   **Sergei Fleytin**
+*   **Suman Gayen**
 
 *Jeśli chcesz wesprzeć projekt finansowo i zobaczyć tutaj swoje imię, opcję **Wsparcie** znajdziesz w menu Narzędzia NVDA (podmenu Vision Assistant) albo podczas konfiguracji po instalacji.*
 
+---
+## Zmiany w wersji 2026.08.06
+
+*   **Etykietowanie w Eksploratorze interfejsu**: teraz można dodawać etykiety wprost do znalezionych elementów w Eksploratorze interfejsu. Doszedł przycisk „Dodaj etykietę”, a okno zostaje otwarte i utrzymuje fokus, więc kilka obiektów da się opisać jeden po drugim bez przerywania pracy.
+*   **Rozbudowana warstwa szybkich ustawień**: warstwa Vision Assistant (`Insert+Shift+V`) jest teraz trwała i w pełni interaktywna. Strzałkami góra i dół przechodzi się między szybkimi ustawieniami (dostawca, model, język odpowiedzi AI, model TTS), a strzałkami lewo i prawo od razu zmienia ich wartości, z krótkim komunikatem głosowym. Wybory działają natychmiast (łącznie z automatycznym włączeniem osobnego modelu dla zadania, jeśli jest potrzebny), a warstwa pozostaje aktywna przez cały czas konfiguracji.
+*   **Czat (`Shift+C`)**: nowe polecenie w warstwie. `Shift+C` otwiera okno czatu — czysty interfejs tekstowy do rozmowy z AI, bez potrzeby zaczynania od obrazu czy dokumentu.
+*   **Poprawne przywoływanie historii rozmowy**: naprawiony poważny błąd, przez który naciśnięcie `Spacji` w celu przywołania ostatniego wyniku gubiło dalszą historię rozmowy. Dodatek śledzi teraz całą rozmowę globalnie. Po zamknięciu okna i naciśnięciu `Spacji` wraca pełna historia wymiany. Działa dla czatu, analizy obrazu, rozmowy o dokumencie i tłumaczenia.
+*   **Opisy obrazów wplecione w tekst przy OCR**: doszła opcja, która przy OCR dokumentu wplata opis obrazu dokładnie tam, gdzie w dokumencie znajduje się ten obraz. Można ją przełączyć w ustawieniach OCR dodatku, w opcjach czytnika dokumentów przed wyodrębnieniem oraz na bieżąco w warstwie szybkich ustawień.
+*   **Tłumaczenie mowy (`Control+T`)**: nowa funkcja. Dyktujesz, a AI od razu tłumaczy wypowiedź i wpisuje ją jako tekst, zgodnie z ustawionym językiem źródłowym i docelowym.
+*   **Poprawki pobierania aktualizacji**: okno pobierania aktualizacji pokazuje teraz poprawnie postęp w procentach, a błąd, przez który po anulowaniu instalacji pojawiał się fantomowy komunikat „Pobieranie aktualizacji”, został naprawiony.
+*   **Poprawki pobierania eSpeak-NG**: doszedł postęp pobierania eSpeak-NG w procentach.
+*   **Odporność wsadowego OCR**: naprawiony błąd we wsadowym OCR plików PDF, przez który przetwarzanie zatrzymywało się, gdy aktywny klucz API wyczerpał limit w połowie pracy. Teraz dodatek sam przełącza się na kolejny dostępny klucz i kontynuuje.
+*   **Obsługa CAPTCHA obrazkowej**: doszła solidna obsługa rozwiązywania CAPTCHA z obrazu. Dodatek próbuje automatycznie rozwiązywać złożone zagadki obrazkowe w rodzaju hCaptcha i reCAPTCHA, co wyraźnie poprawia dostępność trudnych formularzy internetowych.
+*   **Przebudowana transkrypcja dźwięku**: moduł transkrypcji został napisany od nowa i obsługuje teraz zarówno pliki dźwiękowe, jak i wideo. Ma trzy tryby pracy: „Transkrybuj (język oryginału)”, „Transkrybuj i przetłumacz (język docelowy)” oraz nowy „Zdubbinguj i przetłumacz (język docelowy)” — ten ostatni dostępny wyłącznie w Gemini, tworzy przetłumaczoną ścieżkę głosową oryginalnej wypowiedzi.
+*   **Numery stron w czytniku dokumentów**: doszło ustawienie, które włącza i wyłącza numery stron oraz separatory w dokumentach wielostronicowych. Opcja jest w ustawieniach głównych i w warstwie szybkich ustawień. Działa zarówno przy eksporcie do pliku tekstowego i HTML, jak i w oknie „Pokaż sformatowane”, dzięki czemu połączone dokumenty czyta się bez przerw.
+*   **Gemini Live TTS bez limitu dla opisów wideo**: przy tworzeniu zsynchronizowanej narracji dźwiękowej (MP3) do filmów można teraz wybrać silnik głosu „Gemini Live TTS”. Korzysta on z Gemini Live API i tworzy wysokiej jakości audiodeskrypcję bez ograniczeń długości ani liczby znaków.
+*   **Modularyzacja kodu**: struktura dodatku została przebudowana z jednego pliku na architekturę wielomodułową, co ułatwia utrzymanie.
+*   **Przeprojektowane ustawienia**: okno ustawień zostało w całości przebudowane na nowoczesny układ z zakładkami zamiast grup. Porządek i nawigacja są wygodniejsze, a wszystkie dotychczasowe opcje zostają.
+*   **Globalny dziennik w osobnym pliku**: doszedł opcjonalny globalny dziennik pod nową zakładką ustawień „Zaawansowane”. Zapisuje zdarzenia, ruch do API i błędy ze wszystkich modułów dodatku do osobnego pliku (`vision_assistant.log`). Obsługuje poziomy szczegółowości (diagnostyka, informacje, ostrzeżenia, błędy) i automatyczne przechowywanie (od godziny do 90 dni), a plik można otworzyć lub wyczyścić wprost z ustawień. Bez wpływu na wydajność i bez zaśmiecania dziennika NVDA.
+*   **Postęp wysyłania do Gemini**: doszły komunikaty o postępie w procentach przy wysyłaniu dużych plików (wideo, dźwięk, dokumenty) do Google Gemini API.
 
 ---
 ## Zmiany w wersji 2026.07.15
@@ -148,7 +334,7 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 *   **Dostawca MiniMax**: Zintegrowano MiniMax jako równorzędnego dostawcę z pełną obsługą multimodalną (czat, obraz, OCR), własnym TTS z ponad 300 dynamicznymi głosami oraz automatycznym usuwaniem bloków rozumowania (np. `<think>...</think>`) z odpowiedzi.
 *   **Tłumaczenie w czytniku dokumentów**: Naprawiono ciche niepowodzenie tłumaczenia u osób korzystających z NVDA w językach innych niż angielski, dbając o to, by do Google Translate trafiał standardowy dwuliterowy kod języka zamiast zlokalizowanej nazwy.
 *   **Ponawianie skanowania wsadowego PDF**: Wprowadzono zoptymalizowaną, osobną i cichą logikę ponawiania przy skanowaniu wsadowym dokumentów PDF, aby zapobiec zbędnym przesłaniom i uniknąć uciążliwych okienek z błędami podczas ponawiania.
-*   **Status czytnika dokumentów**: Naprawiono błąd, przez który ogólny status dodatku (sprawdzany przez `I`) pozostawał zatrzymany na „Rozpoczęto przetwarzanie wsadowe" podczas długiego skanowania dokumentów.
+*   **Status czytnika dokumentów**: Naprawiono błąd, przez który ogólny status dodatku (sprawdzany przez `I`) pozostawał zatrzymany na „Rozpoczęto przetwarzanie wsadowe” podczas długiego skanowania dokumentów.
 *   **Naprawiona awaria wątkowania**: Naprawiono poważną awarię (`IsMain() failed in wxTimerImpl`) przy otwieraniu dokumentów z wątku działającego w tle, przenosząc kolejkę wywołań GUI na `wx.CallAfter`.
 
 ---
@@ -169,9 +355,9 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 ---
 ## Zmiany w wersji 6.1.0
 
-*   **Uniwersalna integracja lokalnej AI (Konfiguracja lokalnej AI)**: Dodano nowy przycisk **„Konfiguracja lokalnej AI"** w ustawieniach niestandardowego dostawcy. Teraz można od razu automatycznie skonfigurować lokalne silniki AI, w tym **Ollama**, **LM Studio**, **Jan.ai** i **KoboldCPP**.
+*   **Uniwersalna integracja lokalnej AI (Konfiguracja lokalnej AI)**: Dodano nowy przycisk **„Konfiguracja lokalnej AI”** w ustawieniach niestandardowego dostawcy. Teraz można od razu automatycznie skonfigurować lokalne silniki AI, w tym **Ollama**, **LM Studio**, **Jan.ai** i **KoboldCPP**.
 *   **Ominięcie lokalnego proxy**: Przebudowano logikę połączenia z zaawansowanym mechanizmem omijania proxy. Dodatek całkowicie omija systemowe proxy Windows przy połączeniach lokalnych, dzięki czemu połączenie z lokalną AI jest stabilne nawet przy aktywnym VPN lub trybie TUN.
-*   **Awaryjne zatrzymanie Operatora AI (Shift+A)**: Dodano wyzwalacz zatrzymania. Naciśnięcie polecenia Operatora AI (**Shift+A** w warstwie poleceń) podczas trwającej operacji autonomicznej natychmiast przerywa pętlę i ogłasza *„Operator AI zatrzymany."*
+*   **Awaryjne zatrzymanie Operatora AI (Shift+A)**: Dodano wyzwalacz zatrzymania. Naciśnięcie polecenia Operatora AI (**Shift+A** w warstwie poleceń) podczas trwającej operacji autonomicznej natychmiast przerywa pętlę i ogłasza *„Operator AI zatrzymany.”*
 *   **Bardzo stabilne etykietowanie AI (v2)**: Zastąpiono klucze oparte na bezwzględnych współrzędnych ekranu zaawansowanym, hybrydowym systemem **sygnatur obiektów**. Etykiety opierają się teraz na identyfikatorach programowych (UIA **AutomationId** lub Win32 **ControlID**) oraz współrzędnych względem okna, dzięki czemu są one całkowicie odporne na zmianę rozmiaru, przesuwanie, zmianę monitora czy skalowanie okna.
 *   **Płynna automatyczna migracja etykiet**: Aktualizacja jest całkowicie przezroczysta. Dodatek automatycznie przeniesie starsze etykiety oparte na współrzędnych do nowego, stabilnego formatu sygnatur w tle przy pierwszym ustawieniu fokusu, bez utraty danych.
 
@@ -180,7 +366,7 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 
 *   **etykietowanie AI**: Teraz można trwale nadawać etykiety nienazwanym przyciskom i ikonom za pomocą AI. Naciśnij **L**, by oznaczyć bieżący obiekt nawigatora (obsługa zarówno fokusu Tab, jak i nawigacji obiektowej), lub **Shift+L**, by przeskanować i oznaczyć całą aplikację naraz.
 *   **Zarządzanie etykietami**: Nowe, w pełni dostępne okno Menedżer etykiet (przez **Shift+L**, jeśli etykiety istnieją) pozwala przeglądać, zmieniać nazwy i zbiorczo usuwać etykiety.
-*   **Bezpośrednia analiza pliku (z pominięciem okna dialogowego)**: Dodatek wykrywa, czy fokus znajduje się na pliku PDF lub graficznym w Eksploratorze Windows. Naciśnięcie **F (Akcja na pliku)** lub **D (Czytnik dokumentów)** na zaznaczonym pliku natychmiast go przetworzy, pomijając standardowe okno „Otwórz".
+*   **Bezpośrednia analiza pliku (z pominięciem okna dialogowego)**: Dodatek wykrywa, czy fokus znajduje się na pliku PDF lub graficznym w Eksploratorze Windows. Naciśnięcie **F (Akcja na pliku)** lub **D (Czytnik dokumentów)** na zaznaczonym pliku natychmiast go przetworzy, pomijając standardowe okno „Otwórz”.
 
 ## Zmiany w wersji 5.6
 
@@ -190,18 +376,18 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 
 ## Zmiany w wersji 5.5.2
 
-* **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w którym litera „v" była wpisywana zamiast wklejania tekstu na niektórych systemach. Poprawka usuwa konflikty czasowe występujące przy dużym obciążeniu systemu.
+* **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w którym litera „v” była wpisywana zamiast wklejania tekstu na niektórych systemach. Poprawka usuwa konflikty czasowe występujące przy dużym obciążeniu systemu.
 * **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest tymczasowo zablokowany przez inne aplikacje.
 * **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami schowka.
 
 ## Zmiany w wersji 5.5 (Aktualizacja automatyzacji)
 
 * **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.
-    * *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *"Kliknij przycisk Ustawienia"* lub *"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter."* AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.
+    * *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *„Kliknij przycisk Ustawienia”* lub *„Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.”* AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.
     * *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.
-    * **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi „widzieć" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.
-* **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po „nieoznaczonych przyciskach"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak „warstwa dostępności" nałożona na dowolną aplikację.
-* **Akcja na pliku zależna od kontekstu (F):** Klawisz „F" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.
+    * **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi „widzieć” dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.
+* **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po „nieoznaczonych przyciskach”? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak „warstwa dostępności” nałożona na dowolną aplikację.
+* **Akcja na pliku zależna od kontekstu (F):** Klawisz „F” został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.
 * **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie.
 
 ## Zmiany w wersji 5.0
@@ -231,14 +417,14 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 ## Zmiany w wersji 4.0.3
 * **Obsługa niestabilnego połączenia:** Dodano mechanizm automatycznych ponownych prób, aby lepiej radzić sobie z chwilowymi błędami serwera i niestabilnym połączeniem.
 * **Okno tłumaczenia:** Dodano dedykowane okno dla wyników tłumaczenia. Długie tłumaczenia można teraz przeglądać wiersz po wierszu, podobnie jak wyniki OCR.
-* **Zbiorczy podgląd sformatowany:** Funkcja „Podgląd sformatowany" w czytniku dokumentów wyświetla teraz wszystkie przetworzone strony w jednym uporządkowanym oknie z nagłówkami stron.
+* **Zbiorczy podgląd sformatowany:** Funkcja „Podgląd sformatowany” w czytniku dokumentów wyświetla teraz wszystkie przetworzone strony w jednym uporządkowanym oknie z nagłówkami stron.
 * **Szybszy OCR:** Dla dokumentów jednostronicowych pomijany jest wybór zakresu stron, co przyspiesza proces rozpoznawania.
-* **Stabilność API:** Zmieniono metodę uwierzytelniania na opartą o nagłówki HTTP, eliminując błędy „Wszystkie klucze API zawiodły" powodowane przez konflikty rotacji kluczy.
+* **Stabilność API:** Zmieniono metodę uwierzytelniania na opartą o nagłówki HTTP, eliminując błędy „Wszystkie klucze API zawiodły” powodowane przez konflikty rotacji kluczy.
 * **Poprawki błędów:** Naprawiono kilka potencjalnych awarii, w tym problem przy zamykaniu dodatku oraz błąd fokusu w oknie czatu.
 
 ## Zmiany w wersji 4.0.1
 * **Czytnik dokumentów:** Nowa przeglądarka PDF i obrazów z wyborem zakresu stron, przetwarzaniem w tle i nawigacją Ctrl+PageUp/Down.
-* **Podmenu Narzędzia:** Dodano podmenu „Vision Assistant" w menu Narzędzia NVDA, umożliwiające szybki dostęp do głównych funkcji, ustawień i dokumentacji.
+* **Podmenu Narzędzia:** Dodano podmenu „Vision Assistant” w menu Narzędzia NVDA, umożliwiające szybki dostęp do głównych funkcji, ustawień i dokumentacji.
 * **Konfiguracja:** Teraz można wybrać preferowany silnik OCR i głos TTS bezpośrednio w panelu ustawień.
 * **Wiele kluczy API:** Dodano obsługę wielu kluczy API Gemini. Klucze można podać po jednym w wierszu lub rozdzielone przecinkami.
 * **Alternatywny silnik OCR:** Dodano nowy silnik OCR, zapewniający niezawodne rozpoznawanie tekstu nawet po przekroczeniu limitów API Gemini.
@@ -247,7 +433,7 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 * **Instagram Stories:** Dodano możliwość opisu i analizy Instagram Stories za pomocą adresów URL.
 * **TikTok:** Dodano obsługę filmów TikTok, umożliwiając opis wizualny i transkrypcję audio.
 * **Okno aktualizacji:** Nowy dostępny interfejs z polem tekstowym do przejrzenia zmian przed instalacją.
-* **Ujednolicenie interfejsu:** Ustandaryzowano okna dialogowe plików w całym dodatku i rozszerzono polecenie „L" o raportowanie postępu w czasie rzeczywistym.
+* **Ujednolicenie interfejsu:** Ustandaryzowano okna dialogowe plików w całym dodatku i rozszerzono polecenie „L” o raportowanie postępu w czasie rzeczywistym.
 
 ## Zmiany w wersji 3.6.0
 * **System pomocy:** Dodano polecenie pomocy (`H`) w warstwie poleceń, wyświetlające listę wszystkich skrótów i ich funkcji.
@@ -273,27 +459,27 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 ## Zmiany w wersji 2.9
 
 * **Dodano tłumaczenia na francuski i turecki.**
-* **Podgląd sformatowany:** Dodano przycisk „Podgląd sformatowany" w oknach czatu, umożliwiający wyświetlenie rozmowy z prawidłowym formatowaniem (nagłówki, pogrubienie, kod) w standardowym oknie przeglądarki.
-* **Ustawienie Markdown:** Dodano opcję „Czyść Markdown w czacie" w ustawieniach. Odznaczenie pozwala widzieć surową składnię Markdown (np. `**`, `#`) w oknie czatu.
-* **Zarządzanie oknami:** Naprawiono problem z wielokrotnym otwieraniem okien „Poprawianie tekstu" lub czatu.
-* **Usprawnienia interfejsu:** Ujednolicono tytuły okien dialogowych plików na „Otwórz" i usunięto zbędne komunikaty głosowe (np. „Otwieranie menu...").
+* **Podgląd sformatowany:** Dodano przycisk „Podgląd sformatowany” w oknach czatu, umożliwiający wyświetlenie rozmowy z prawidłowym formatowaniem (nagłówki, pogrubienie, kod) w standardowym oknie przeglądarki.
+* **Ustawienie Markdown:** Dodano opcję „Czyść Markdown w czacie” w ustawieniach. Odznaczenie pozwala widzieć surową składnię Markdown (np. `**`, `#`) w oknie czatu.
+* **Zarządzanie oknami:** Naprawiono problem z wielokrotnym otwieraniem okien „Poprawianie tekstu” lub czatu.
+* **Usprawnienia interfejsu:** Ujednolicono tytuły okien dialogowych plików na „Otwórz” i usunięto zbędne komunikaty głosowe (np. „Otwieranie menu...”).
 
 ## Zmiany w wersji 2.8
 * Dodano tłumaczenie na włoski.
-* **Raport stanu:** Dodano polecenie (NVDA+Control+Shift+I) odczytujące bieżący stan dodatku (np. „Przesyłanie...", „Analizowanie...").
-* **Eksport HTML:** Przycisk „Zapisz treść" w oknach wyników zapisuje teraz dane jako sformatowany plik HTML, zachowując style takie jak nagłówki i pogrubienia.
+* **Raport stanu:** Dodano polecenie (NVDA+Control+Shift+I) odczytujące bieżący stan dodatku (np. „Przesyłanie...”, „Analizowanie...”).
+* **Eksport HTML:** Przycisk „Zapisz treść” w oknach wyników zapisuje teraz dane jako sformatowany plik HTML, zachowując style takie jak nagłówki i pogrubienia.
 * **Interfejs ustawień:** Poprawiono układ panelu ustawień z dostępnym grupowaniem.
 * **Nowe modele:** Dodano obsługę gemini-flash-latest i gemini-flash-lite-latest.
 * **Języki:** Dodano nepalski do obsługiwanych języków.
-* **Poprawianie tekstu:** Naprawiono błąd, przez który polecenia „Poprawianie tekstu" nie działały, gdy język interfejsu NVDA nie był angielski.
+* **Poprawianie tekstu:** Naprawiono błąd, przez który polecenia „Poprawianie tekstu” nie działały, gdy język interfejsu NVDA nie był angielski.
 * **Dyktowanie:** Poprawiono wykrywanie ciszy, aby zapobiec błędnemu rozpoznawaniu tekstu przy braku mowy.
-* **Ustawienia aktualizacji:** Opcja „Sprawdzaj aktualizacje przy uruchomieniu" jest teraz domyślnie wyłączona, zgodnie z polityką Add-on Store.
+* **Ustawienia aktualizacji:** Opcja „Sprawdzaj aktualizacje przy uruchomieniu” jest teraz domyślnie wyłączona, zgodnie z polityką Add-on Store.
 * Porządki w kodzie.
 
 ## Zmiany w wersji 2.7
 * Przeniesiono strukturę projektu na oficjalny szablon dodatków NV Access, zapewniając zgodność ze standardami.
 * Dodano automatyczne ponawianie prób przy błędach HTTP 429 (limit zapytań), poprawiając niezawodność w okresach dużego ruchu.
-* Zoptymalizowano polecenia tłumaczenia dla wyższej dokładności i lepszej obsługi logiki „Zamień języki".
+* Zoptymalizowano polecenia tłumaczenia dla wyższej dokładności i lepszej obsługi logiki „Zamień języki”.
 * Zaktualizowano tłumaczenie rosyjskie.
 
 ## Zmiany w wersji 2.6
@@ -303,7 +489,7 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 
 ## Zmiany w wersji 2.5
 * Dodano polecenie OCR pliku (NVDA+Control+Shift+F).
-* Dodano przycisk „Zapisz czat" w oknach wyników.
+* Dodano przycisk „Zapisz czat” w oknach wyników.
 * Wdrożono pełną obsługę lokalizacji (i18n).
 * Przeniesiono sygnały dźwiękowe na natywny moduł NVDA.
 * Przejście na Gemini File API dla lepszej obsługi plików PDF i audio.
@@ -327,7 +513,7 @@ Serdecznie dziękujemy członkom społeczności, którzy swoimi hojnymi wkładam
 * Dodano obsługę ponad 20 nowych języków.
 * Dodano okno dialogowe do doprecyzowywania wyników za pomocą pytań uzupełniających.
 * Dodano wbudowane dyktowanie.
-* Dodano kategorię „Vision Assistant" w oknie Zdarzenia wejścia NVDA.
+* Dodano kategorię „Vision Assistant” w oknie Zdarzenia wejścia NVDA.
 * Naprawiono awarie COMError w niektórych aplikacjach, takich jak Firefox i Word.
 * Dodano mechanizm automatycznego ponawiania prób przy błędach serwera.
 

--- a/addon/locale/pl/LC_MESSAGES/nvda.po
+++ b/addon/locale/pl/LC_MESSAGES/nvda.po
@@ -1,19 +1,10 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the 'VisionAssistant' package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the 'VisionAssistant' package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 'VisionAssistant' '6.5.0'\n"
+"Project-Id-Version: 'VisionAssistant' '2026.08.06'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-07-15 22:25+0330\n"
-"PO-Revision-Date: 2026-07-16 19:10+0200\n"
+"POT-Creation-Date: 2026-08-06 21:29+0330\n"
+"PO-Revision-Date: 2026-08-09 12:44+0200\n"
 "Last-Translator: Oliwia Sobczak <oliwia.sobczak@proton.me>\n"
 "Language-Team: Polish <pl@li.org>\n"
 "Language: pl\n"
@@ -22,65 +13,1791 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
+#. Translators: Prefix for custom prompts in the Refine menu
+#: addon\globalPlugins\visionAssistant\prompt_utils.py:217 addon\globalPlugins\visionAssistant\vision_config.py:1024
+msgid "Custom: "
+msgstr "Niestandardowe: "
+
+#. --- 1. Recommended (Auto-Updating) ---
+#. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest
+#. version.
+#: addon\globalPlugins\visionAssistant\vision_config.py:36 addon\globalPlugins\visionAssistant\vision_config.py:37
+msgid "[Auto]"
+msgstr "[Auto]"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:36 addon\globalPlugins\visionAssistant\vision_config.py:37
+msgid "(Latest)"
+msgstr "(Najnowszy)"
+
+#. --- 2. Current Standard (Free & Fast) ---
+#. Translators: AI Model info. [Free] = Generous usage limits. (Preview) =
+#. Experimental or early-access version.
+#: addon\globalPlugins\visionAssistant\vision_config.py:41 addon\globalPlugins\visionAssistant\vision_config.py:42 addon\globalPlugins\visionAssistant\vision_config.py:43 addon\globalPlugins\visionAssistant\vision_config.py:44 addon\globalPlugins\visionAssistant\vision_config.py:45
+#: addon\globalPlugins\visionAssistant\vision_config.py:46
+msgid "[Free]"
+msgstr "[Darmowy]"
+
+#. --- 3. High Intelligence (Paid/Pro/Preview) ---
+#. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview)
+#. = Experimental version.
+#: addon\globalPlugins\visionAssistant\vision_config.py:50 addon\globalPlugins\visionAssistant\vision_config.py:51
+msgid "[Pro]"
+msgstr "[Pro]"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:50
+msgid "(Preview)"
+msgstr "(Podgląd)"
+
+#. Translators: Adjective describing a bright AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:56 addon\globalPlugins\visionAssistant\vision_config.py:72
+msgid "Bright"
+msgstr "Jasny"
+
+#. Translators: Adjective describing an upbeat AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:58 addon\globalPlugins\visionAssistant\vision_config.py:85
+msgid "Upbeat"
+msgstr "Pogodny"
+
+#. Translators: Adjective describing an informative AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:60 addon\globalPlugins\visionAssistant\vision_config.py:84
+msgid "Informative"
+msgstr "Informacyjny"
+
+#. Translators: Adjective describing a firm AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:62 addon\globalPlugins\visionAssistant\vision_config.py:67 addon\globalPlugins\visionAssistant\vision_config.py:88
+msgid "Firm"
+msgstr "Stanowczy"
+
+#. Translators: Adjective describing an excitable AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:64
+msgid "Excitable"
+msgstr "Entuzjastyczny"
+
+#. Translators: Adjective describing a youthful AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:66
+msgid "Youthful"
+msgstr "Młodzieńczy"
+
+#. Translators: Adjective describing a breezy AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:69
+msgid "Breezy"
+msgstr "Lekki"
+
+#. Translators: Adjective describing an easy-going AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:71 addon\globalPlugins\visionAssistant\vision_config.py:77
+msgid "Easy-going"
+msgstr "Wyluzowany"
+
+#. Translators: Adjective describing a breathy AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:74
+msgid "Breathy"
+msgstr "Szeptany"
+
+#. Translators: Adjective describing a clear AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:76 addon\globalPlugins\visionAssistant\vision_config.py:81 addon\globalPlugins\visionAssistant\vision_config.py:127
+msgid "Clear"
+msgstr "Wyraźny"
+
+#. Translators: Adjective describing a smooth AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:79 addon\globalPlugins\visionAssistant\vision_config.py:80
+msgid "Smooth"
+msgstr "Łagodny"
+
+#. Translators: Adjective describing a gravelly AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:83
+msgid "Gravelly"
+msgstr "Chropowaty"
+
+#. Translators: Adjective describing a soft AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:87
+msgid "Soft"
+msgstr "Miękki"
+
+#. Translators: Adjective describing an even AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:90
+msgid "Even"
+msgstr "Równomierny"
+
+#. Translators: Adjective describing a mature AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:92
+msgid "Mature"
+msgstr "Dojrzały"
+
+#. Translators: Adjective describing a forward AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:94
+msgid "Forward"
+msgstr "Bezpośredni"
+
+#. Translators: Adjective describing a friendly AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:96
+msgid "Friendly"
+msgstr "Przyjazny"
+
+#. Translators: Adjective describing a casual AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:98
+msgid "Casual"
+msgstr "Swobodny"
+
+#. Translators: Adjective describing a gentle AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:100 addon\globalPlugins\visionAssistant\vision_config.py:126
+msgid "Gentle"
+msgstr "Delikatny"
+
+#. Translators: Adjective describing a lively AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:102
+msgid "Lively"
+msgstr "Żywiołowy"
+
+#. Translators: Adjective describing a knowledgeable AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:104
+msgid "Knowledgeable"
+msgstr "Kompetentny"
+
+#. Translators: Adjective describing a warm AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:106
+msgid "Warm"
+msgstr "Ciepły"
+
+#. Translators: Adjective describing a neutral AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:111
+msgid "Neutral"
+msgstr "Neutralny"
+
+#. Translators: Adjective describing a quirky AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:113
+msgid "Quirky"
+msgstr "Ekscentryczny"
+
+#. Translators: Adjective describing a professional AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:115
+msgid "Professional"
+msgstr "Profesjonalny"
+
+#. Translators: Adjective describing a cheerful AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:117
+msgid "Cheerful"
+msgstr "Radosny"
+
+#. Translators: Adjective describing a confident AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:119
+msgid "Confident"
+msgstr "Pewny siebie"
+
+#. Translators: Adjective describing a British AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:121
+msgid "British"
+msgstr "Brytyjski"
+
+#. Translators: Adjective describing a pleasant AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:123
+msgid "Pleasant"
+msgstr "Przyjemny"
+
+#. Translators: Adjective describing a deep AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:125
+msgid "Deep"
+msgstr "Głęboki"
+
+#. Translators: Adjective describing an expressive AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:129
+msgid "Expressive"
+msgstr "Ekspresyjny"
+
+#. Translators: Adjective describing a reliable AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:131
+msgid "Reliable"
+msgstr "Niezawodny"
+
+#. Translators: Adjective describing an energetic AI voice style.
+#: addon\globalPlugins\visionAssistant\vision_config.py:133
+msgid "Energetic"
+msgstr "Energiczny"
+
+#. Translators: Option in the language list to automatically detect the source
+#. language.
+#: addon\globalPlugins\visionAssistant\vision_config.py:164
+msgid "Auto-detect"
+msgstr "Wykryj automatycznie"
+
+#. Translators: OCR Engine option (Fast but less formatted)
+#: addon\globalPlugins\visionAssistant\vision_config.py:178
+msgid "Chrome (Fast)"
+msgstr "Chrome (szybki)"
+
+#. Translators: OCR Engine option (Slower but better formatting/AI-driven)
+#: addon\globalPlugins\visionAssistant\vision_config.py:180
+msgid "AI (Advanced)"
+msgstr "AI (zaawansowany)"
+
+#. Translators: OCR Engine option for searchable PDFs (extracts text without
+#. OCR)
+#: addon\globalPlugins\visionAssistant\vision_config.py:182
+msgid "None (Extract Text Layer)"
+msgstr "Wyodrębnij tekst (offline)"
+
+#. Translators: Log retention option: 1 hour
+#: addon\globalPlugins\visionAssistant\vision_config.py:283
+msgid "1 Hour"
+msgstr "1 godzina"
+
+#. Translators: Log retention option: 3 hours
+#: addon\globalPlugins\visionAssistant\vision_config.py:285
+msgid "3 Hours"
+msgstr "3 godziny"
+
+#. Translators: Log retention option: 6 hours
+#: addon\globalPlugins\visionAssistant\vision_config.py:287
+msgid "6 Hours"
+msgstr "6 godzin"
+
+#. Translators: Log retention option: 12 hours
+#: addon\globalPlugins\visionAssistant\vision_config.py:289
+msgid "12 Hours"
+msgstr "12 godzin"
+
+#. Translators: Log retention option: 24 hours (1 day)
+#: addon\globalPlugins\visionAssistant\vision_config.py:291
+msgid "24 Hours (1 Day)"
+msgstr "24 godziny (1 dzień)"
+
+#. Translators: Log retention option: 3 days
+#: addon\globalPlugins\visionAssistant\vision_config.py:293
+msgid "3 Days"
+msgstr "3 dni"
+
+#. Translators: Log retention option: 7 days
+#: addon\globalPlugins\visionAssistant\vision_config.py:295
+msgid "7 Days"
+msgstr "7 dni"
+
+#. Translators: Log retention option: 14 days
+#: addon\globalPlugins\visionAssistant\vision_config.py:297
+msgid "14 Days"
+msgstr "14 dni"
+
+#. Translators: Log retention option: 30 days
+#: addon\globalPlugins\visionAssistant\vision_config.py:299
+msgid "30 Days"
+msgstr "30 dni"
+
+#. Translators: Log retention option: 90 days
+#: addon\globalPlugins\visionAssistant\vision_config.py:301
+msgid "90 Days"
+msgstr "90 dni"
+
+#. Translators: Section header for text refinement prompts in Prompt Manager.
+#. Translators: Title of the Refine dialog
+#: addon\globalPlugins\visionAssistant\vision_config.py:310 addon\globalPlugins\visionAssistant\vision_config.py:318 addon\globalPlugins\visionAssistant\vision_config.py:325 addon\globalPlugins\visionAssistant\vision_config.py:332 addon\globalPlugins\visionAssistant\features\vision.py:394
+msgid "Refine"
+msgstr "Poprawianie"
+
+#. Translators: Label for the text summarization prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:312
+msgid "Summarize"
+msgstr "Podsumuj"
+
+#. Translators: Label for the grammar correction prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:320
+msgid "Fix Grammar"
+msgstr "Popraw gramatykę"
+
+#. Translators: Label for the grammar correction and translation prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:327
+msgid "Fix Grammar & Translate"
+msgstr "Popraw gramatykę i przetłumacz"
+
+#. Translators: Label for the text explanation prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:334
+msgid "Explain"
+msgstr "Wyjaśnij"
+
+#. Translators: Section header for translation-related prompts in Prompt
+#. Manager.
+#. Translators: Label for end page
+#: addon\globalPlugins\visionAssistant\vision_config.py:340 addon\globalPlugins\visionAssistant\vision_config.py:351 addon\globalPlugins\visionAssistant\dialogs\document.py:265
+msgid "Translation"
+msgstr "Tłumaczenie"
+
+#. Translators: Label for the smart translation prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:342 addon\globalPlugins\visionAssistant\vision_config.py:344
+msgid "Smart Translation"
+msgstr "Inteligentne tłumaczenie"
+
+#. Translators: Label for the quick translation prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:353
+msgid "Quick Translation"
+msgstr "Szybkie tłumaczenie"
+
+#. Translators: Section header for document-related prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:359 addon\globalPlugins\visionAssistant\vision_config.py:617
+msgid "Document"
+msgstr "Dokument"
+
+#. Translators: Label for the initial context prompt in document chat.
+#: addon\globalPlugins\visionAssistant\vision_config.py:361
+msgid "Document Chat Context"
+msgstr "Kontekst czatu z dokumentem"
+
+#. Translators: Section header for image analysis prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:374 addon\globalPlugins\visionAssistant\vision_config.py:387 addon\globalPlugins\visionAssistant\vision_config.py:672 addon\globalPlugins\visionAssistant\vision_config.py:700 addon\globalPlugins\visionAssistant\vision_config.py:721
+#: addon\globalPlugins\visionAssistant\vision_config.py:736
+msgid "Vision"
+msgstr "Rozpoznawanie"
+
+#. Translators: Label for the prompt used to analyze the current navigator
+#. object.
+#: addon\globalPlugins\visionAssistant\vision_config.py:376
+msgid "Navigator Object Analysis"
+msgstr "Analiza obiektu nawigatora"
+
+#. Translators: Label for the prompt used to analyze the entire screen.
+#: addon\globalPlugins\visionAssistant\vision_config.py:389
+msgid "Full Screen Analysis"
+msgstr "Analiza pełnego ekranu"
+
+#. Translators: Section header for video analysis prompts in Prompt Manager.
+#. Translators: Labels for the AI and User in chat history
+#: addon\globalPlugins\visionAssistant\vision_config.py:415 addon\globalPlugins\visionAssistant\vision_config.py:483 addon\globalPlugins\visionAssistant\vision_config.py:527 addon\globalPlugins\visionAssistant\__init__.py:518 addon\globalPlugins\visionAssistant\dialogs\settings.py:360
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:667 addon\globalPlugins\visionAssistant\features\quick_settings.py:248
+msgid "Video"
+msgstr "Wideo"
+
+#. Translators: Label for the general video content analysis prompt.
+#. Translators: Option to generate an Audio Description SRT file.
+#. Translators: Option for general video analysis without timestamps.
+#: addon\globalPlugins\visionAssistant\vision_config.py:417 addon\globalPlugins\visionAssistant\dialogs\media.py:258 addon\globalPlugins\visionAssistant\features\video.py:84
+msgid "General Video Analysis"
+msgstr "Ogólna analiza wideo"
+
+#. Translators: Label for the Audio Description (SRT) generation prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:485
+msgid "Audio Description Generation (SRT)"
+msgstr "Generowanie audiodeskrypcji (SRT)"
+
+#. Translators: Label for the local video recording analysis prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:529
+msgid "Local Video Recording Analysis"
+msgstr "Analiza nagrania ekranu"
+
+#. Translators: Section header for audio-related prompts in Prompt Manager.
+#. Translators: Label for audio translation prompt in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:540 addon\globalPlugins\visionAssistant\vision_config.py:548 addon\globalPlugins\visionAssistant\vision_config.py:557 addon\globalPlugins\visionAssistant\vision_config.py:570
+msgid "Audio"
+msgstr "Audio"
+
+#. Translators: Label for the audio file transcription prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:542
+msgid "Audio Transcription"
+msgstr "Transkrypcja audio"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:549 addon\globalPlugins\visionAssistant\vision_config.py:551
+msgid "Audio Translation"
+msgstr "Tłumaczenie audio"
+
+#. Translators: Label for the smart voice dictation prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:559 addon\globalPlugins\visionAssistant\vision_config.py:561
+msgid "Smart Dictation"
+msgstr "Dyktowanie"
+
+#. Translators: Prompt Manager label for voice translation feature
+#: addon\globalPlugins\visionAssistant\vision_config.py:572 addon\globalPlugins\visionAssistant\vision_config.py:574
+msgid "Voice Translation"
+msgstr "Tłumaczenie mowy"
+
+#. Translators: Section header for OCR-related prompts in Prompt Manager.
+#. Translators: Prefix for main model status
+#: addon\globalPlugins\visionAssistant\vision_config.py:587 addon\globalPlugins\visionAssistant\vision_config.py:599 addon\globalPlugins\visionAssistant\vision_config.py:635 addon\globalPlugins\visionAssistant\__init__.py:511 addon\globalPlugins\visionAssistant\features\quick_settings.py:241
+msgid "OCR"
+msgstr "OCR"
+
+#. Translators: Label for the OCR prompt used for image text extraction.
+#: addon\globalPlugins\visionAssistant\vision_config.py:589
+msgid "OCR Image Extraction"
+msgstr "Wyodrębnianie tekstu z obrazu (OCR)"
+
+#. Translators: Label for the OCR prompt used for document text extraction.
+#: addon\globalPlugins\visionAssistant\vision_config.py:601 addon\globalPlugins\visionAssistant\vision_config.py:603
+msgid "OCR Document Extraction"
+msgstr "Wyodrębnianie tekstu z dokumentu (OCR)"
+
+#. Translators: Label for the combined OCR and translation prompt for
+#. documents.
+#: addon\globalPlugins\visionAssistant\vision_config.py:619 addon\globalPlugins\visionAssistant\vision_config.py:621
+msgid "Document OCR + Translate"
+msgstr "OCR dokumentu + tłumaczenie"
+
+#. Translators: Title for the sub-prompt that instructs the AI to describe
+#. images inline.
+#: addon\globalPlugins\visionAssistant\vision_config.py:637
+msgid "Image Description Instruction (Sub-prompt)"
+msgstr "Wytyczne do opisu obrazu (polecenie dodatkowe)"
+
+#. Translators: Checkbox label to add an AI warning disclaimer at the
+#. beginning of the video SRT output.
+#. --- CAPTCHA Group ---
+#: addon\globalPlugins\visionAssistant\vision_config.py:651 addon\globalPlugins\visionAssistant\dialogs\settings.py:383
+msgid "CAPTCHA"
+msgstr "CAPTCHA"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:652 addon\globalPlugins\visionAssistant\vision_config.py:654
+msgid "CAPTCHA Solver"
+msgstr "Rozwiązywanie CAPTCHA"
+
+#. Translators: Label for the UI Explorer system instruction prompt in the
+#. Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:674
+msgid "UI Explorer Instruction"
+msgstr "Instrukcja Eksploratora interfejsu"
+
+#. Translators: Feature name shown in the warning dialog when a user tries to
+#. eid the UI Explorer prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:677
+msgid "UI Explorer"
+msgstr "Eksplorator interfejsu"
+
+#. Translators: Label for the AI Operator system instruction prompt in the
+#. Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:702
+msgid "AI Operator Instruction"
+msgstr "Instrukcja Operatora AI"
+
+#. Translators: Feature name shown in the warning dialog when a user tries to
+#. edit the AI Operator prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:705 addon\globalPlugins\visionAssistant\features\operator_captcha.py:152
+msgid "AI Operator"
+msgstr "Operator AI"
+
+#. Translators: Label for the prompt used to identify a single UI icon.
+#: addon\globalPlugins\visionAssistant\vision_config.py:723
+msgid "Single Labeling Instruction"
+msgstr "Instrukcja pojedynczego etykietowania"
+
+#. Translators: Label for the prompt used to identify multiple unnamed
+#. elements at once.
+#: addon\globalPlugins\visionAssistant\vision_config.py:738
+msgid "Batch Labeling Instruction"
+msgstr "Instrukcja zbiorczego etykietowania"
+
+#. Translators: Feature name used in guarded prompt warnings for Batch
+#. Labeling.
+#: addon\globalPlugins\visionAssistant\vision_config.py:741
+msgid "Batch Labeling"
+msgstr "Zbiorcze etykietowanie"
+
+#. Translators: Section header for advanced prompts in Prompt Manager.
+#. --- Advanced Group ---
+#. Translators: Title of the advanced settings tab
+#: addon\globalPlugins\visionAssistant\vision_config.py:757 addon\globalPlugins\visionAssistant\dialogs\settings.py:427
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#. Translators: Label for the advanced visual CAPTCHA solver prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:759
+msgid "Visual CAPTCHA Solver"
+msgstr "Rozwiązywanie CAPTCHA obrazkowej"
+
+#. Translators: Section header for the Live Assistant prompt in Prompt
+#. Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:779 addon\globalPlugins\visionAssistant\__init__.py:519 addon\globalPlugins\visionAssistant\features\quick_settings.py:249
+msgid "Live"
+msgstr "Asystent głosowy"
+
+#. Translators: Label for the Live Assistant system instruction prompt in the
+#. Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:781
+msgid "Live Assistant Instruction"
+msgstr "Instrukcja asystenta głosowego"
+
+#. Translators: Feature name shown in the warning dialog when a user tries to
+#. edit the Live Assistant prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:784
+msgid "Live Assistant"
+msgstr "Asystent głosowy"
+
+#. Translators: Description and input type for the [selection] variable in the
+#. Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:804
+msgid "Currently selected text"
+msgstr "Aktualnie zaznaczony tekst"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:804 addon\globalPlugins\visionAssistant\vision_config.py:805 addon\globalPlugins\visionAssistant\vision_config.py:817 addon\globalPlugins\visionAssistant\vision_config.py:818 addon\globalPlugins\visionAssistant\vision_config.py:819
+#: addon\globalPlugins\visionAssistant\vision_config.py:820 addon\globalPlugins\visionAssistant\vision_config.py:822
+msgid "Text"
+msgstr "Tekst"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:805
+msgid "Clipboard content"
+msgstr "Zawartość schowka"
+
+#. Translators: Description for the [clipboard_image] variable in the
+#. Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:807
+msgid "Image currently in clipboard"
+msgstr "Obraz obecnie w schowku"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:807 addon\globalPlugins\visionAssistant\vision_config.py:808 addon\globalPlugins\visionAssistant\vision_config.py:809 addon\globalPlugins\visionAssistant\vision_config.py:810
+msgid "Image"
+msgstr "Obraz"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:808
+msgid "Screenshot of the navigator object"
+msgstr "Zrzut ekranu obiektu nawigatora"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:809
+msgid "Screenshot of the entire screen"
+msgstr "Zrzut całego ekranu"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:810
+msgid "Screenshot of the active foreground window"
+msgstr "Zrzut ekranu aktywnego okna pierwszoplanowego"
+
+#. Translators: Description and input type for the [file_ocr] variable in the
+#. Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:812
+msgid "Select image/PDF/TIFF for text extraction"
+msgstr "Wybierz obraz/PDF/TIFF do wyodrębnienia tekstu"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:812
+msgid "Image, PDF, TIFF"
+msgstr "Obraz, PDF, TIFF"
+
+#. Translators: Description and input type for the [file_read] variable in the
+#. Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:814
+msgid "Select document for reading"
+msgstr "Wybierz dokument do odczytu"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:814
+msgid "TXT, Code, PDF"
+msgstr "TXT, kod, PDF"
+
+#. Translators: Description and input type for the [file_audio] variable in
+#. the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:816
+msgid "Select audio file for analysis"
+msgstr "Wybierz plik audio do analizy"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:816
+msgid "MP3, WAV, OGG"
+msgstr "MP3, WAV, OGG"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:817
+msgid "Current target language"
+msgstr "Bieżący język docelowy"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:818
+msgid "Current source language"
+msgstr "Bieżący język źródłowy"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:819
+msgid "Current AI response language"
+msgstr "Bieżący język odpowiedzi AI"
+
+#: addon\globalPlugins\visionAssistant\vision_config.py:820
+msgid "Fallback language for translation"
+msgstr "Język zapasowy tłumaczenia"
+
+#. Translators: Description for the {swap_instruction} variable in the
+#. Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:822
+msgid "Smart swap translation instruction"
+msgstr "Instrukcja tłumaczenia dla zamiany"
+
+#. Translators: Error message shown when uploading a video file fails.
+#: addon\globalPlugins\visionAssistant\__init__.py:105 addon\globalPlugins\visionAssistant\__init__.py:224 addon\globalPlugins\visionAssistant\__init__.py:396 addon\globalPlugins\visionAssistant\__init__.py:967 addon\globalPlugins\visionAssistant\__init__.py:980 addon\globalPlugins\visionAssistant\__init__.py:1073
+#: addon\globalPlugins\visionAssistant\__init__.py:1089 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:185 addon\globalPlugins\visionAssistant\dialogs\document.py:147 addon\globalPlugins\visionAssistant\dialogs\document.py:203 addon\globalPlugins\visionAssistant\dialogs\document.py:241
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:358 addon\globalPlugins\visionAssistant\dialogs\document.py:465 addon\globalPlugins\visionAssistant\dialogs\document.py:775 addon\globalPlugins\visionAssistant\dialogs\document.py:854 addon\globalPlugins\visionAssistant\dialogs\document.py:932
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:949 addon\globalPlugins\visionAssistant\dialogs\document.py:963 addon\globalPlugins\visionAssistant\dialogs\document.py:969 addon\globalPlugins\visionAssistant\dialogs\media.py:1599 addon\globalPlugins\visionAssistant\features\audio.py:139
+#: addon\globalPlugins\visionAssistant\features\audio.py:251 addon\globalPlugins\visionAssistant\features\audio.py:367 addon\globalPlugins\visionAssistant\features\audio.py:659 addon\globalPlugins\visionAssistant\features\operator_captcha.py:274 addon\globalPlugins\visionAssistant\features\operator_captcha.py:488
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:512 addon\globalPlugins\visionAssistant\features\operator_captcha.py:584 addon\globalPlugins\visionAssistant\features\operator_captcha.py:646 addon\globalPlugins\visionAssistant\features\operator_captcha.py:719
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:839 addon\globalPlugins\visionAssistant\features\video.py:395 addon\globalPlugins\visionAssistant\features\video.py:411 addon\globalPlugins\visionAssistant\features\video.py:419 addon\globalPlugins\visionAssistant\features\video.py:637
+#: addon\globalPlugins\visionAssistant\features\video.py:642 addon\globalPlugins\visionAssistant\features\video.py:650 addon\globalPlugins\visionAssistant\features\video.py:657 addon\globalPlugins\visionAssistant\features\video.py:778 addon\globalPlugins\visionAssistant\features\video.py:802
+#: addon\globalPlugins\visionAssistant\features\vision.py:819 addon\globalPlugins\visionAssistant\features\vision.py:926 addon\globalPlugins\visionAssistant\features\vision.py:1048 addon\globalPlugins\visionAssistant\features\vision.py:1073 addon\globalPlugins\visionAssistant\features\vision.py:1076
+#: addon\globalPlugins\visionAssistant\features\vision.py:1094 addon\globalPlugins\visionAssistant\features\vision.py:1233 addon\globalPlugins\visionAssistant\features\vision.py:1236 addon\globalPlugins\visionAssistant\features\vision.py:1263 addon\globalPlugins\visionAssistant\features\vision.py:1274
+#: addon\globalPlugins\visionAssistant\features\vision.py:1278 addon\globalPlugins\visionAssistant\features\vision.py:1295 addon\globalPlugins\visionAssistant\features\vision.py:1298 addon\globalPlugins\visionAssistant\features\vision.py:1302 addon\globalPlugins\visionAssistant\utils\media_capture.py:205
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:213
+msgid "Idle"
+msgstr "Bezczynny"
+
+#. Translators: Menu item for Document Reader
+#: addon\globalPlugins\visionAssistant\__init__.py:128
+msgid "&Document Reader..."
+msgstr "&Czytnik dokumentów..."
+
+#. Translators: Menu item for media transcription and dubbing
+#: addon\globalPlugins\visionAssistant\__init__.py:132
+msgid "Media Transcription and &Dubbing..."
+msgstr "Transkrypcja i &dubbing mediów..."
+
+#. Translators: Menu item for Video Analysis
+#: addon\globalPlugins\visionAssistant\__init__.py:136
+msgid "Analyze &Video..."
+msgstr "Analizuj &wideo..."
+
+#. Translators: Menu item to open settings
+#: addon\globalPlugins\visionAssistant\__init__.py:142
+msgid "&Settings..."
+msgstr "&Ustawienia..."
+
+#. Translators: Menu item to check for updates
+#: addon\globalPlugins\visionAssistant\__init__.py:146
+msgid "Check for &Update"
+msgstr "Sprawdź &aktualizację"
+
+#. Translators: Menu item to open documentation
+#: addon\globalPlugins\visionAssistant\__init__.py:150
+msgid "Docu&mentation"
+msgstr "Doku&mentacja"
+
+#. Translators: Menu item for donations
+#: addon\globalPlugins\visionAssistant\__init__.py:154
+msgid "D&onate"
+msgstr "W&esprzyj"
+
+#. Translators: Menu item to open the Telegram channel
+#: addon\globalPlugins\visionAssistant\__init__.py:158
+msgid "Telegram &Channel"
+msgstr "Kanał w &Telegramie"
+
+#. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
+#: addon\globalPlugins\visionAssistant\__init__.py:163
+msgid "Vision Assistant"
+msgstr "Vision Assistant"
+
+#. Translators: Announcement when an in-progress OCR extraction is stopped by
+#. the user.
+#: addon\globalPlugins\visionAssistant\__init__.py:226 addon\globalPlugins\visionAssistant\features\vision.py:1050
+msgid "OCR operation stopped."
+msgstr "Zatrzymano operację OCR."
+
+#. Translators: Title of the dialog asking whether to resume an OCR operation
+#. Translators: Title of the dialog asking whether to resume an OCR operation
+#. that did not finish (for example after NVDA closed unexpectedly).
+#: addon\globalPlugins\visionAssistant\__init__.py:240 addon\globalPlugins\visionAssistant\features\vision.py:157
+msgid "Unfinished Operation"
+msgstr "Niedokończona operacja"
+
+#. Translators: Message asking whether to continue an interrupted OCR
+#. extraction.
+#. Translators: Message asking whether to continue an interrupted OCR
+#. extraction. {done} is the number of pages already processed, {total} is the
+#. total number of pages, and {files} is the number of files involved.
+#: addon\globalPlugins\visionAssistant\__init__.py:242 addon\globalPlugins\visionAssistant\features\vision.py:159
+#, python-brace-format
+msgid "You have an unfinished operation: {done} of {total} pages processed across {files} file(s). Would you like to continue from where it stopped?"
+msgstr "Masz niedokończoną operację: przetworzono stron {done} z {total} w plikach: {files}. Kontynuować od miejsca zatrzymania?"
+
+#. Translators: File dialog filter for supported files
+#: addon\globalPlugins\visionAssistant\__init__.py:267 addon\globalPlugins\visionAssistant\features\vision.py:367
+msgid "Supported Files"
+msgstr "Obsługiwane pliki"
+
+#. Translators: Error when PyMuPDF is missing
+#: addon\globalPlugins\visionAssistant\__init__.py:275 addon\globalPlugins\visionAssistant\features\vision.py:663 addon\globalPlugins\visionAssistant\features\vision.py:939
+msgid "PyMuPDF library is missing."
+msgstr "Brak biblioteki PyMuPDF."
+
+#. Translators: Message shown when a PDF has no text layer.
+#: addon\globalPlugins\visionAssistant\__init__.py:284 addon\globalPlugins\visionAssistant\dialogs\document.py:554 addon\globalPlugins\visionAssistant\features\vision.py:651 addon\globalPlugins\visionAssistant\features\vision.py:741 addon\globalPlugins\visionAssistant\features\vision.py:947
+msgid "The 'None (Extract Text Layer)' engine cannot process image-based content. Please change the OCR Engine to 'Chrome' or 'AI (Advanced)' in settings."
+msgstr "Silnik „Wyodrębnij tekst (offline)” nie obsługuje treści graficznych. Zmień silnik OCR na „Chrome” albo „AI (Advanced)” w ustawieniach."
+
+#. Translators: Title of the error dialog shown when the selected OCR engine
+#. cannot process the chosen image-based files.
+#: addon\globalPlugins\visionAssistant\__init__.py:286 addon\globalPlugins\visionAssistant\features\vision.py:653 addon\globalPlugins\visionAssistant\features\vision.py:948
+msgid "OCR Engine Error"
+msgstr "Błąd silnika OCR"
+
+#. Translators: Error when no pages found
+#: addon\globalPlugins\visionAssistant\__init__.py:293 addon\globalPlugins\visionAssistant\features\vision.py:669 addon\globalPlugins\visionAssistant\features\vision.py:954
+msgid "No readable pages found."
+msgstr "Nie znaleziono stron do odczytu."
+
+#. Translators: Script description for 'Shows a list of available commands in
+#. the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:344 addon\globalPlugins\visionAssistant\__init__.py:380
+msgid "Shows a list of available commands in the layer."
+msgstr "Wyświetla listę dostępnych poleceń w warstwie."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:348 addon\globalPlugins\visionAssistant\features\operator_captcha.py:135
+msgid "Asks the AI Operator to perform an action or describe the screen."
+msgstr "Aktywuje okno operatora ai."
+
+#. Translators: Script description for 'Shows a list of available commands in
+#. the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:349 addon\globalPlugins\visionAssistant\features\operator_captcha.py:40
+msgid "Toggles the interactive UI elements explorer."
+msgstr "Przełącza interaktywny eksplorator elementów interfejsu."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:350 addon\globalPlugins\visionAssistant\features\vision.py:1428
+msgid "Translates the selected text or navigator object."
+msgstr "Tłumaczy zaznaczony tekst lub obiekt nawigatora."
+
+#. Translators: Script description for 'Shows a list of available commands in
+#. the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:351 addon\globalPlugins\visionAssistant\features\vision.py:1411
+msgid "Translates the text currently in the clipboard."
+msgstr "Tłumaczy tekst znajdujący się w schowku."
+
+#. Translators: Script description for 'Shows a list of available commands in
+#. the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:352 addon\globalPlugins\visionAssistant\features\audio.py:143
+msgid "Records voice, transcribes and translates it using AI, and types the result."
+msgstr "Nagrywa mowę, transkrybuje ją i tłumaczy przy użyciu AI, a wynik wpisuje jako tekst."
+
+#. Translators: Script description for 'Opens a menu to Explain, Summarize, or
+#. Fix the selected text.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:354 addon\globalPlugins\visionAssistant\features\vision.py:1356
+msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
+msgstr "Otwiera menu do wyjaśniania, podsumowywania lub poprawiania zaznaczonego tekstu."
+
+#. Translators: Script description for 'Performs OCR and description on the
+#. entire screen.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:356 addon\globalPlugins\visionAssistant\features\vision.py:1342
+msgid "Performs OCR and description on the entire screen."
+msgstr "Wykonuje OCR i opis całego ekranu."
+
+#. Translators: Script description for 'Describes the current object
+#. (Navigator Object).' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:358 addon\globalPlugins\visionAssistant\features\vision.py:1334
+msgid "Describes the current object (Navigator Object)."
+msgstr "Opisuje bieżący obiekt nawigatora."
+
+#. Translators: Script description for 'Opens the Document Reader for detailed
+#. page-by-page analysis (PDF/Images).' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:360 addon\globalPlugins\visionAssistant\features\vision.py:1305
+msgid "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
+msgstr "Otwiera czytnik dokumentów do szczegółowej analizy strona po stronie (PDF/obrazy)."
+
+#. Translators: Script description for 'Performs smart actions (OCR or
+#. Description) on a selected image or PDF file.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:362 addon\globalPlugins\visionAssistant\features\vision.py:1385
+msgid "Performs smart actions (OCR or Description) on a selected image or PDF file."
+msgstr "Wykonuje inteligentne akcje (OCR lub opis) na wybranym pliku obrazu lub PDF."
+
+#. Translators: Script description for 'Transcribes or dubs a selected media
+#. file.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:364 addon\globalPlugins\visionAssistant\features\audio.py:266
+msgid "Transcribes or dubs a selected media file."
+msgstr "Transkrybuje lub dubbinguje wybrany plik multimedialny."
+
+#. Translators: Script description for 'Analyzes a local video file or an
+#. online video URL.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:366 addon\globalPlugins\visionAssistant\features\video.py:45
+msgid "Analyzes a local video file or an online video URL."
+msgstr "Analizuje lokalny plik wideo lub adres URL wideo online."
+
+#. Translators: Script description for 'Starts or stops local video recording
+#. of the screen.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:368 addon\globalPlugins\visionAssistant\features\video.py:659
+msgid "Starts or stops local video recording of the screen."
+msgstr "Rozpoczyna lub zatrzymuje lokalne nagrywanie ekranu."
+
+#. Translators: Script description for 'Attempts to solve a CAPTCHA on the
+#. screen or navigator object.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:370 addon\globalPlugins\visionAssistant\features\operator_captcha.py:651
+msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
+msgstr "Próbuje rozwiązać CAPTCHA na ekranie lub w obiekcie nawigatora."
+
+#. Translators: Script description for 'Opens a chat dialog to directly prompt
+#. the AI with text or files.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:371 addon\globalPlugins\visionAssistant\__init__.py:844 addon\globalPlugins\visionAssistant\features\vision.py:1350
+msgid "Opens a chat dialog to directly prompt the AI with text or files."
+msgstr "Otwiera okno rozmowy, w którym można zadać AI pytanie tekstem lub przekazać pliki."
+
+#. Translators: Script description for 'Records voice, transcribes it using
+#. AI, and types the result.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:373 addon\globalPlugins\visionAssistant\features\audio.py:40
+msgid "Records voice, transcribes it using AI, and types the result."
+msgstr "Nagrywa głos, transkrybuje go przy użyciu AI i wpisuje wynik."
+
+#: addon\globalPlugins\visionAssistant\__init__.py:374 addon\globalPlugins\visionAssistant\__init__.py:393
+msgid "Announces the current status of the add-on."
+msgstr "Odczytuje bieżący stan dodatku."
+
+#. Translators: Script description for 'Labels the current navigator object
+#. using AI.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:375 addon\globalPlugins\visionAssistant\__init__.py:929 addon\globalPlugins\visionAssistant\features\operator_captcha.py:447
+msgid "Labels the current navigator object using AI."
+msgstr "Nadaje etykietę bieżącemu obiektowi nawigatora za pomocą AI."
+
+#. Translators: Script description for 'Manages existing labels or scans the
+#. entire app to label unnamed elements.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:376 addon\globalPlugins\visionAssistant\__init__.py:1002 addon\globalPlugins\visionAssistant\features\operator_captcha.py:517
+msgid "Manages existing labels or scans the entire app to label unnamed elements."
+msgstr "Zarządza istniejącymi etykietami lub skanuje całą aplikację w poszukiwaniu elementów bez nich."
+
+#. Translators: Script description for 'Checks for updates manually.' in Input
+#. Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:377 addon\globalPlugins\visionAssistant\__init__.py:418
+msgid "Checks for updates manually."
+msgstr "Ręcznie sprawdza dostępność aktualizacji."
+
+#. Translators: Script description for 'Shows the last AI response in a chat
+#. dialog for review or follow-up questions.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:379 addon\globalPlugins\visionAssistant\__init__.py:849 addon\globalPlugins\visionAssistant\features\vision.py:1370
+msgid "Shows the last AI response in a chat dialog for review or follow-up questions."
+msgstr "Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub zadawania dodatkowych pytań."
+
+#. Translators: Script description for 'Starts or ends a live voice
+#. conversation with the AI assistant.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:382 addon\globalPlugins\visionAssistant\__init__.py:400
+msgid "Starts or ends a live voice conversation with the AI assistant."
+msgstr "Rozpoczyna lub kończy rozmowę głosową z asystentem AI."
+
+#. Translators: Script description for 'Opens the Vision Assistant settings
+#. dialog.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:384 addon\globalPlugins\visionAssistant\__init__.py:412
+msgid "Opens the Vision Assistant settings dialog."
+msgstr "Otwiera okno ustawień Vision Assistant."
+
+#. Translators: Script description for 'Reports the number of Gemini API keys
+#. that have exceeded their daily quota and their reset time.' in Input
+#. Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:386 addon\globalPlugins\visionAssistant\__init__.py:426 addon\globalPlugins\visionAssistant\features\quick_settings.py:159
+msgid "Reports the number of Gemini API keys that have exceeded their daily quota and their reset time."
+msgstr "Podaje liczbę kluczy API Gemini, które przekroczyły dzienny limit i czas ich zresetowania."
+
+#. Translators: Script description for 'Reports the AI models selected in
+#. advanced routing.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:388 addon\globalPlugins\visionAssistant\__init__.py:493 addon\globalPlugins\visionAssistant\features\quick_settings.py:225
+msgid "Reports the AI models selected in advanced routing."
+msgstr "Podaje modele AI wybrane w osobnym modelu dla każdego zadania."
+
+#. Translators: Title of the help dialog
+#: addon\globalPlugins\visionAssistant\__init__.py:391
+#, python-brace-format
+msgid "{name} Help"
+msgstr "Pomoc {name}"
+
+#. Translators: Error shown when the Live Assistant is used with a non-Gemini
+#. provider.
+#: addon\globalPlugins\visionAssistant\__init__.py:408
+msgid "The Live Assistant is only supported with the Gemini provider (or a Custom provider with API type set to Gemini)."
+msgstr "Asystent głosowy działa tylko z dostawcą Gemini (lub niestandardowym dostawcą z typem API ustawionym na Gemini)."
+
+#. Translators: Message reported when calling the update command
+#: addon\globalPlugins\visionAssistant\__init__.py:422
+msgid "Checking for updates..."
+msgstr "Sprawdzanie aktualizacji..."
+
+#. Translators: Message shown when a user tries to check Gemini API quotas but
+#. another provider is active.
+#: addon\globalPlugins\visionAssistant\__init__.py:431 addon\globalPlugins\visionAssistant\features\quick_settings.py:164
+msgid "This feature is only available for Google Gemini."
+msgstr "Ta funkcja jest dostępna tylko dla Google Gemini."
+
+#. Translators: Message when no API keys are out of quota
+#: addon\globalPlugins\visionAssistant\__init__.py:459 addon\globalPlugins\visionAssistant\features\quick_settings.py:192
+msgid "No API keys have exceeded their daily quota."
+msgstr "Żaden klucz API nie przekroczył dziennego limitu."
+
+#. Translators: Prefix for time when the daily quota resets on the next day
+#: addon\globalPlugins\visionAssistant\__init__.py:472 addon\globalPlugins\visionAssistant\features\quick_settings.py:204
+#, python-brace-format
+msgid "tomorrow at {time}"
+msgstr "jutro o {time}"
+
+#. Translators: Shows detailed information for a banned API key. {key} is the
+#. API key, {model} is the model name, {time_str} is the reset time.
+#: addon\globalPlugins\visionAssistant\__init__.py:474 addon\globalPlugins\visionAssistant\features\quick_settings.py:206
+#, python-brace-format
+msgid ""
+"Key: {key}\n"
+"Model: {model}\n"
+"Resets around: {time_str}\n"
+msgstr ""
+"Klucz: {key}\n"
+"Model: {model}\n"
+"Odnowienie około: {time_str}\n"
+
+#. Translators: Shows how many API keys have exceeded their quota for a
+#. specific model. {count} is the number of keys, {model} is the model name.
+#: addon\globalPlugins\visionAssistant\__init__.py:485 addon\globalPlugins\visionAssistant\features\quick_settings.py:216
+#, python-brace-format
+msgid "{count} keys for model {model}"
+msgstr "Kluczy dla modelu {model}: {count}"
+
+#. Translators: Message shown when API keys run out of quota.
+#: addon\globalPlugins\visionAssistant\__init__.py:488 addon\globalPlugins\visionAssistant\features\quick_settings.py:219
+msgid "have exceeded their daily quota."
+msgstr "przekroczyło dzienny limit."
+
+#. Translators: Title of the browseable message dialog showing exhausted API
+#. keys
+#: addon\globalPlugins\visionAssistant\__init__.py:491 addon\globalPlugins\visionAssistant\features\quick_settings.py:222
+msgid "Exhausted API Keys"
+msgstr "Wyczerpane klucze API"
+
+#. Translators: Prefix for main model status
+#: addon\globalPlugins\visionAssistant\__init__.py:504 addon\globalPlugins\visionAssistant\features\quick_settings.py:235
+#, python-brace-format
+msgid "Main: {model}"
+msgstr "Główny: {model}"
+
+#. Translators: Abbreviation for Speech-to-Text.
+#: addon\globalPlugins\visionAssistant\__init__.py:513 addon\globalPlugins\visionAssistant\features\quick_settings.py:243
+msgid "STT"
+msgstr "STT"
+
+#. Translators: Abbreviation for Text-to-Speech.
+#: addon\globalPlugins\visionAssistant\__init__.py:515 addon\globalPlugins\visionAssistant\features\quick_settings.py:245
+msgid "TTS"
+msgstr "TTS"
+
+#. Translators: Labels for the AI and User in chat history
+#: addon\globalPlugins\visionAssistant\__init__.py:517 addon\globalPlugins\visionAssistant\features\operator_captcha.py:312 addon\globalPlugins\visionAssistant\features\quick_settings.py:247
+msgid "Operator"
+msgstr "Operator"
+
+#. Translators: Message when no specific AI models are selected in advanced
+#. routing
+#: addon\globalPlugins\visionAssistant\__init__.py:523 addon\globalPlugins\visionAssistant\features\quick_settings.py:252
+msgid "No specific models selected."
+msgstr "Nie wybrano konkretnych modeli."
+
+#. Translators: Line appended to the conversation when the live session has
+#. ended.
+#: addon\globalPlugins\visionAssistant\__init__.py:602 addon\globalPlugins\visionAssistant\features\vision.py:123
+msgid "--- Session ended ---"
+msgstr "--- Sesja zakończona ---"
+
+#. Translators: Message announced by NVDA when the live voice conversation
+#. ends.
+#: addon\globalPlugins\visionAssistant\__init__.py:608 addon\globalPlugins\visionAssistant\features\vision.py:128
+msgid "Live conversation ended."
+msgstr "Rozmowa głosowa zakończona."
+
+#. Translators: Message announced by NVDA when the live voice conversation
+#. ends.
+#: addon\globalPlugins\visionAssistant\__init__.py:611 addon\globalPlugins\visionAssistant\features\screen_capture.py:203 addon\globalPlugins\visionAssistant\features\vision.py:96 addon\globalPlugins\visionAssistant\features\vision.py:426
+msgid "Open"
+msgstr "Otwórz"
+
+#. Translators: Message of a dialog which may pop up while performing an AI
+#. call
+#: addon\globalPlugins\visionAssistant\__init__.py:658 addon\globalPlugins\visionAssistant\features\upload.py:68
+#, python-brace-format
+msgid "File Upload Error: {error}"
+msgstr "Błąd przesyłania pliku: {error}"
+
+#. Translators: Script description for 'Activates the Command Layer for quick
+#. access to all features.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:733
+msgid "Activates the Command Layer for quick access to all features."
+msgstr "Aktywuje warstwę poleceń umożliwiającą szybki dostęp do wszystkich funkcji."
+
+#. Translators: Error when all available API keys fail
+#: addon\globalPlugins\visionAssistant\__init__.py:823 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:550 addon\globalPlugins\visionAssistant\features\vision.py:272
+msgid "All API Keys failed (Quota/Server)."
+msgstr "Wszystkie klucze API zawiodły (limit/serwer)."
+
+#. Translators: Initial greeting message for the Direct Chat dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:826 addon\globalPlugins\visionAssistant\features\vision.py:276
+msgid "Hello! I am Vision Assistant Pro. How can I help you today?"
+msgstr "Witaj! Tu Vision Assistant Pro. W czym mogę pomóc?"
+
+#. Translators: Dialog title for Direct Chat
+#: addon\globalPlugins\visionAssistant\__init__.py:831 addon\globalPlugins\visionAssistant\features\vision.py:281
+#, python-brace-format
+msgid "{name} - Direct Chat"
+msgstr "{name} — czat"
+
+#. Translators: Message shown when a user tries to use AI labeling in a web
+#. browser.
+#: addon\globalPlugins\visionAssistant\__init__.py:941 addon\globalPlugins\visionAssistant\__init__.py:1008 addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:268 addon\globalPlugins\visionAssistant\features\operator_captcha.py:457 addon\globalPlugins\visionAssistant\features\operator_captcha.py:524
+msgid "AI Labeling is currently not supported in web browsers."
+msgstr "Etykietowanie AI nie jest obecnie obsługiwane w przeglądarkach internetowych."
+
+#. Translators: Message spoken by NVDA when the current object already has a
+#. custom or AI-generated label. {name} is replaced with the existing label
+#. text.
+#: addon\globalPlugins\visionAssistant\__init__.py:956 addon\globalPlugins\visionAssistant\features\operator_captcha.py:476
+#, python-brace-format
+msgid "Already labeled as: {name}"
+msgstr "Już oznaczono jako: {name}"
+
+#. Translators: Progress message spoken when the add-on starts taking a
+#. screenshot of the current focused object.
+#: addon\globalPlugins\visionAssistant\__init__.py:961 addon\globalPlugins\visionAssistant\features\operator_captcha.py:481
+msgid "Identifying object..."
+msgstr "Rozpoznawanie obiektu..."
+
+#. Translators: Progress message spoken when the add-on starts taking a
+#. screenshot of the current focused object.
+#: addon\globalPlugins\visionAssistant\__init__.py:969 addon\globalPlugins\visionAssistant\features\audio.py:355 addon\globalPlugins\visionAssistant\features\operator_captcha.py:490 addon\globalPlugins\visionAssistant\features\vision.py:1226
+msgid "Analyzing..."
+msgstr "Analizowanie..."
+
+#. Translators: Success message spoken when the AI successfully assigns a new
+#. label to the object. {name} is replaced with the AI-generated label.
+#: addon\globalPlugins\visionAssistant\__init__.py:993 addon\globalPlugins\visionAssistant\features\operator_captcha.py:508
+#, python-brace-format
+msgid "Labeled as: {name}"
+msgstr "Etykieta jako: {name}"
+
+#. Translators: Confirmation message shown after labels are deleted or
+#. renamed.
+#: addon\globalPlugins\visionAssistant\__init__.py:1027 addon\globalPlugins\visionAssistant\features\operator_captcha.py:544
+msgid "Labels updated."
+msgstr "Etykiety zaktualizowane."
+
+#. Translators: Progress message spoken when the add-on begins scanning the
+#. current application window to find UI elements (like buttons or icons) that
+#. do not have accessibility names.
+#: addon\globalPlugins\visionAssistant\__init__.py:1046 addon\globalPlugins\visionAssistant\features\operator_captcha.py:561
+msgid "Scanning application UI..."
+msgstr "Skanowanie interfejsu aplikacji..."
+
+#. Translators: Message spoken when the add-on finishes the UI scan but finds
+#. no unnamed elements to label (everything already has a name).
+#: addon\globalPlugins\visionAssistant\__init__.py:1075 addon\globalPlugins\visionAssistant\features\operator_captcha.py:586
+msgid "No unnamed elements found."
+msgstr "Nie ma niezaetykietowanych elementów."
+
+#. Translators: Progress message spoken when the add-on has found unnamed
+#. elements and is now sending the full application screenshot to AI for batch
+#. labeling.
+#: addon\globalPlugins\visionAssistant\__init__.py:1079 addon\globalPlugins\visionAssistant\features\operator_captcha.py:590
+msgid "Analyzing application..."
+msgstr "Analizowanie aplikacji..."
+
+#. Translators: Success message spoken when the AI finishes analyzing the app
+#. and successfully names multiple elements in the background.
+#: addon\globalPlugins\visionAssistant\__init__.py:1143 addon\globalPlugins\visionAssistant\features\operator_captcha.py:638
+msgid "Application labeling complete."
+msgstr "Etykietowanie aplikacji zakończone."
+
+#. Translators: Error message spoken when the add-on fails to parse or map the
+#. labels returned by the AI (e.g., due to invalid AI response format).
+#: addon\globalPlugins\visionAssistant\__init__.py:1148 addon\globalPlugins\visionAssistant\features\operator_captcha.py:643
+msgid "Batch labeling failed."
+msgstr "Zbiorcze etykietowanie nie powiodło się."
+
+#. Translators: Error message when TTS is not supported by the provider
+#: addon\globalPlugins\visionAssistant\ai\core.py:315
+msgid "TTS is not supported by this provider."
+msgstr "Ten dostawca nie obsługuje syntezy mowy."
+
+#. Translators: Status message showing the file upload progress percentage.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:150
+#, python-brace-format
+msgid "Uploading: {percent}%"
+msgstr "Wysyłanie: {percent}%"
+
+#. Translators: Note appended to the API error message when the daily
+#. RequestsPerDay quota limit is reached.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:286
+msgid " (RequestsPerDay quota exceeded)"
+msgstr " (przekroczono limit RequestsPerDay)"
+
+#. Translators: Error message for Bad Request (400)
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:295
+msgid "Error 400: Bad Request (Check API Key)"
+msgstr "Błąd 400: nieprawidłowe żądanie (sprawdź klucz API)"
+
+#. Translators: Error message for Forbidden (403)
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:297
+msgid "Error 403: Forbidden (Check Region)"
+msgstr "Błąd 403: dostęp zabroniony (sprawdź region)"
+
+#. Translators: Message of a dialog which may pop up while performing an AI
+#. call
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:391
+msgid "Error 429: Quota Exceeded (Try later)"
+msgstr "Błąd 429: przekroczono limit (spróbuj później)"
+
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:393 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:546
+#, python-brace-format
+msgid "Server Error {code}: {reason}"
+msgstr "Błąd serwera {code}: {reason}"
+
+#. Translators: Error prefix shown when the AI response is blocked by safety
+#. filters.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:485 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:499 addon\globalPlugins\visionAssistant\ai\providers\openai.py:144
+msgid "Blocked by AI Safety Filters: "
+msgstr "Zablokowane przez filtry bezpieczeństwa AI: "
+
+#. Translators: Error shown when the AI response is blocked during generation.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:488 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:507
+msgid "The response was blocked mid-generation by safety filters."
+msgstr "Filtry bezpieczeństwa zablokowały odpowiedź w trakcie generowania."
+
+#. Translators: Generic error message when Gemini returns an empty response.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:490 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:500
+msgid "AI failed to provide a response. This might be due to safety filters or a temporary server issue."
+msgstr "AI nie zwróciła odpowiedzi. Powodem mogą być filtry bezpieczeństwa lub chwilowy problem serwera."
+
+#. Translators: Error shown when the response structure is unexpected or
+#. empty.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:509
+msgid "AI returned an empty response structure."
+msgstr "AI zwróciła pustą strukturę odpowiedzi."
+
+#. Translators: Error when no API keys are found in settings
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:518 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:781
+msgid "No valid API key available or daily quota exhausted for all keys."
+msgstr "Brak ważnego klucza API lub wyczerpany dzienny limit dla wszystkich kluczy."
+
+#. Translators: Generic error message when an operation fails for an unknown
+#. reason.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:558
+msgid "Unknown error occurred."
+msgstr "Wystąpił nieznany błąd."
+
+#. Translators: Error message for missing API Keys
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:614
+msgid "No API Keys."
+msgstr "Brak kluczy API."
+
+#. Translators: Message reported when an upload fails and the system
+#. automatically switches to the next available API key.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:664
+msgid "Upload failed. Rotating key..."
+msgstr "Wysyłanie nie powiodło się. Zmiana klucza..."
+
+#. Translators: Error message for upload failure
+#. Translators: Error message shown when uploading a video file fails.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:669 addon\globalPlugins\visionAssistant\ai\providers\mistral.py:172 addon\globalPlugins\visionAssistant\dialogs\document.py:99 addon\globalPlugins\visionAssistant\dialogs\document.py:109 addon\globalPlugins\visionAssistant\features\video.py:418
+msgid "Upload failed."
+msgstr "Przesyłanie nie powiodło się."
+
+#. Translators: Message shown when an API rate limit is reached. {sec} is the
+#. number of seconds to wait.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:705 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:963
+#, python-brace-format
+msgid "Rate limit reached. Waiting {sec}s before retry..."
+msgstr "Osiągnięto limit zapytań. Czekam {sec}s przed ponowną próbą..."
+
+#. Translators: Status message indicating an API request retry due to a
+#. temporary error for specific pages. {error} is replaced with details,
+#. {range} is the page range, {current} and {total} are attempts.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:717
+#, python-brace-format
+msgid "Temporary error ({error}). Retrying API request for pages {range} (Attempt {current}/{total})..."
+msgstr "Błąd tymczasowy ({error}). Ponawianie zapytania API dla stron {range} (próba {current}/{total})..."
+
+#. Translators: Status message indicating an API request retry due to a
+#. temporary error. {error} is replaced with details, {current} and {total}
+#. are attempts.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:719 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:971
+#, python-brace-format
+msgid "Temporary error ({error}). Retrying on current key (Attempt {current}/{total})..."
+msgstr "Błąd tymczasowy ({error}). Ponawianie na bieżącym kluczu (próba {current}/{total})..."
+
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:728 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:742
+msgid "All keys failed."
+msgstr "Wszystkie klucze zawiodły."
+
+#. Translators: Message reported when API quota is exhausted and the system
+#. rotates key.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:738 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:985
+msgid "Daily quota exhausted or retries failed. Rotating key and re-uploading..."
+msgstr "Wyczerpany dzienny limit lub nieudane ponowne próby. Zmiana klucza i ponowne wysyłanie..."
+
+#. Translators: Status message indicating video upload progress with file size
+#. in MB.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:870
+#, python-brace-format
+msgid "Uploading to AI ({size:.1f} MB)..."
+msgstr "Wysyłanie do AI ({size:.1f} MB)..."
+
+#. Translators: Status message indicating video upload progress with file size
+#. in MB and retry attempt numbers.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:903
+#, python-brace-format
+msgid "Uploading to AI ({size:.1f} MB) (Key {current}/{total})..."
+msgstr "Wysyłanie do AI ({size:.1f} MB) (klucz {current}/{total})..."
+
+#. Translators: Message reported when a file upload fails and the system is
+#. retrying.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:909
+msgid "Upload failed. Retrying..."
+msgstr "Wysyłanie nie powiodło się. Ponawianie..."
+
+#. Translators: Error shown internally when AI stops early
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:940
+msgid "Incomplete description. AI stopped early."
+msgstr "Niepełny opis. AI zatrzymała się przedwcześnie."
+
+#. Translators: Message reported when all available API keys have reached
+#. their usage limits.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:989
+msgid "All API keys exhausted or server unavailable."
+msgstr "Wszystkie klucze API wyczerpane lub serwer niedostępny."
+
+#. Translators: Error message shown when all API keys run out of quota or
+#. fail.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:999
+msgid "All API keys failed or daily quota exhausted."
+msgstr "Wszystkie klucze API zawiodły lub wyczerpano dzienny limit."
+
+#. Translators: Error when no API keys are found in settings
+#. Translators: Error message when TTS is not supported by the provider
+#. Translators: Message box content for successful save
+#. Translators: Error message when TTS is not supported by the provider
+#: addon\globalPlugins\visionAssistant\ai\providers\mistral.py:23 addon\globalPlugins\visionAssistant\ai\providers\mistral.py:118 addon\globalPlugins\visionAssistant\ai\providers\openai.py:26 addon\globalPlugins\visionAssistant\ai\providers\openai.py:199 addon\globalPlugins\visionAssistant\dialogs\document.py:653
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:869 addon\globalPlugins\visionAssistant\dialogs\document.py:977 addon\globalPlugins\visionAssistant\features\audio.py:393 addon\globalPlugins\visionAssistant\utils\media_capture.py:1019
+msgid "No API Keys configured."
+msgstr "Nie skonfigurowano kluczy API."
+
+#. Translators: Error message shown when the AI returns an unknown error
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:146 addon\globalPlugins\visionAssistant\features\operator_captcha.py:229
+msgid "AI Error"
+msgstr "Błąd AI"
+
+#. Translators: Error message when speech-to-text fails.
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:191
+msgid "Transcription Failed"
+msgstr "Transkrypcja nie powiodła się"
+
+#. Translators: Label for the AI response text area in a chat dialog
+#. Translators: Label for Target Language selection
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:36 addon\globalPlugins\visionAssistant\dialogs\settings.py:309
+msgid "AI Response:"
+msgstr "Odpowiedź AI:"
+
+#. Translators: Format for displaying User message in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:53 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:144 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:228
+#, python-brace-format
+msgid ""
+"\n"
+"You: {text}\n"
+msgstr ""
+"\n"
+"Ty: {text}\n"
+
+#. Translators: Format for displaying AI message in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:57 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:63 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:214 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:229
+#, python-brace-format
+msgid "AI: {text}\n"
+msgstr "AI: {text}\n"
+
+#. Translators: Label for user input field in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:77
+msgid "Ask:"
+msgstr "Zapytaj:"
+
+#. Translators: Button to attach files in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:89 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:202
+msgid "&Attach File"
+msgstr "Dołącz &plik"
+
+#. Translators: Button to send message in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:92 addon\globalPlugins\visionAssistant\dialogs\document.py:74
+msgid "Send"
+msgstr "Wyślij"
+
+#. Translators: Button to view the content in a formatted HTML window
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:94 addon\globalPlugins\visionAssistant\dialogs\document.py:404
+msgid "View Formatted"
+msgstr "Podgląd sformatowany"
+
+#. Translators: Button to save only the result content without chat history
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:97
+msgid "Save Content"
+msgstr "Zapisz treść odpowiedzi"
+
+#. Translators: Button to save chat in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:100
+msgid "Save Chat"
+msgstr "Zapisz cały czat"
+
+#. Translators: Button to close chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:102 addon\globalPlugins\visionAssistant\dialogs\document.py:436 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:110
+msgid "Close"
+msgstr "Zamknij"
+
+#. Translators: Message shown while processing in a chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:148 addon\globalPlugins\visionAssistant\dialogs\document.py:136
+msgid "Thinking..."
+msgstr "Przetwarzanie..."
+
+#. Translators: Text appended to the chat window while waiting for the AI to
+#. respond.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:152
+msgid ""
+"\n"
+"Processing...\n"
+msgstr ""
+"\n"
+"Przetwarzanie...\n"
+
+#. Translators: Status when the AI is thinking in chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:160
+msgid "Processing response..."
+msgstr "Przetwarzanie odpowiedzi..."
+
+#. Translators: Title of the file selection dialog when attaching a file to a
+#. chat.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:166
+msgid "Select a file to attach"
+msgstr "Wybierz plik do dołączenia"
+
+#. Translators: Label for attach button when files are attached
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:171
+#, python-brace-format
+msgid "Attach File ({count})"
+msgstr "Dołącz plik ({count})"
+
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:172
+#, python-brace-format
+msgid "File attached: {name}"
+msgstr "Dołączono plik: {name}"
+
+#. Translators: Title of the formatted result window
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:249
+msgid "Formatted Conversation"
+msgstr "Sformatowana rozmowa"
+
+#. Translators: Error message if viewing fails
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:252
+#, python-brace-format
+msgid "Error displaying content: {error}"
+msgstr "Błąd wyświetlania treści: {error}"
+
+#. Translators: Save dialog title
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:257
+msgid "Save Chat Log"
+msgstr "Zapisz dziennik czatu"
+
+#. Translators: Message shown on successful save of a file.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:262 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:274
+msgid "Saved."
+msgstr "Zapisano."
+
+#. Translators: Message in the error dialog when saving fails.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:265 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:276
+#, python-brace-format
+msgid "Save failed: {error}"
+msgstr "Zapisywanie nie powiodło się: {error}"
+
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:269
+msgid "Save Result"
+msgstr "Zapisywanie wyniku"
+
+#. Translators: Title of the chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:50
+msgid "Ask about Document"
+msgstr "Zapytaj o dokument"
+
+#. Translators: Label showing the analyzed file name
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:59
+#, python-brace-format
+msgid "File: {name}"
+msgstr "Plik: {name}"
+
+#. Translators: Status message while uploading
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:64
+msgid "Uploading to AI...\n"
+msgstr "Przesyłanie do AI...\n"
+
+#. Translators: Label for the chat input field
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:68
+msgid "Your Question:"
+msgstr "Twoje pytanie:"
+
+#. Translators: Message shown in the chat area when the file is uploaded and
+#. the AI is ready to answer questions.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:126
+msgid "Ready! Ask your questions.\n"
+msgstr "Gotowe! Zadawaj pytania.\n"
+
+#. Translators: Placeholder text used in document chat when the text is still
+#. being extracted or is empty.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:180
+msgid "[Text extraction in progress or empty]"
+msgstr "[Wyodrębnianie tekstu w toku lub puste]"
+
+#. Translators: Prefix for an AI message line in the Live Assistant history.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:237 addon\globalPlugins\visionAssistant\utils\media_capture.py:1290 addon\globalPlugins\visionAssistant\utils\media_capture.py:1306
+msgid "AI: "
+msgstr "AI: "
+
+#. Translators: Title of the PDF and document options dialog (range,
+#. translation, etc.)
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:246
+msgid "Options"
+msgstr "Opcje"
+
+#. Translators: Label showing total pages found
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:249
+#, python-brace-format
+msgid "Total Pages (All Files): {count}"
+msgstr "Łączna liczba stron (wszystkie pliki): {count}"
+
+#. Translators: Box title for page range selection
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:252
+msgid "Range"
+msgstr "Zakres"
+
+#. Translators: Label for start page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:255
+msgid "From:"
+msgstr "Od:"
+
+#. Translators: Label for end page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:259
+msgid "To:"
+msgstr "Do:"
+
+#. Translators: Checkbox to enable translation
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:267
+msgid "Translate Output"
+msgstr "Przetłumacz wynik"
+
+#. Translators: Checkbox to enable translation
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:270 addon\globalPlugins\visionAssistant\dialogs\media.py:204 addon\globalPlugins\visionAssistant\dialogs\settings.py:304
+msgid "Target:"
+msgstr "Docelowy:"
+
+#. Translators: Label for the checkbox that enables image descriptions during
+#. OCR in the extraction dialog
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:280
+msgid "Describe images inline during OCR"
+msgstr "Wplataj opisy obrazów w tekst podczas OCR"
+
+#. Translators: Button to start processing
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:286 addon\globalPlugins\visionAssistant\dialogs\media.py:214
+msgid "Start"
+msgstr "Rozpocznij"
+
+#. Translators: Button to add a label for the selected element
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:288 addon\globalPlugins\visionAssistant\dialogs\media.py:217 addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:231
+msgid "Cancel"
+msgstr "Anuluj"
+
+#. Translators: Title of settings group for Document Reader features
+#. --- Document Reader Settings ---
+#. Translators: Title of settings group for Document Reader features
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:316 addon\globalPlugins\visionAssistant\dialogs\settings.py:321
+msgid "Document Reader"
+msgstr "Czytnik dokumentów"
+
+#. Translators: Initial status message
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:364 addon\globalPlugins\visionAssistant\dialogs\media.py:415
+msgid "Initializing..."
+msgstr "Inicjowanie..."
+
+#. Translators: Button to go to previous page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:370
+msgid "Previous (Ctrl+PageUp)"
+msgstr "Poprzednia (Ctrl+PageUp)"
+
+#. Translators: Button to go to next page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:374
+msgid "Next (Ctrl+PageDown)"
+msgstr "Następna (Ctrl+PageDown)"
+
+#. Translators: Label for Go To Page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:378
+msgid "Go to:"
+msgstr "Przejdź do:"
+
+#. Translators: Button to Ask questions about the document
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:389
+msgid "Ask AI (Alt+A)"
+msgstr "Zapytaj AI (Alt+A)"
+
+#. Translators: Button to force re-scan
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:394
+msgid "Re-scan with AI (Alt+R)"
+msgstr "Ponowne skanowanie AI (Alt+R)"
+
+#. Translators: Button to generate audio
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:399
+msgid "Generate Audio (Alt+G)"
+msgstr "Generuj audio (Alt+G)"
+
+#. Translators: Button to save text
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:409
+msgid "Save (Alt+S)"
+msgstr "Zapisz (Alt+S)"
+
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:417 addon\globalPlugins\visionAssistant\dialogs\settings.py:349
+msgid "TTS Voice:"
+msgstr "Głos TTS:"
+
+#. Translators: Message reported when extracting text from a file
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:474 addon\globalPlugins\visionAssistant\features\vision.py:750
+msgid "Extracting Text..."
+msgstr "Wyodrębnianie tekstu..."
+
+#. Translators: Status message showing page-by-page progress during file OCR.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:529 addon\globalPlugins\visionAssistant\features\vision.py:721 addon\globalPlugins\visionAssistant\features\vision.py:733 addon\globalPlugins\visionAssistant\features\vision.py:795 addon\globalPlugins\visionAssistant\features\vision.py:811
+#, python-brace-format
+msgid "Processing page {current} of {total}..."
+msgstr "Przetwarzanie strony {current} z {total}..."
+
+#. Translators: Spoken message when the current page is ready
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:537
+#, python-brace-format
+msgid "Page {num} ready"
+msgstr "Strona {num} gotowa"
+
+#. Translators: Placeholder text when OCR fails
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:567
+msgid "[OCR failed. Try a different AI model or provider.]"
+msgstr "[OCR nie powiodło się. Spróbuj innego modelu AI lub dostawcy.]"
+
+#. Translators: Error message for page processing failure
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:585
+msgid "Error processing page."
+msgstr "Błąd przetwarzania strony."
+
+#. Translators: Status label format
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:590
+#, python-brace-format
+msgid "Page {current} of {total}"
+msgstr "Strona {current} z {total}"
+
+#. Translators: Status when page is loading
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:597
+msgid "Processing in background..."
+msgstr "Przetwarzanie w tle..."
+
+#. Translators: Spoken message when switching pages
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:608 addon\globalPlugins\visionAssistant\dialogs\document.py:628 addon\globalPlugins\visionAssistant\dialogs\document.py:1023
+#, python-brace-format
+msgid "Page {num}"
+msgstr "Strona {num}"
+
+#. Translators: Title of the formatted result window
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:644
+msgid "Formatted Content"
+msgstr "Sformatowana treść"
+
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:653 addon\globalPlugins\visionAssistant\dialogs\document.py:863 addon\globalPlugins\visionAssistant\dialogs\document.py:869 addon\globalPlugins\visionAssistant\dialogs\document.py:930 addon\globalPlugins\visionAssistant\dialogs\document.py:971
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:977 addon\globalPlugins\visionAssistant\dialogs\document.py:1041 addon\globalPlugins\visionAssistant\dialogs\settings.py:808 addon\globalPlugins\visionAssistant\dialogs\settings.py:1142
+msgid "Error"
+msgstr "Błąd"
+
+#. Translators: Menu option for current page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:657
+msgid "Current Page"
+msgstr "Bieżąca strona"
+
+#. Translators: Menu option for all pages
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:659
+msgid "All Pages (In Range)"
+msgstr "Wszystkie strony (w zakresie)"
+
+#. Translators: Message during manual scan
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:669
+msgid "Scanning with AI..."
+msgstr "Skanowanie AI..."
+
+#. Translators: Error shown when a specific page scan fails.
+#. Translators: Error shown in the document reader when a page is dropped
+#. because the AI output exceeded its limit during batch processing.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:685 addon\globalPlugins\visionAssistant\dialogs\document.py:767 addon\globalPlugins\visionAssistant\dialogs\document.py:838 addon\globalPlugins\visionAssistant\dialogs\document.py:845
+#, python-brace-format
+msgid "[Scan failed: {err}]"
+msgstr "[Skanowanie nie powiodło się: {err}]"
+
+#. Translators: Message shown when OCR returns no text for a page.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:690
+msgid "[No text detected]"
+msgstr "[Nie wykryto tekstu]"
+
+#. Translators: Message when scan is complete
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:695
+msgid "Scan complete"
+msgstr "Skanowanie zakończone"
+
+#. Translators: Generic system error message inside the document viewer.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:698
+#, python-brace-format
+msgid "[Error: {msg}]"
+msgstr "[Błąd: {msg}]"
+
+#. Translators: Status message for local text extraction
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:711
+msgid "Extracting text layer..."
+msgstr "Wyodrębnianie tekstu..."
+
+#. Translators: Message when batch scan starts
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:718 addon\globalPlugins\visionAssistant\dialogs\document.py:783
+msgid "Batch Processing Started"
+msgstr "Rozpoczęto przetwarzanie wsadowe"
+
+#. Translators: Status message showing the progress of document scanning.
+#. {start} and {end} are page numbers.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:737 addon\globalPlugins\visionAssistant\dialogs\document.py:800 addon\globalPlugins\visionAssistant\features\vision.py:847
+#, python-brace-format
+msgid "Processing pages {start} to {end}..."
+msgstr "Przetwarzanie stron {start} do {end}..."
+
+#. Translators: Success message shown when all batches of the document have
+#. been processed.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:780 addon\globalPlugins\visionAssistant\dialogs\document.py:858
+msgid "All document pages have been processed."
+msgstr "Wszystkie strony dokumentu zostały przetworzone."
+
+#. Translators: Error shown in the document reader when the AI returns an
+#. empty response for a batch of pages.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:823
+msgid "[Error: Empty response received from AI. Try reducing the batch size in settings or scanning page-by-page.]"
+msgstr "[Błąd: otrzymano pustą odpowiedź od AI. Zmniejsz rozmiar wsadu w ustawieniach lub skanuj strona po stronie.]"
+
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:830
+msgid "[Error: Page skipped during batch processing due to model output limits. Try a smaller batch size in settings.]"
+msgstr "[Błąd: pominięto stronę podczas przetwarzania wsadowego z powodu limitów wyjścia modelu. Zmniejsz rozmiar wsadu w ustawieniach.]"
+
+#. Translators: Error message when trying to use TTS with an unsupported
+#. provider
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:863
+msgid "TTS is not supported by the current provider or configuration."
+msgstr "Bieżący dostawca lub konfiguracja nie obsługuje syntezy mowy."
+
+#. Translators: Menu option for TTS current page
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:874
+msgid "Generate for Current Page"
+msgstr "Generuj dla bieżącej strony"
+
+#. Translators: Menu option for TTS all pages
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:876
+msgid "Generate for All Pages (In Range)"
+msgstr "Generuj dla wszystkich stron (w zakresie)"
+
+#. Translators: Error message when text field is empty
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:886
+msgid "No text to read."
+msgstr "Brak tekstu do odczytu."
+
+#. Translators: Message while gathering text
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:896
+msgid "Gathering text for audio..."
+msgstr "Zbieranie tekstu do audio..."
+
+#. Translators: Placeholder text shown in the document reader when processing
+#. takes too long
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:903 addon\globalPlugins\visionAssistant\dialogs\document.py:1014
+msgid "[Processing timeout]"
+msgstr "[Przekroczono czas przetwarzania]"
+
+#. Translators: File dialog title for saving audio
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:910
+msgid "Save Audio"
+msgstr "Zapisz audio"
+
+#. Translators: Message while generating audio
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:921
+msgid "Generating Audio..."
+msgstr "Generowanie audio..."
+
+#. Translators: Fallback error message during text-to-speech generation.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:929
+msgid "Unknown Error"
+msgstr "Nieznany błąd"
+
+#. Translators: Success message after generating TTS audio.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:930 addon\globalPlugins\visionAssistant\dialogs\document.py:971
+#, python-brace-format
+msgid "TTS Error: {error}"
+msgstr "Błąd TTS: {error}"
+
+#. Translators: Error message when the MP3 encoder (LAME) is missing.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:947
+msgid "lame.exe not found in lib folder."
+msgstr "Nie znaleziono lame.exe w folderze lib."
+
+#. Translators: Spoken message when audio is saved
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:961
+msgid "Audio Saved"
+msgstr "Audio zapisane"
+
+#. Translators: Success message shown when narration generation is
+#. successfully completed with silence detection.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:966
+msgid "Audio file generated and saved successfully."
+msgstr "Plik audio został wygenerowany i zapisany."
+
+#. Translators: Title for the success message box.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:966 addon\globalPlugins\visionAssistant\dialogs\document.py:1039 addon\globalPlugins\visionAssistant\dialogs\donate.py:55 addon\globalPlugins\visionAssistant\dialogs\media.py:1568
+msgid "Success"
+msgstr "Sukces"
+
+#. Translators: File dialog title for saving
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:996
+msgid "Save"
+msgstr "Zapisz"
+
+#. Translators: Message showing save progress
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1008
+#, python-brace-format
+msgid "Saving Page {num}..."
+msgstr "Zapisywanie strony {num}..."
+
+#. Translators: Status label when save is complete
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1038
+msgid "Saved"
+msgstr "Zapisano"
+
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1039
+msgid "File saved successfully."
+msgstr "Plik zapisany."
+
+#. Translators: Message box content for successful save
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1041 addon\globalPlugins\visionAssistant\dialogs\settings.py:1142
+#, python-brace-format
+msgid "Save Error: {error}"
+msgstr "Błąd zapisu: {error}"
+
 #. Translators: Label for the button to open a website to purchase an Apple
 #. Gift Card.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:20
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:21
 msgid "Buy Apple Gift Card (US Region)"
 msgstr "Kup Apple Gift Card (region USA)"
 
 #. Translators: Label for the button to copy the support email address for
 #. gift cards.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:22
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:23
 msgid "Copy Support Email"
 msgstr "Kopiuj adres e-mail wsparcia"
 
 #. Translators: Label for the button to copy the TON cryptocurrency wallet
 #. address.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:24
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:25
 msgid "Copy TON Address"
 msgstr "Kopiuj adres TON"
 
+#. Translators: Label for the button to copy the TRON cryptocurrency wallet
+#. address.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:27
+msgid "Copy TRON Address"
+msgstr "Skopiuj adres TRON"
+
 #. Translators: Button to dismiss the donation dialog without taking any
 #. action.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:33
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:36
 msgid "Maybe Later"
 msgstr "Może później"
 
 #. Translators: Message shown after the gift card website is opened.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:45
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:48
 #, python-brace-format
-msgid ""
-"The website has been opened. Please purchase a 'US Region' card and send the"
-" code to: {email}"
-msgstr ""
-"Otwarto stronę. Kup kartę z regionu USA i wyślij kod na adres: {email}"
+msgid "The website has been opened. Please purchase a 'US Region' card and send the code to: {email}"
+msgstr "Otwarto stronę. Kup kartę z regionu USA i wyślij kod na adres: {email}"
 
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:46
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:49
 msgid "Information"
 msgstr "Informacja"
 
 #. Translators: Success message shown after an address or email is copied to
 #. the clipboard.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:50
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:53
 msgid "Copied to clipboard! Your support is greatly appreciated!"
 msgstr "Skopiowano do schowka! Twoje wsparcie jest bardzo ważne!"
 
-#. Translators: Title for the success message box.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:52
-#: addon\globalPlugins\visionAssistant\__init__.py:6792
-#: addon\globalPlugins\visionAssistant\__init__.py:6855
-#: addon\globalPlugins\visionAssistant\__init__.py:8160
-msgid "Success"
-msgstr "Sukces"
-
 #. Translators: Title of the donation request dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:63
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:66
 #, python-brace-format
 msgid "Support the Future of {name}"
 msgstr "Wesprzyj przyszłość {name}"
 
 #. Translators: The main message of the donation dialog.
-#: addon\globalPlugins\visionAssistant\donate_dialog.py:66
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:69
 #, python-brace-format
 msgid ""
 "{name} is a project born from a personal vision to bridge the gap between AI and true accessibility. The initial concept and many of the features you enjoy were created from my own ideas to solve real challenges and provide a new level of digital independence.\n"
@@ -99,156 +1816,535 @@ msgstr ""
 "\n"
 "Jeśli ten asystent wniósł wartość do Twojego codziennego życia, Twoje wsparcie jest wspaniałym sposobem na docenienie włożonej pracy i zaangażowania. Dziękuję, że jesteś częścią tej misji!"
 
+#. Translators: Title of the Live Assistant conversation window.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:47
+#, python-brace-format
+msgid "{name} - Live Assistant"
+msgstr "{name} - Asystent głosowy"
+
+#. Translators: Label for the conversation history area in the Live Assistant
+#. window.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:58
+msgid "Conversation:"
+msgstr "Rozmowa:"
+
+#. Translators: Label for TTS Voice selection in the Live Assistant window.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:64
+msgid "&TTS Voice:"
+msgstr "Głos &TTS:"
+
+#. Translators: Label for Thinking Depth selection in the Live Assistant
+#. window.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:82
+msgid "Thinking &Depth:"
+msgstr "Głębia &myślenia:"
+
+#. Translators: Thinking level option for no reasoning (lowest latency)
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:86
+msgid "Minimal (Fastest)"
+msgstr "Minimalna (najszybsza)"
+
+#. Translators: Thinking level option for slight reasoning
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:88
+msgid "Low (Agentic)"
+msgstr "Niska (agentowa)"
+
+#. Translators: Thinking level option for standard reasoning (balanced)
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:90
+msgid "Medium (Balanced)"
+msgstr "Średnia (zrównoważona)"
+
+#. Translators: Thinking level option for deep reasoning
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:92
+msgid "High (Deep)"
+msgstr "Wysoka (głęboka)"
+
+#. Translators: Button that ends the live voice conversation.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:108 addon\globalPlugins\visionAssistant\dialogs\media.py:165
+msgid "&End"
+msgstr "&Zakończ"
+
+#. Translators: Message shown in conversation log when voice is changed
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:128
+msgid "--- Changing voice, reconnecting... ---"
+msgstr "--- Zmiana głosu, ponowne łączenie... ---"
+
+#. Translators: Message shown in conversation log when thinking depth is
+#. changed
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:137
+msgid "--- Changing thinking depth, reconnecting... ---"
+msgstr "--- Zmiana głębi myślenia, ponowne łączenie... ---"
+
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:165
+msgid "&Start"
+msgstr "&Rozpocznij"
+
+#. Translators: Title of the dubbing options dialog
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:187
+msgid "Dubbing Options"
+msgstr "Opcje dubbingu"
+
+#. Translators: Title of the translation options dialog
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:190
+msgid "Translation Options"
+msgstr "Opcje tłumaczenia"
+
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:197 addon\globalPlugins\visionAssistant\dialogs\settings.py:299
+msgid "Source:"
+msgstr "Źródłowy:"
+
+#. Translators: Title of the video analysis dialog
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:237
+#, python-brace-format
+msgid "{name} - Analyze Video"
+msgstr "{name} - Analiza wideo"
+
+#. Translators: Label instructing the user to enter a URL or browse for a
+#. local video
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:243
+msgid "Enter Video URL (YouTube, Instagram, Twitter, TikTok) or Browse for a local video:"
+msgstr "Wprowadź adres URL wideo (YouTube, Instagram, Twitter, TikTok) lub wskaż lokalny plik wideo:"
+
+#. Translators: Button to browse for a local video file
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:251
+msgid "&Browse..."
+msgstr "&Przeglądaj..."
+
+#. Translators: Option to generate an Audio Description SRT file.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:258 addon\globalPlugins\visionAssistant\features\video.py:86
+msgid "Generate Audio Description (SRT File)"
+msgstr "Generuj audiodeskrypcję (plik SRT)"
+
+#. Translators: Label for the video action radio box
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:262
+msgid "Action"
+msgstr "Akcja"
+
+#. Translators: Checkbox label to add character list as the first subtitle in
+#. video SRT output.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:272 addon\globalPlugins\visionAssistant\dialogs\settings.py:371
+msgid "Add character list as first subtitle"
+msgstr "Dodaj listę postaci jako pierwszy napis"
+
+#. Translators: Checkbox label to add an AI warning disclaimer at the
+#. beginning of the video SRT output.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:278 addon\globalPlugins\visionAssistant\dialogs\settings.py:376
+msgid "Add AI disclaimer at the beginning"
+msgstr "Dodaj zastrzeżenie AI na początku"
+
+#. Translators: Filter for video files in the file dialog
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:291
+msgid "Video Files"
+msgstr "Pliki wideo"
+
+#. Translators: Title of the file dialog for selecting a video
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:293
+msgid "Select Local Video"
+msgstr "Wybierz lokalne wideo"
+
+#. Translators: Title of the progress dialog when generating SRT
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:308 addon\globalPlugins\visionAssistant\dialogs\media.py:810
+#, python-brace-format
+msgid "{name} - Generating Audio Description"
+msgstr "{name} - Generowanie audiodeskrypcji"
+
+#. Translators: Label for the status log text box
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:322
+msgid "Process Status / Subtitle Content:"
+msgstr "Stan procesu / treść napisów:"
+
+#. Translators: Label for selecting the Windows TTS voice
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:329
+msgid "Narration Voice:"
+msgstr "Głos narracji:"
+
+#. Translators: Label for selecting the eSpeak voice variant
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:339
+msgid "eSpeak Voice Variant:"
+msgstr "Wariant głosu eSpeak:"
+
+#. Translators: Button to download missing eSpeak-NG
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:352
+msgid "Download eSpeak-NG"
+msgstr "Pobierz eSpeak-NG"
+
+#. Translators: Label for selecting the Gemini Live TTS voice
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:366
+msgid "Gemini Voice:"
+msgstr "Głos Gemini:"
+
+#. Translators: Button to save the generated SRT file
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:386
+msgid "&Save SRT"
+msgstr "&Zapisz SRT"
+
+#. Translators: Button to generate a synced MP3 narration using offline TTS
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:391
+msgid "&Generate Synced Narration (MP3)"
+msgstr "&Generuj zsynchronizowaną narrację (MP3)"
+
+#. Translators: Button to regenerate the audio description
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:396
+msgid "&Regenerate"
+msgstr "&Generuj ponownie"
+
+#. Translators: Button to close the dialog
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:401
+msgid "&Close / Cancel"
+msgstr "&Zamknij / Anuluj"
+
+#. Translators: Status message when downloading eSpeak-NG
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:648
+msgid "Downloading eSpeak-NG, please wait..."
+msgstr "Pobieranie eSpeak-NG, proszę czekać..."
+
+#. Translators: Progress message during eSpeak-NG download
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:668
+#, python-brace-format
+msgid "Downloading eSpeak-NG: {percent}%"
+msgstr "Pobieranie eSpeak-NG: {percent}%"
+
+#. Translators: Status message when extracting eSpeak-NG
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:674
+msgid "Extracting eSpeak-NG..."
+msgstr "Wypakowywanie eSpeak-NG..."
+
+#. Translators: Success message after eSpeak-NG download completes
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:683
+msgid "eSpeak-NG downloaded successfully!"
+msgstr "Pobrano eSpeak-NG."
+
+#. Translators: Error message when eSpeak-NG download fails
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:690
+#, python-brace-format
+msgid "Failed to download eSpeak-NG: {error}"
+msgstr "Nie udało się pobrać eSpeak-NG: {error}"
+
+#. Translators: Option for eSpeak voice matching the user's current NVDA voice
+#. settings
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:710
+msgid "eSpeak (Current NVDA Language)"
+msgstr "eSpeak (bieżący język NVDA)"
+
+#. Translators: Option to use Gemini Live API for highly realistic text-to-
+#. speech
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:734
+msgid "Gemini Live TTS (Online, High Quality)"
+msgstr "Gemini Live TTS (online, wysoka jakość)"
+
+#. Translators: Option for default English eSpeak voice
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:738
+msgid "eSpeak (English Default)"
+msgstr "eSpeak (domyślny angielski)"
+
+#. Translators: Title of the dialog when generation is successfully finished
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:783
+#, python-brace-format
+msgid "{name} - Audio Description Ready"
+msgstr "{name} — audiodeskrypcja gotowa"
+
+#. Translators: Success announcement when generation is complete
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:794
+msgid "Audio description generated successfully! You can read the subtitle content in the text box."
+msgstr "Audiodeskrypcja wygenerowana! Treść napisów możesz przeczytać w polu tekstowym."
+
+#. Translators: Status message when an error occurs during SRT generation
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:800
+#, python-brace-format
+msgid "Error: {err}"
+msgstr "Błąd: {err}"
+
+#. Translators: Status message when restarting generation
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:819
+msgid "Re-initializing..."
+msgstr "Ponowna inicjalizacja..."
+
+#. Translators: File dialog title for saving the generated SRT file
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:836
+msgid "Save Audio Description"
+msgstr "Zapisz audiodeskrypcję"
+
+#. Translators: Success message when SRT file is saved
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:848
+msgid "SRT file saved successfully."
+msgstr "Zapisano plik SRT."
+
+#. Translators: Error when SRT parsing finds no valid subtitle blocks
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:909
+msgid "No valid subtitle blocks found in the SRT content."
+msgstr "Nie znaleziono prawidłowych bloków napisów w treści SRT."
+
+#. Translators: Error when no voice is selected
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:919
+msgid "Please select an offline voice from the list."
+msgstr "Wybierz głos offline z listy."
+
+#. Translators: Warning prompt for online videos indicating that the output
+#. will only contain narration.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:964
+msgid "Because the source is an online video, the final file will ONLY contain the AI voice narration (synced to the timestamps) and will NOT include the original background audio of the video. Do you want to proceed?"
+msgstr "Ponieważ źródłem jest wideo online, plik końcowy będzie zawierał WYŁĄCZNIE narrację głosem AI (zsynchronizowaną ze znacznikami czasu) i NIE będzie zawierał oryginalnego dźwięku tła wideo. Kontynuować?"
+
+#. Translators: Title of the warning dialog when opening an online video link.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:966
+msgid "Online Video Mode"
+msgstr "Tryb wideo online"
+
+#. Translators: Title of the narration mode selection dialog.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:973
+msgid "Select Narration Mode"
+msgstr "Wybierz tryb narracji"
+
+#. Translators: Instruction prompt for narration mode selection.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:975
+msgid "Choose how the narration should be mixed with the video audio:"
+msgstr "Wybierz, jak narracja ma być zmiksowana z dźwiękiem wideo:"
+
+#. Translators: Option for mixing voice directly over the video without
+#. pausing.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:978
+msgid "Standard AD (Mix voice directly over audio - No Pausing)"
+msgstr "Standardowa AD (miksuj głos wprost na dźwięku - bez pauz)"
+
+#. Translators: Option for pausing the background video audio during
+#. descriptions.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:980
+msgid "Extended AD (Pause background audio during descriptions)"
+msgstr "Rozszerzona AD (pauzuj dźwięk tła podczas opisów)"
+
+#. Translators: Prompt asking whether to lower the background video audio
+#. during the descriptions.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:996
+msgid "Do you want to fade/duck the background video audio during the descriptions?"
+msgstr "Czy przyciszyć dźwięk tła wideo podczas opisów?"
+
+#. Translators: Title for the audio ducking prompt.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:998
+msgid "Audio Ducking"
+msgstr "Przyciszanie dźwięku tła"
+
+#. Translators: Button label or menu item to save the generated AI audio
+#. narration synced to the video.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1010
+msgid "Save Synced Narration"
+msgstr "Zapisz zsynchronizowaną narrację"
+
+#. Translators: Status message when narration generation starts
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1035
+msgid "Generating offline synced narration. This may take a few moments..."
+msgstr "Generowanie zsynchronizowanej narracji offline. Może to chwilę potrwać..."
+
+#. Translators: Status message shown when extracting the original video audio
+#. tracks.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1147
+msgid "Extracting original video audio..."
+msgstr "Wyodrębnianie oryginalnego dźwięku wideo..."
+
+#. Translators: Error message shown when extraction of the video's original
+#. audio fails.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1165
+msgid "Failed to extract video audio."
+msgstr "Nie udało się wyodrębnić dźwięku wideo."
+
+#. Translators: Status message shown when analyzing the video's audio to
+#. detect periods of silence.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1174
+msgid "Analyzing video for natural silences..."
+msgstr "Analiza wideo pod kątem naturalnych cisz..."
+
+#. Translators: Status message shown when starting connection to Gemini Live
+#. API
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1288
+msgid "Connecting to Gemini Live API..."
+msgstr "Łączenie z Gemini Live API..."
+
+#. Translators: Error message shown when connection to Gemini Live API fails
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1291
+msgid "Failed to connect to Gemini Live API."
+msgstr "Nie udało się połączyć z Gemini Live API."
+
+#. Translators: Progress message during narration generation. {current} is the
+#. current block number, {total} is total blocks.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1310
+#, python-brace-format
+msgid "Generating narration: part {current} of {total}..."
+msgstr "Generowanie narracji: część {current} z {total}..."
+
+#. Translators: Status message when combining audio blocks
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1435
+msgid "Arranging audio track... Please wait."
+msgstr "Układanie ścieżki dźwiękowej... Proszę czekać."
+
+#. Translators: Status message when mixing generated narration with original
+#. video audio
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1492
+msgid "Mixing narration with original video audio..."
+msgstr "Miksowanie narracji z oryginalnym dźwiękiem wideo..."
+
+#. Translators: Status message when slicing and splicing the audio file with
+#. natural pauses.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1515
+msgid "Splicing audio based on natural pauses..."
+msgstr "Sklejanie dźwięku na podstawie naturalnych pauz..."
+
+#. Translators: Status message shown when converting the final raw WAV mix to
+#. MP3 format.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1550
+msgid "Converting final audio to MP3..."
+msgstr "Konwersja końcowego dźwięku do MP3..."
+
+#. Translators: Message spoken on successful save of the synced narration.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1567
+msgid "Synced extended narration with silence detection saved successfully."
+msgstr "Zapisano zsynchronizowaną rozszerzoną narrację z wykrywaniem ciszy."
+
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1568
+msgid "Synced extended audio narration file generated successfully with smart silence matching."
+msgstr "Wygenerowano zsynchronizowany rozszerzony plik narracji dźwiękowej z dopasowaniem do naturalnych cisz."
+
+#. Translators: Error message shown when the final MP3 conversion fails.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1571
+msgid "Failed to generate the final MP3 file."
+msgstr "Nie udało się wygenerować końcowego pliku MP3."
+
+#. Translators: Error message shown when narration generation fails.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1576
+#, python-brace-format
+msgid "Narration Error: {error}"
+msgstr "Błąd narracji: {error}"
+
+#. Translators: Message announced when user cancels the process
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1601
+msgid "Process cancelled."
+msgstr "Proces anulowany."
+
 #. Translators: Label for prompt name input field.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:22
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:22
 msgid "Name:"
 msgstr "Nazwa:"
 
 #. Translators: Label for prompt text input field.
-#. Translators: Label above the prompt editor textarea.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:28
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:189
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:28 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:186
 msgid "Prompt Text:"
 msgstr "Treść Promptu:"
 
 #. Translators: Button label to open the variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:47
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:142
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:47 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:141
 msgid "Variables Guide"
 msgstr "Przewodnik po zmiennych"
 
 #. Translators: Validation error for empty prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:64
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:64
 msgid "Name cannot be empty."
 msgstr "Nazwa nie może być pusta."
 
 #. Translators: Title of validation warning dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:66
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:74
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:361
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:472
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:500
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:66 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:73 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:355 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:465
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:491
 msgid "Validation Error"
 msgstr "Błąd walidacji"
 
 #. Translators: Validation error for empty prompt text.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:72
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:359
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:72 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:354
 msgid "Prompt text cannot be empty."
 msgstr "Treść polecenia nie może być pusta."
 
 #. Translators: Title for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:95
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:94
 msgid "Prompt Variables Guide"
 msgstr "Przewodnik po zmiennych poleceń"
 
 #. Translators: Intro text for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:99
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:98
 msgid "Use these variables inside prompt text:"
 msgstr "Użyj tych zmiennych wewnątrz treści polecenia:"
 
-#. Translators: Button to close chat dialog
-#. Translators: Label for a button to close the dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:110
-#: addon\globalPlugins\visionAssistant\__init__.py:4712
-#: addon\globalPlugins\visionAssistant\__init__.py:6264
-msgid "Close"
-msgstr "Zamknij"
-
 #. Translators: Title for the prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:120
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:120
 msgid "Prompt Manager"
 msgstr "Menedżer poleceń"
 
 #. Translators: Notebook tab for built-in refine prompts.
-#. Translators: Label above the list of default prompt entries.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:132
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:166
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:132 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:164
 msgid "Default Prompts"
 msgstr "Polecenia domyślne"
 
 #. Translators: Notebook tab for user-defined prompts.
-#. Translators: Label above the list of custom prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:134
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:221
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:134 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:217
 msgid "Custom Prompts"
 msgstr "Polecenia niestandardowe"
 
 #. Translators: Note explaining when prompt changes are persisted.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:146
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:145
 msgid "Changes are applied only when you press OK."
 msgstr "Zmiany zostaną zastosowane dopiero po naciśnięciu OK."
 
 #. Translators: Button label to reset currently selected default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:178
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:176
 msgid "Reset Selected"
 msgstr "Resetuj wybrane"
 
 #. Translators: Button label to reset all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:183
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:181
 msgid "Reset All"
 msgstr "Resetuj wszystkie"
 
 #. Translators: Button label to apply current editor text to the selected
 #. default prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:198
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:195
 msgid "Apply to Selected"
 msgstr "Zastosuj do wybranego"
 
 #. Translators: Button label for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:230
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:226
 msgid "Add"
 msgstr "Dodaj"
 
 #. Translators: Button label for editing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:232
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:228
 msgid "Edit"
 msgstr "Edytuj"
 
 #. Translators: Button label for removing a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:234
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:230
 msgid "Remove"
 msgstr "Usuń"
 
 #. Translators: Button label for moving selected custom prompt up in the list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:245
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:241
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
 #. Translators: Button label for moving selected custom prompt down in the
 #. list.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:247
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:243
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
 #. Translators: Label above the custom prompt preview area.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:256
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:252
 msgid "Prompt Preview:"
 msgstr "Podgląd polecenia:"
 
 #. Translators: Validation message shown when required text is missing in a
 #. guarded prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:318
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:314
 #, python-brace-format
-msgid ""
-"This prompt is used by {feature}. To save it, add the required text below:"
-msgstr ""
-"Ten prompt jest używany przez funkcję {feature}. Aby go zapisać, dodaj "
-"wymagany tekst poniżej:"
+msgid "This prompt is used by {feature}. To save it, add the required text below:"
+msgstr "Ten prompt jest używany przez funkcję {feature}. Aby go zapisać, dodaj wymagany tekst poniżej:"
 
 #. Translators: Guidance shown after listing missing required text.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:324
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:320
 msgid "Add these items exactly as written, then try again."
-msgstr ""
-"Dodaj te elementy dokładnie tak, jak podano, a następnie spróbuj ponownie."
+msgstr "Dodaj te elementy dokładnie tak, jak podano, a następnie spróbuj ponownie."
 
 #. Translators: Title of validation warning dialog for guarded prompt checks.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:326
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:322
 msgid "Required Text Missing"
 msgstr "Brak wymaganego tekstu"
 
 #. Translators: Confirmation message shown before saving a guarded prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:337
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:333
 #, python-brace-format
 msgid ""
 "You are editing a prompt used by {feature}.\n"
@@ -265,1576 +2361,343 @@ msgstr ""
 
 #. Translators: Title of confirmation dialog shown before saving guarded
 #. prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:340
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:336
 msgid "Confirm"
 msgstr "Potwierdź"
 
 #. Translators: Confirm button label for guarded prompt save confirmation.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:344
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:340
 msgid "Yes, Save Anyway"
 msgstr "Tak, zapisz mimo to"
 
 #. Translators: Cancel button label for guarded prompt save confirmation.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:346
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:342
 msgid "No, Go Back"
 msgstr "Nie, wróć"
 
 #. Translators: Message shown after applying changes to the selected default
 #. prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:395
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:389
 msgid "Selected prompt updated."
 msgstr "Wybrane polecenie zaktualizowane."
 
 #. Translators: Confirmation text before resetting all default prompts.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:408
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:402
 msgid "Reset all default prompts to built-in values?"
 msgstr "Przywrócić wszystkie domyślne polecenia do wartości domyślnych?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:410
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:404
 msgid "Confirm Reset"
 msgstr "Potwierdź reset"
 
 #. Translators: Title of dialog for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:465
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:459
 msgid "Add Custom Prompt"
 msgstr "Dodaj polecenie niestandardowe"
 
 #. Translators: Validation error for duplicate custom prompt name.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:470
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:498
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:464 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:490
 msgid "A custom prompt with this name already exists."
 msgstr "Polecenie niestandardowe o tej nazwie już istnieje."
 
 #. Translators: Title of the dialog for editing an existing custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:489
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:482
 msgid "Edit Custom Prompt"
 msgstr "Edytuj polecenie niestandardowe"
 
 #. Translators: Confirmation text before deleting a custom prompt.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:513
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:504
 #, python-brace-format
 msgid "Remove custom prompt '{name}'?"
 msgstr "Usunąć polecenie niestandardowe \"{name}\"?"
 
-#. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\prompt_manager_dialog.py:515
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:505
 msgid "Confirm Remove"
 msgstr "Potwierdź usunięcie"
 
-#. --- 1. Recommended (Auto-Updating) ---
-#. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest
-#. version.
-#: addon\globalPlugins\visionAssistant\__init__.py:90
-#: addon\globalPlugins\visionAssistant\__init__.py:91
-msgid "[Auto]"
-msgstr "[Auto]"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:90
-#: addon\globalPlugins\visionAssistant\__init__.py:91
-msgid "(Latest)"
-msgstr "(Najnowszy)"
-
-#. --- 2. Current Standard (Free & Fast) ---
-#. Translators: AI Model info. [Free] = Generous usage limits. (Preview) =
-#. Experimental or early-access version.
-#: addon\globalPlugins\visionAssistant\__init__.py:95
-#: addon\globalPlugins\visionAssistant\__init__.py:96
-#: addon\globalPlugins\visionAssistant\__init__.py:97
-#: addon\globalPlugins\visionAssistant\__init__.py:98
-msgid "[Free]"
-msgstr "[Darmowy]"
-
-#. --- 3. High Intelligence (Paid/Pro/Preview) ---
-#. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview)
-#. = Experimental version.
-#: addon\globalPlugins\visionAssistant\__init__.py:102
-#: addon\globalPlugins\visionAssistant\__init__.py:103
-msgid "[Pro]"
-msgstr "[Pro]"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:102
-msgid "(Preview)"
-msgstr "(Podgląd)"
-
-#. Translators: Adjective describing a bright AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:108
-#: addon\globalPlugins\visionAssistant\__init__.py:126
-msgid "Bright"
-msgstr "Jasny"
-
-#. Translators: Adjective describing an upbeat AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:110
-#: addon\globalPlugins\visionAssistant\__init__.py:144
-msgid "Upbeat"
-msgstr "Energiczny"
-
-#. Translators: Adjective describing an informative AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:112
-#: addon\globalPlugins\visionAssistant\__init__.py:142
-msgid "Informative"
-msgstr "Informacyjny"
-
-#. Translators: Adjective describing a firm AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:114
-#: addon\globalPlugins\visionAssistant\__init__.py:120
-#: addon\globalPlugins\visionAssistant\__init__.py:148
-msgid "Firm"
-msgstr "Stanowczy"
-
-#. Translators: Adjective describing an excitable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:116
-msgid "Excitable"
-msgstr "Entuzjastyczny"
-
-#. Translators: Adjective describing a youthful AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:118
-msgid "Youthful"
-msgstr "Młodzieńczy"
-
-#. Translators: Adjective describing a breezy AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:122
-msgid "Breezy"
-msgstr "Swobodny"
-
-#. Translators: Adjective describing an easy-going AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:124
-#: addon\globalPlugins\visionAssistant\__init__.py:132
-msgid "Easy-going"
-msgstr "Wyluzowany"
-
-#. Translators: Adjective describing a breathy AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:128
-msgid "Breathy"
-msgstr "Szeptany"
-
-#. Translators: Adjective describing a clear AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:130
-#: addon\globalPlugins\visionAssistant\__init__.py:138
-#: addon\globalPlugins\visionAssistant\__init__.py:188
-msgid "Clear"
-msgstr "Wyraźny"
-
-#. Translators: Adjective describing a smooth AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:134
-#: addon\globalPlugins\visionAssistant\__init__.py:136
-msgid "Smooth"
-msgstr "Łagodny"
-
-#. Translators: Adjective describing a gravelly AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:140
-msgid "Gravelly"
-msgstr "Chropowaty"
-
-#. Translators: Adjective describing a soft AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:146
-msgid "Soft"
-msgstr "Miękki"
-
-#. Translators: Adjective describing an even AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:150
-msgid "Even"
-msgstr "Równomierny"
-
-#. Translators: Adjective describing a mature AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:152
-msgid "Mature"
-msgstr "Dojrzały"
-
-#. Translators: Adjective describing a forward AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:154
-msgid "Forward"
-msgstr "Bezpośredni"
-
-#. Translators: Adjective describing a friendly AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:156
-msgid "Friendly"
-msgstr "Przyjacielski"
-
-#. Translators: Adjective describing a casual AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:158
-msgid "Casual"
-msgstr "Swobodny"
-
-#. Translators: Adjective describing a gentle AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:160
-#: addon\globalPlugins\visionAssistant\__init__.py:186
-msgid "Gentle"
-msgstr "Delikatny"
-
-#. Translators: Adjective describing a lively AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:162
-msgid "Lively"
-msgstr "Żywiołowy"
-
-#. Translators: Adjective describing a knowledgeable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:164
-msgid "Knowledgeable"
-msgstr "Kompetentny"
-
-#. Translators: Adjective describing a warm AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:166
-msgid "Warm"
-msgstr "Ciepły"
-
-#. Translators: Adjective describing a neutral AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:170
-msgid "Neutral"
-msgstr "Neutralny"
-
-#. Translators: Adjective describing a quirky AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:172
-msgid "Quirky"
-msgstr "Ekscentryczny"
-
-#. Translators: Adjective describing a professional AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:174
-msgid "Professional"
-msgstr "Profesjonalny"
-
-#. Translators: Adjective describing a cheerful AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:176
-msgid "Cheerful"
-msgstr "Radosny"
-
-#. Translators: Adjective describing a confident AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:178
-msgid "Confident"
-msgstr "Pewny siebie"
-
-#. Translators: Adjective describing a British AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:180
-msgid "British"
-msgstr "Brytyjski"
-
-#. Translators: Adjective describing a pleasant AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:182
-msgid "Pleasant"
-msgstr "Przyjemny"
-
-#. Translators: Adjective describing a deep AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:184
-msgid "Deep"
-msgstr "Głęboki"
-
-#. Translators: Adjective describing an expressive AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:190
-msgid "Expressive"
-msgstr "Ekspresyjny"
-
-#. Translators: Adjective describing a reliable AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:192
-msgid "Reliable"
-msgstr "Niezawodny"
-
-#. Translators: Adjective describing an energetic AI voice style.
-#: addon\globalPlugins\visionAssistant\__init__.py:194
-msgid "Energetic"
-msgstr "Energiczny"
-
-#. Translators: Option in the language list to automatically detect the source
-#. language.
-#: addon\globalPlugins\visionAssistant\__init__.py:273
-msgid "Auto-detect"
-msgstr "Wykryj automatycznie"
-
-#. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\__init__.py:287
-msgid "Chrome (Fast)"
-msgstr "Chrome (szybki)"
-
-#. Translators: OCR Engine option (Slower but better formatting/AI-driven)
-#: addon\globalPlugins\visionAssistant\__init__.py:289
-msgid "AI (Advanced)"
-msgstr "AI (zaawansowany)"
-
-#. Translators: OCR Engine option for searchable PDFs (extracts text without
-#. OCR)
-#: addon\globalPlugins\visionAssistant\__init__.py:291
-msgid "None (Extract Text Layer)"
-msgstr "Wyodrębnij tekst (offline)"
-
-#. Translators: Section header for text refinement prompts in Prompt Manager.
-#. Translators: main message of the Refine dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:391
-#: addon\globalPlugins\visionAssistant\__init__.py:399
-#: addon\globalPlugins\visionAssistant\__init__.py:407
-#: addon\globalPlugins\visionAssistant\__init__.py:415
-#: addon\globalPlugins\visionAssistant\__init__.py:9170
-msgid "Refine"
-msgstr "Poprawianie"
-
-#. Translators: Label for the text summarization prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:393
-msgid "Summarize"
-msgstr "Podsumuj"
-
-#. Translators: Label for the grammar correction prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:401
-msgid "Fix Grammar"
-msgstr "Popraw gramatykę"
-
-#. Translators: Label for the grammar correction and translation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:409
-msgid "Fix Grammar & Translate"
-msgstr "Popraw gramatykę i przetłumacz"
-
-#. Translators: Label for the text explanation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:417
-msgid "Explain"
-msgstr "Wyjaśnij"
-
-#. Translators: Section header for translation-related prompts in Prompt
-#. Manager.
-#. Translators: Box title for translation options
-#: addon\globalPlugins\visionAssistant\__init__.py:423
-#: addon\globalPlugins\visionAssistant\__init__.py:435
-#: addon\globalPlugins\visionAssistant\__init__.py:5902
-msgid "Translation"
-msgstr "Tłumaczenie"
-
-#. Translators: Label for the smart translation prompt.
-#. Translators: Feature name used in guarded prompt warnings for smart
-#. translation.
-#: addon\globalPlugins\visionAssistant\__init__.py:425
-#: addon\globalPlugins\visionAssistant\__init__.py:428
-msgid "Smart Translation"
-msgstr "tłumaczenie"
-
-#. Translators: Label for the quick translation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:437
-msgid "Quick Translation"
-msgstr "szybkie Tłumaczenie"
-
-#. Translators: Section header for document-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:443
-#: addon\globalPlugins\visionAssistant\__init__.py:675
-msgid "Document"
-msgstr "Dokument"
-
-#. Translators: Label for the initial context prompt in document chat.
-#: addon\globalPlugins\visionAssistant\__init__.py:445
-msgid "Document Chat Context"
-msgstr "Kontekst czatu z dokumentem"
-
-#. Translators: Section header for image analysis prompts in Prompt Manager.
-#. Translators: Section header for UI Explorer prompts in the Prompt Manager
-#. dialog.
-#. Translators: Section header for AI Operator prompts in the Prompt Manager
-#. dialog.
-#. Translators: Section header for labeling prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:458
-#: addon\globalPlugins\visionAssistant\__init__.py:472
-#: addon\globalPlugins\visionAssistant\__init__.py:709
-#: addon\globalPlugins\visionAssistant\__init__.py:738
-#: addon\globalPlugins\visionAssistant\__init__.py:760
-#: addon\globalPlugins\visionAssistant\__init__.py:776
-msgid "Vision"
-msgstr "Rozpoznawanie"
-
-#. Translators: Label for the prompt used to analyze the current navigator
-#. object.
-#: addon\globalPlugins\visionAssistant\__init__.py:460
-msgid "Navigator Object Analysis"
-msgstr "Analiza obiektu nawigatora"
-
-#. Translators: Label for the prompt used to analyze the entire screen.
-#: addon\globalPlugins\visionAssistant\__init__.py:474
-msgid "Full Screen Analysis"
-msgstr "Analiza pełnego ekranu"
-
-#. Translators: Section header for video analysis prompts in Prompt Manager.
-#. Translators: Title of settings group for Video features
-#: addon\globalPlugins\visionAssistant\__init__.py:500
-#: addon\globalPlugins\visionAssistant\__init__.py:565
-#: addon\globalPlugins\visionAssistant\__init__.py:610
-#: addon\globalPlugins\visionAssistant\__init__.py:5161
-#: addon\globalPlugins\visionAssistant\__init__.py:8674
-msgid "Video"
-msgstr "Wideo"
-
-#. Translators: Label for the general video content analysis prompt.
-#. Translators: Options for video analysis mode
-#. Translators: Dialog choice for analyzing video content generally.
-#: addon\globalPlugins\visionAssistant\__init__.py:502
-#: addon\globalPlugins\visionAssistant\__init__.py:7127
-#: addon\globalPlugins\visionAssistant\__init__.py:10123
-msgid "General Video Analysis"
-msgstr "Ogólna analiza wideo"
-
-#. Translators: Label for the Audio Description (SRT) generation prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:567
-msgid "Audio Description Generation (SRT)"
-msgstr "Generowanie audiodeskrypcji (SRT)"
-
-#. Translators: Label for the local video recording analysis prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:612
-msgid "Local Video Recording Analysis"
-msgstr "Analiza nagrania ekranu"
-
-#. Translators: Section header for audio-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:623
-#: addon\globalPlugins\visionAssistant\__init__.py:631
-msgid "Audio"
-msgstr "Audio"
-
-#. Translators: Label for the audio file transcription prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:625
-msgid "Audio Transcription"
-msgstr "Transkrypcja audio"
-
-#. Translators: Label for the smart voice dictation prompt.
-#. Translators: Feature name used in guarded prompt warnings for smart
-#. dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:633
-#: addon\globalPlugins\visionAssistant\__init__.py:636
-msgid "Smart Dictation"
-msgstr "dyktowanie"
-
-#. Translators: Section header for OCR-related prompts in Prompt Manager.
-#. Translators: Status prefix for specific tasks
-#: addon\globalPlugins\visionAssistant\__init__.py:646
-#: addon\globalPlugins\visionAssistant\__init__.py:658
-#: addon\globalPlugins\visionAssistant\__init__.py:8670
-msgid "OCR"
-msgstr "OCR"
-
-#. Translators: Label for the OCR prompt used for image text extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:648
-msgid "OCR Image Extraction"
-msgstr "Wyodrębnianie tekstu z obrazu (OCR)"
-
-#. Translators: Label for the OCR prompt used for document text extraction.
-#. Translators: Feature name used in guarded prompt warnings for OCR document
-#. extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:660
-#: addon\globalPlugins\visionAssistant\__init__.py:663
-msgid "OCR Document Extraction"
-msgstr "Wyodrębnianie tekstu z dokumentu (OCR)"
-
-#. Translators: Label for the combined OCR and translation prompt for
-#. documents.
-#: addon\globalPlugins\visionAssistant\__init__.py:677
-msgid "Document OCR + Translate"
-msgstr "OCR dokumentu + tłumaczenie"
-
-#. Translators: Section header for CAPTCHA-related prompts in Prompt Manager.
-#. Translators: Title of the settings group for Captchas
-#. --- CAPTCHA Group ---
-#: addon\globalPlugins\visionAssistant\__init__.py:687
-#: addon\globalPlugins\visionAssistant\__init__.py:5186
-msgid "CAPTCHA"
-msgstr "CAPTCHA"
-
-#. Translators: Label for the CAPTCHA solving prompt.
-#. Translators: Feature name used in guarded prompt warnings for CAPTCHA
-#. solver.
-#: addon\globalPlugins\visionAssistant\__init__.py:689
-#: addon\globalPlugins\visionAssistant\__init__.py:692
-msgid "CAPTCHA Solver"
-msgstr "Rozwiązywanie CAPTCHA"
-
-#. Translators: Label for the UI Explorer system instruction prompt in the
-#. Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:711
-msgid "UI Explorer Instruction"
-msgstr "Instrukcja Eksploratora interfejsu"
-
-#. Translators: Feature name shown in the warning dialog when a user tries to
-#. eid the UI Explorer prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:714
-msgid "UI Explorer"
-msgstr "Eksplorator interfejsu"
-
-#. Translators: Label for the AI Operator system instruction prompt in the
-#. Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:740
-msgid "AI Operator Instruction"
-msgstr "Instrukcja Operatora AI"
-
-#. Translators: Feature name shown in the warning dialog when a user tries to
-#. edit the AI Operator prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:743
-#: addon\globalPlugins\visionAssistant\__init__.py:11348
-msgid "AI Operator"
-msgstr "Operator AI"
-
-#. Translators: Label for the prompt used to identify a single UI icon.
-#: addon\globalPlugins\visionAssistant\__init__.py:762
-msgid "Single Labeling Instruction"
-msgstr "Instrukcja pojedynczego etykietowania"
-
-#. Translators: Label for the prompt used to identify multiple unnamed
-#. elements at once.
-#: addon\globalPlugins\visionAssistant\__init__.py:778
-msgid "Batch Labeling Instruction"
-msgstr "Instrukcja zbiorczego etykietowania"
-
-#. Translators: Feature name used in guarded prompt warnings for Batch
-#. Labeling.
-#: addon\globalPlugins\visionAssistant\__init__.py:781
-msgid "Batch Labeling"
-msgstr "Zbiorcze etykietowanie"
-
-#. Translators: Section header for the Live Assistant prompt in Prompt
-#. Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:797
-#: addon\globalPlugins\visionAssistant\__init__.py:8675
-msgid "Live"
-msgstr "Asystent głosowy"
-
-#. Translators: Label for the Live Assistant system instruction prompt in the
-#. Prompt Manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:799
-msgid "Live Assistant Instruction"
-msgstr "Instrukcja asystenta głosowego"
-
-#. Translators: Feature name shown in the warning dialog when a user tries to
-#. edit the Live Assistant prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:802
-msgid "Live Assistant"
-msgstr "Asystent głosowy"
-
-#. Translators: Description and input type for the [selection] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:822
-msgid "Currently selected text"
-msgstr "Aktualnie zaznaczony tekst"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:822
-#: addon\globalPlugins\visionAssistant\__init__.py:824
-#: addon\globalPlugins\visionAssistant\__init__.py:840
-#: addon\globalPlugins\visionAssistant\__init__.py:842
-#: addon\globalPlugins\visionAssistant\__init__.py:844
-#: addon\globalPlugins\visionAssistant\__init__.py:846
-#: addon\globalPlugins\visionAssistant\__init__.py:848
-msgid "Text"
-msgstr "Tekst"
-
-#. Translators: Description for the [clipboard] variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:824
-msgid "Clipboard content"
-msgstr "Zawartość schowka"
-
-#. Translators: Description for the [clipboard_image] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:826
-msgid "Image currently in clipboard"
-msgstr "Obraz obecnie w schowku"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:826
-#: addon\globalPlugins\visionAssistant\__init__.py:828
-#: addon\globalPlugins\visionAssistant\__init__.py:830
-#: addon\globalPlugins\visionAssistant\__init__.py:832
-msgid "Image"
-msgstr "Obraz"
-
-#. Translators: Description and input type for the [screen_obj] variable in
-#. the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:828
-msgid "Screenshot of the navigator object"
-msgstr "Zrzut ekranu obiektu nawigatora"
-
-#. Translators: Description for the [screen_full] variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:830
-msgid "Screenshot of the entire screen"
-msgstr "Zrzut całego ekranu"
-
-#. Translators: Description for the [screen_fg_obj] variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:832
-msgid "Screenshot of the active foreground window"
-msgstr "Zrzut ekranu aktywnego okna pierwszoplanowego"
-
-#. Translators: Description and input type for the [file_ocr] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:834
-msgid "Select image/PDF/TIFF for text extraction"
-msgstr "Wybierz obraz/PDF/TIFF do wyodrębnienia tekstu"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:834
-msgid "Image, PDF, TIFF"
-msgstr "Obraz, PDF, TIFF"
-
-#. Translators: Description and input type for the [file_read] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:836
-msgid "Select document for reading"
-msgstr "Wybierz dokument do odczytu"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:836
-msgid "TXT, Code, PDF"
-msgstr "TXT, kod, PDF"
-
-#. Translators: Description and input type for the [file_audio] variable in
-#. the Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:838
-msgid "Select audio file for analysis"
-msgstr "Wybierz plik audio do analizy"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:838
-msgid "MP3, WAV, OGG"
-msgstr "MP3, WAV, OGG"
-
-#. Translators: Description for the {target_lang} variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:840
-msgid "Current target language"
-msgstr "Bieżący język docelowy"
-
-#. Translators: Description for the {source_lang} variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:842
-msgid "Current source language"
-msgstr "Bieżący język źródłowy"
-
-#. Translators: Description for the {response_lang} variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:844
-msgid "Current AI response language"
-msgstr "Bieżący język odpowiedzi AI"
-
-#. Translators: Description for the {swap_target} variable in the Variables
-#. Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:846
-msgid "Fallback language for translation"
-msgstr "Język zapasowy tłumaczenia"
-
-#. Translators: Description for the {swap_instruction} variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\__init__.py:848
-msgid "Smart swap translation instruction"
-msgstr "Instrukcja tłumaczenia dla zamiany"
-
-#. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\__init__.py:1052
-msgid "Custom: "
-msgstr "Niestandardowe: "
-
-#. Translators: Title of the error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:1316
-#, python-brace-format
-msgid "{name} Error"
-msgstr "Błąd {name}"
-
-#. Translators: Error message shown when trying to take a screenshot while
-#. NVDA's Screen Curtain is enabled.
-#: addon\globalPlugins\visionAssistant\__init__.py:1323
-msgid ""
-"The Screen Curtain is currently enabled. Please disable it "
-"(NVDA+Control+Escape) before using visual recognition features."
-msgstr ""
-"Kurtyna ekranowa jest obecnie włączona. Wyłącz ją (NVDA+Control+Escape) "
-"przed użyciem funkcji rozpoznawania obrazu."
-
-#. Translators: Error message shown when processing a local video file fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1544
-msgid "Error processing local video."
-msgstr "Błąd przetwarzania lokalnego wideo."
-
-#. Translators: Status message when compressing a local video file before
-#. uploading.
-#: addon\globalPlugins\visionAssistant\__init__.py:1555
-msgid "Compressing video (this may take a moment)..."
-msgstr "Kompresja wideo (może chwilę potrwać)..."
-
-#. Translators: Error message shown when video compression fails or is
-#. cancelled by the user.
-#: addon\globalPlugins\visionAssistant\__init__.py:1559
-msgid "Error: Video compression failed or was cancelled."
-msgstr "Błąd: kompresja wideo nie powiodła się lub została anulowana."
-
-#. Translators: Error message shown when processing an online video fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1581
-#: addon\globalPlugins\visionAssistant\__init__.py:1643
-msgid "Error processing video."
-msgstr "Błąd przetwarzania wideo."
-
-#. Translators: Message reported when the add-on starts processing an online
-#. video link.
-#: addon\globalPlugins\visionAssistant\__init__.py:1588
-#: addon\globalPlugins\visionAssistant\__init__.py:1652
-msgid "Processing Video..."
-msgstr "Przetwarzanie wideo..."
-
-#. Translators: Error message when the add-on fails to get a direct download
-#. link for an Instagram video.
-#: addon\globalPlugins\visionAssistant\__init__.py:1595
-msgid "Error: Could not extract Instagram video."
-msgstr "Błąd: nie udało się pobrać wideo z Instagrama."
-
-#. Translators: Error message when the add-on fails to get a direct download
-#. link for a Twitter/X video.
-#: addon\globalPlugins\visionAssistant\__init__.py:1599
-msgid "Error: Could not extract Twitter video."
-msgstr "Błąd: nie udało się pobrać wideo z Twittera."
-
-#. Translators: Error message when the add-on fails to get a direct download
-#. link for a TikTok video.
-#: addon\globalPlugins\visionAssistant\__init__.py:1603
-msgid "Error: Could not extract TikTok video."
-msgstr "Błąd: nie udało się pobrać wideo z TikToka."
-
-#. Translators: Message reported when the add-on is downloading the video from
-#. the extracted link.
-#: addon\globalPlugins\visionAssistant\__init__.py:1619
-msgid "Downloading Video..."
-msgstr "Pobieranie wideo..."
-
-#. Translators: Error message when downloading the online video fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:1624
-msgid "Error: Download failed."
-msgstr "Błąd: pobieranie nie powiodło się."
-
-#. Translators: Note appended to the API error message when the daily
-#. RequestsPerDay quota limit is reached.
-#: addon\globalPlugins\visionAssistant\__init__.py:1994
-msgid " (RequestsPerDay quota exceeded)"
-msgstr " (przekroczono limit RequestsPerDay)"
-
-#. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\__init__.py:2003
-msgid "Error 400: Bad Request (Check API Key)"
-msgstr "Błąd 400: nieprawidłowe żądanie (sprawdź klucz API)"
-
-#. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\__init__.py:2005
-msgid "Error 403: Forbidden (Check Region)"
-msgstr "Błąd 403: dostęp zabroniony (sprawdź region)"
-
-#. Translators: Message of a dialog which may pop up while performing an AI
-#. call
-#: addon\globalPlugins\visionAssistant\__init__.py:2098
-msgid "Error 429: Quota Exceeded (Try later)"
-msgstr "Błąd 429: przekroczono limit (spróbuj później)"
-
-#. Translators: Message of a dialog which may pop up while performing an AI
-#. call
-#: addon\globalPlugins\visionAssistant\__init__.py:2101
-#: addon\globalPlugins\visionAssistant\__init__.py:2261
-#, python-brace-format
-msgid "Server Error {code}: {reason}"
-msgstr "Błąd serwera {code}: {reason}"
-
-#. Translators: Error prefix shown when the AI response is blocked by safety
-#. filters.
-#: addon\globalPlugins\visionAssistant\__init__.py:2196
-#: addon\globalPlugins\visionAssistant\__init__.py:2211
-#: addon\globalPlugins\visionAssistant\__init__.py:3208
-msgid "Blocked by AI Safety Filters: "
-msgstr "Zablokowane przez filtry bezpieczeństwa AI: "
-
-#. Translators: Error shown when the AI response is blocked during generation.
-#: addon\globalPlugins\visionAssistant\__init__.py:2199
-#: addon\globalPlugins\visionAssistant\__init__.py:2221
-msgid "The response was blocked mid-generation by safety filters."
-msgstr "Filtry bezpieczeństwa zablokowały odpowiedź w trakcie generowania."
-
-#. Translators: Generic error message when Gemini returns an empty response.
-#: addon\globalPlugins\visionAssistant\__init__.py:2201
-#: addon\globalPlugins\visionAssistant\__init__.py:2213
-msgid ""
-"AI failed to provide a response. This might be due to safety filters or a "
-"temporary server issue."
-msgstr ""
-"AI nie zwróciła odpowiedzi. Powodem mogą być filtry bezpieczeństwa lub "
-"chwilowy problem serwera."
-
-#. Translators: Error shown when the response structure is unexpected or
-#. empty.
-#: addon\globalPlugins\visionAssistant\__init__.py:2223
-msgid "AI returned an empty response structure."
-msgstr "AI zwróciła pustą strukturę odpowiedzi."
-
-#. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:2232
-#: addon\globalPlugins\visionAssistant\__init__.py:2513
-msgid "No valid API key available or daily quota exhausted for all keys."
-msgstr ""
-"Brak ważnego klucza API lub wyczerpany dzienny limit dla wszystkich kluczy."
-
-#. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:2265
-msgid "All API Keys failed (Quota/Server)."
-msgstr "Wszystkie klucze API zawiodły (limit/serwer)."
-
-#. Translators: Generic error message when an operation fails for an unknown
-#. reason.
-#: addon\globalPlugins\visionAssistant\__init__.py:2273
-msgid "Unknown error occurred."
-msgstr "Wystąpił nieznany błąd."
-
-#. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\__init__.py:2327
-msgid "No API Keys."
-msgstr "Brak kluczy API."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:2395
-msgid "Upload failed. Rotating key..."
-msgstr "Wysyłanie nie powiodło się. Zmiana klucza..."
-
-#. Translators: Error message for upload failure
-#. Translators: Error message shown when uploading a file fails
-#. Translators: Error message shown when uploading the video to the AI server
-#. fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:2400
-#: addon\globalPlugins\visionAssistant\__init__.py:3477
-#: addon\globalPlugins\visionAssistant\__init__.py:5996
-#: addon\globalPlugins\visionAssistant\__init__.py:6006
-#: addon\globalPlugins\visionAssistant\__init__.py:10392
-msgid "Upload failed."
-msgstr "Przesyłanie nie powiodło się."
-
-#. Translators: Message shown when an API rate limit is reached. {sec} is the
-#. number of seconds to wait.
-#: addon\globalPlugins\visionAssistant\__init__.py:2436
-#: addon\globalPlugins\visionAssistant\__init__.py:2762
-#, python-brace-format
-msgid "Rate limit reached. Waiting {sec}s before retry..."
-msgstr "Osiągnięto limit zapytań. Czekam {sec}s przed ponowną próbą..."
-
-#. Translators: Status message indicating an API request retry due to a
-#. temporary error for specific pages. {error} is replaced with details,
-#. {range} is the page range, {current} and {total} are attempts.
-#: addon\globalPlugins\visionAssistant\__init__.py:2448
-#, python-brace-format
-msgid ""
-"Temporary error ({error}). Retrying API request for pages {range} (Attempt "
-"{current}/{total})..."
-msgstr ""
-"Błąd tymczasowy ({error}). Ponawianie zapytania API dla stron {range} (próba"
-" {current}/{total})..."
-
-#. Translators: Status message indicating an API request retry due to a
-#. temporary error. {error} is replaced with details, {current} and {total}
-#. are attempts.
-#: addon\globalPlugins\visionAssistant\__init__.py:2451
-#: addon\globalPlugins\visionAssistant\__init__.py:2770
-#, python-brace-format
-msgid ""
-"Temporary error ({error}). Retrying on current key (Attempt "
-"{current}/{total})..."
-msgstr ""
-"Błąd tymczasowy ({error}). Ponawianie na bieżącym kluczu (próba "
-"{current}/{total})..."
-
-#. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:2460
-#: addon\globalPlugins\visionAssistant\__init__.py:2475
-msgid "All keys failed."
-msgstr "Wszystkie klucze zawiodły."
-
-#. Translators: Message reported when API quota is exhausted and the system
-#. rotates key.
-#: addon\globalPlugins\visionAssistant\__init__.py:2470
-#: addon\globalPlugins\visionAssistant\__init__.py:2785
-msgid ""
-"Daily quota exhausted or retries failed. Rotating key and re-uploading..."
-msgstr ""
-"Wyczerpany dzienny limit lub nieudane ponowne próby. Zmiana klucza i ponowne"
-" wysyłanie..."
-
-#. Translators: Status message indicating video upload progress with file size
-#. in MB.
-#: addon\globalPlugins\visionAssistant\__init__.py:2670
-#, python-brace-format
-msgid "Uploading to AI ({size:.1f} MB)..."
-msgstr "Wysyłanie do AI ({size:.1f} MB)..."
-
-#. Translators: Status message indicating video upload progress with file size
-#. in MB and retry attempt numbers.
-#: addon\globalPlugins\visionAssistant\__init__.py:2703
-#, python-brace-format
-msgid "Uploading to AI ({size:.1f} MB) (Key {current}/{total})..."
-msgstr "Wysyłanie do AI ({size:.1f} MB) (klucz {current}/{total})..."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:2708
-msgid "Upload failed. Retrying..."
-msgstr "Wysyłanie nie powiodło się. Ponawianie..."
-
-#. Translators: Error shown internally when AI stops early
-#: addon\globalPlugins\visionAssistant\__init__.py:2739
-msgid "Incomplete description. AI stopped early."
-msgstr "Niepełny opis. AI zatrzymała się przedwcześnie."
-
-#. Translators: Message reported when all available API keys have reached
-#. their usage limits.
-#: addon\globalPlugins\visionAssistant\__init__.py:2789
-msgid "All API keys exhausted or server unavailable."
-msgstr "Wszystkie klucze API wyczerpane lub serwer niedostępny."
-
-#. Translators: Error message shown when all API keys run out of quota or
-#. fail.
-#: addon\globalPlugins\visionAssistant\__init__.py:2799
-msgid "All API keys failed or daily quota exhausted."
-msgstr "Wszystkie klucze API zawiodły lub wyczerpano dzienny limit."
-
-#. Translators: Error when no API keys are found in settings
-#. Translators: Error message shown when the user attempts an AI operation
-#. without configuring any API keys in the settings.
-#. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\__init__.py:3105
-#: addon\globalPlugins\visionAssistant\__init__.py:3238
-#: addon\globalPlugins\visionAssistant\__init__.py:3355
-#: addon\globalPlugins\visionAssistant\__init__.py:3423
-#: addon\globalPlugins\visionAssistant\__init__.py:4131
-#: addon\globalPlugins\visionAssistant\__init__.py:6474
-#: addon\globalPlugins\visionAssistant\__init__.py:6694
-#: addon\globalPlugins\visionAssistant\__init__.py:6804
-msgid "No API Keys configured."
-msgstr "Nie skonfigurowano kluczy API."
-
-#. Translators: Error message shown when the AI returns an unknown error
-#. Translators: Fallback error message shown in the AI Operator if the server
-#. returns an empty or invalid response.
-#: addon\globalPlugins\visionAssistant\__init__.py:3210
-#: addon\globalPlugins\visionAssistant\__init__.py:11435
-msgid "AI Error"
-msgstr "Błąd AI"
-
-#. Translators: Error message when speech-to-text fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:3342
-msgid "Transcription Failed"
-msgstr "Transkrypcja nie powiodła się"
-
-#. Translators: Error message when TTS is not supported by the provider
-#: addon\globalPlugins\visionAssistant\__init__.py:3348
-msgid "TTS is not supported by this provider."
-msgstr "Ten dostawca nie obsługuje syntezy mowy."
-
-#. Translators: Error shown when the live voice session fails to connect.
-#. {error} is replaced with the specific error detail.
-#: addon\globalPlugins\visionAssistant\__init__.py:4171
-#, python-brace-format
-msgid "Could not connect to the Live service: {error}"
-msgstr "Nie udało się połączyć z usługą asystenta głosowego: {error}"
-
-#. Translators: Error shown when the microphone cannot be opened for the live
-#. session.
-#: addon\globalPlugins\visionAssistant\__init__.py:4216
-msgid "Could not open the microphone."
-msgstr "Nie udało się otworzyć mikrofonu."
-
-#. Translators: Line shown when the live server unexpectedly closes the
-#. connection. {reason} is the server's reason.
-#: addon\globalPlugins\visionAssistant\__init__.py:4271
-#, python-brace-format
-msgid "[Connection closed: {reason}]"
-msgstr "[Połączenie zamknięte: {reason}]"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:4271
-msgid "unknown"
-msgstr "nieznany"
-
-#. Translators: Message announced by NVDA when the live voice conversation
-#. starts.
-#: addon\globalPlugins\visionAssistant\__init__.py:4286
-msgid "Live conversation started. You can speak now."
-msgstr "Rozmowa głosowa rozpoczęta. Możesz teraz mówić."
-
-#. Translators: Prefix for the user's transcribed speech line in the Live
-#. Assistant history.
-#: addon\globalPlugins\visionAssistant\__init__.py:4333
-msgid "You: "
-msgstr "Ty: "
-
-#. Translators: Prefix for an AI message line in the Live Assistant history.
-#. Translators: Spoken prefix for AI response
-#: addon\globalPlugins\visionAssistant\__init__.py:4338
-#: addon\globalPlugins\visionAssistant\__init__.py:4354
-#: addon\globalPlugins\visionAssistant\__init__.py:6133
-msgid "AI: "
-msgstr "AI: "
-
-#. Translators: Title of the Live Assistant conversation window.
-#: addon\globalPlugins\visionAssistant\__init__.py:4398
-#, python-brace-format
-msgid "{name} - Live Assistant"
-msgstr "{name} - Asystent głosowy"
-
-#. Translators: Label for the conversation history area in the Live Assistant
-#. window.
-#: addon\globalPlugins\visionAssistant\__init__.py:4409
-msgid "Conversation:"
-msgstr "Rozmowa:"
-
-#. Translators: Label for TTS Voice selection in the Live Assistant window.
-#: addon\globalPlugins\visionAssistant\__init__.py:4415
-msgid "&TTS Voice:"
-msgstr "Głos &TTS:"
-
-#. Translators: Label for Thinking Depth selection in the Live Assistant
-#. window.
-#: addon\globalPlugins\visionAssistant\__init__.py:4433
-msgid "Thinking &Depth:"
-msgstr "Głębia &myślenia:"
-
-#. Translators: Thinking level option for no reasoning (lowest latency)
-#: addon\globalPlugins\visionAssistant\__init__.py:4437
-msgid "Minimal (Fastest)"
-msgstr "Minimalna (najszybsza)"
-
-#. Translators: Thinking level option for slight reasoning
-#: addon\globalPlugins\visionAssistant\__init__.py:4439
-msgid "Low (Agentic)"
-msgstr "Niska (agentowa)"
-
-#. Translators: Thinking level option for standard reasoning (balanced)
-#: addon\globalPlugins\visionAssistant\__init__.py:4441
-msgid "Medium (Balanced)"
-msgstr "Średnia (zrównoważona)"
-
-#. Translators: Thinking level option for deep reasoning
-#: addon\globalPlugins\visionAssistant\__init__.py:4443
-msgid "High (Deep)"
-msgstr "Wysoka (głęboka)"
-
-#. Translators: Button that ends the live voice conversation.
-#. Translators: Button label to end the live conversation / Button label to
-#. start it again.
-#: addon\globalPlugins\visionAssistant\__init__.py:4459
-#: addon\globalPlugins\visionAssistant\__init__.py:4516
-msgid "&End"
-msgstr "&Zakończ"
-
-#. Translators: Message shown in conversation log when voice is changed
-#: addon\globalPlugins\visionAssistant\__init__.py:4479
-msgid "--- Changing voice, reconnecting... ---"
-msgstr "--- Zmiana głosu, ponowne łączenie... ---"
-
-#. Translators: Message shown in conversation log when thinking depth is
-#. changed
-#: addon\globalPlugins\visionAssistant\__init__.py:4488
-msgid "--- Changing thinking depth, reconnecting... ---"
-msgstr "--- Zmiana głębi myślenia, ponowne łączenie... ---"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:4516
-msgid "&Start"
-msgstr "&Rozpocznij"
-
-#. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4536
-msgid "Update Available"
-msgstr "Dostępna jest aktualizacja"
-
-#. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\__init__.py:4543
-#, python-brace-format
-msgid "A new version ({version}) of {name} is available."
-msgstr "Dostępna jest nowa wersja ({version}) dodatku {name}."
-
-#. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\__init__.py:4548
-msgid "Changes:"
-msgstr "Zmiany:"
-
-#. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\__init__.py:4555
-msgid "Download and Install?"
-msgstr "Pobrać i zainstalować?"
-
-#. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\__init__.py:4560
-msgid "&Yes"
-msgstr "&Tak"
-
-#. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\__init__.py:4562
-msgid "&No"
-msgstr "&Nie"
-
-#. Translators: Error message when an update is found but the addon file is
-#. missing from GitHub.
-#: addon\globalPlugins\visionAssistant\__init__.py:4605
-msgid "Update found but no .nvda-addon file in release."
-msgstr "Znaleziono aktualizację, ale brak pliku .nvda-addon w wydaniu."
-
-#. Translators: Status message informing the user they are already on the
-#. latest version.
-#: addon\globalPlugins\visionAssistant\__init__.py:4609
-msgid "You have the latest version."
-msgstr "Masz najnowszą wersję."
-
-#. Translators: Error message shown when the add-on fails to check for
-#. updates. The {error} placeholder is replaced with specific error details.
-#: addon\globalPlugins\visionAssistant\__init__.py:4614
-#, python-brace-format
-msgid "Update check failed: {error}"
-msgstr "Sprawdzanie aktualizacji nie powiodło się: {error}"
-
-#. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\__init__.py:4642
-msgid "Downloading update..."
-msgstr "Pobieranie aktualizacji..."
-
-#. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\__init__.py:4651
-#, python-brace-format
-msgid "Download failed: {error}"
-msgstr "Pobieranie nie powiodło się: {error}"
-
-#. Translators: Label for the AI response text area in a chat dialog
-#. Translators: Label for AI Response Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:4671
-#: addon\globalPlugins\visionAssistant\__init__.py:5121
-msgid "AI Response:"
-msgstr "Odpowiedź AI:"
-
-#. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4681
-#: addon\globalPlugins\visionAssistant\__init__.py:4776
-#: addon\globalPlugins\visionAssistant\__init__.py:4793
-#, python-brace-format
-msgid "AI: {text}\n"
-msgstr "AI: {text}\n"
-
-#. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4692
-msgid "Ask:"
-msgstr "Zapytaj:"
-
-#. Translators: Button to send message in a chat dialog
-#. Translators: Button to send message
-#: addon\globalPlugins\visionAssistant\__init__.py:4702
-#: addon\globalPlugins\visionAssistant\__init__.py:5971
-msgid "Send"
-msgstr "Wyślij"
-
-#. Translators: Button to view the content in a formatted HTML window
-#. Translators: Button to view formatted content
-#: addon\globalPlugins\visionAssistant\__init__.py:4704
-#: addon\globalPlugins\visionAssistant\__init__.py:6231
-msgid "View Formatted"
-msgstr "Podgląd sformatowany"
-
-#. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:4707
-msgid "Save Content"
-msgstr "Zapisz treść odpowiedzi"
-
-#. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4710
-msgid "Save Chat"
-msgstr "Zapisz pełny czat"
-
-#. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4745
-#: addon\globalPlugins\visionAssistant\__init__.py:4791
-#, python-brace-format
-msgid ""
-"\n"
-"You: {text}\n"
-msgstr ""
-"\n"
-"Ty: {text}\n"
-
-#. Translators: Message shown while processing in a chat dialog
-#. Translators: Message showing AI is thinking
-#: addon\globalPlugins\visionAssistant\__init__.py:4749
-#: addon\globalPlugins\visionAssistant\__init__.py:6033
-msgid "Thinking..."
-msgstr "Przetwarzanie..."
-
-#. Translators: Initial status when the add-on is doing nothing
-#. Translators: Status message when the addon is idle.
-#: addon\globalPlugins\visionAssistant\__init__.py:4761
-#: addon\globalPlugins\visionAssistant\__init__.py:6044
-#: addon\globalPlugins\visionAssistant\__init__.py:6099
-#: addon\globalPlugins\visionAssistant\__init__.py:6137
-#: addon\globalPlugins\visionAssistant\__init__.py:6184
-#: addon\globalPlugins\visionAssistant\__init__.py:6293
-#: addon\globalPlugins\visionAssistant\__init__.py:6595
-#: addon\globalPlugins\visionAssistant\__init__.py:6677
-#: addon\globalPlugins\visionAssistant\__init__.py:6758
-#: addon\globalPlugins\visionAssistant\__init__.py:6775
-#: addon\globalPlugins\visionAssistant\__init__.py:6789
-#: addon\globalPlugins\visionAssistant\__init__.py:6795
-#: addon\globalPlugins\visionAssistant\__init__.py:8189
-#: addon\globalPlugins\visionAssistant\__init__.py:8211
-#: addon\globalPlugins\visionAssistant\__init__.py:8302
-#: addon\globalPlugins\visionAssistant\__init__.py:8564
-#: addon\globalPlugins\visionAssistant\__init__.py:8958
-#: addon\globalPlugins\visionAssistant\__init__.py:8963
-#: addon\globalPlugins\visionAssistant\__init__.py:8967
-#: addon\globalPlugins\visionAssistant\__init__.py:8973
-#: addon\globalPlugins\visionAssistant\__init__.py:8980
-#: addon\globalPlugins\visionAssistant\__init__.py:9031
-#: addon\globalPlugins\visionAssistant\__init__.py:9041
-#: addon\globalPlugins\visionAssistant\__init__.py:9045
-#: addon\globalPlugins\visionAssistant\__init__.py:9236
-#: addon\globalPlugins\visionAssistant\__init__.py:9371
-#: addon\globalPlugins\visionAssistant\__init__.py:9374
-#: addon\globalPlugins\visionAssistant\__init__.py:9685
-#: addon\globalPlugins\visionAssistant\__init__.py:9770
-#: addon\globalPlugins\visionAssistant\__init__.py:9919
-#: addon\globalPlugins\visionAssistant\__init__.py:9922
-#: addon\globalPlugins\visionAssistant\__init__.py:9926
-#: addon\globalPlugins\visionAssistant\__init__.py:9947
-#: addon\globalPlugins\visionAssistant\__init__.py:9950
-#: addon\globalPlugins\visionAssistant\__init__.py:10059
-#: addon\globalPlugins\visionAssistant\__init__.py:10073
-#: addon\globalPlugins\visionAssistant\__init__.py:10076
-#: addon\globalPlugins\visionAssistant\__init__.py:10080
-#: addon\globalPlugins\visionAssistant\__init__.py:10368
-#: addon\globalPlugins\visionAssistant\__init__.py:10384
-#: addon\globalPlugins\visionAssistant\__init__.py:10393
-#: addon\globalPlugins\visionAssistant\__init__.py:10608
-#: addon\globalPlugins\visionAssistant\__init__.py:10612
-#: addon\globalPlugins\visionAssistant\__init__.py:10779
-#: addon\globalPlugins\visionAssistant\__init__.py:10788
-#: addon\globalPlugins\visionAssistant\__init__.py:10978
-#: addon\globalPlugins\visionAssistant\__init__.py:11000
-#: addon\globalPlugins\visionAssistant\__init__.py:11006
-#: addon\globalPlugins\visionAssistant\__init__.py:11051
-#: addon\globalPlugins\visionAssistant\__init__.py:11055
-#: addon\globalPlugins\visionAssistant\__init__.py:11063
-#: addon\globalPlugins\visionAssistant\__init__.py:11487
-#: addon\globalPlugins\visionAssistant\__init__.py:11766
-#: addon\globalPlugins\visionAssistant\__init__.py:11780
-#: addon\globalPlugins\visionAssistant\__init__.py:11880
-#: addon\globalPlugins\visionAssistant\__init__.py:11897
-msgid "Idle"
-msgstr "Bezczynny"
-
-#. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:4813
-msgid "Formatted Conversation"
-msgstr "Sformatowana rozmowa"
-
-#. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\__init__.py:4816
-#, python-brace-format
-msgid "Error displaying content: {error}"
-msgstr "Błąd wyświetlania treści: {error}"
-
-#. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:4821
-msgid "Save Chat Log"
-msgstr "Zapisz dziennik czatu"
-
-#. Translators: Message shown on successful save of a file.
-#. Translators: Message on successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:4826
-#: addon\globalPlugins\visionAssistant\__init__.py:4840
-msgid "Saved."
-msgstr "Zapisano."
-
-#. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:4829
-#: addon\globalPlugins\visionAssistant\__init__.py:4843
-#, python-brace-format
-msgid "Save failed: {error}"
-msgstr "Zapisywanie nie powiodło się: {error}"
-
-#. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\__init__.py:4834
-msgid "Save Result"
-msgstr "Zapisywanie wyniku"
-
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\__init__.py:4854
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:43
 msgid "Connection"
 msgstr "Połączenie"
 
 #. Translators: Name of the Google Gemini AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:4861
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:50
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
 #. Translators: Name of the OpenAI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:4863
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:52
 msgid "OpenAI"
 msgstr "OpenAI"
 
 #. Translators: Name of the Mistral AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:4865
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:54
 msgid "Mistral AI"
 msgstr "Mistral AI"
 
 #. Translators: Name of the Groq AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:4867
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:56
 msgid "Groq"
 msgstr "Groq"
 
 #. Translators: Name of the MiniMax AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:4869
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:58
 msgid "MiniMax"
 msgstr "MiniMax"
 
 #. Translators: Option for a user-defined custom AI provider
-#: addon\globalPlugins\visionAssistant\__init__.py:4871
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:60
 msgid "Custom"
 msgstr "Niestandardowy"
 
 #. Translators: Label for AI Provider selection
-#: addon\globalPlugins\visionAssistant\__init__.py:4874
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:63
 msgid "Provider:"
 msgstr "Dostawca:"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\__init__.py:4882
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:71
 msgid "API Key (Separate multiple keys with comma or newline):"
 msgstr "Klucz API (rozdziel wiele kluczy przecinkiem lub nową linią):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\__init__.py:4893
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:82
 msgid "Show API Key"
 msgstr "Pokaż klucz API"
 
 #. Custom Fields Box
 #. Translators: Static box title for custom AI provider settings
-#: addon\globalPlugins\visionAssistant\__init__.py:4899
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:88
 msgid "Custom Provider Settings"
 msgstr "Ustawienia niestandardowego dostawcy"
 
 #. Translators: Button label to automatically configure local AI engines
 #. (Ollama, LM Studio, etc.)
-#. Translators: Title of the local AI setup dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:4903
-#: addon\globalPlugins\visionAssistant\__init__.py:5442
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:91 addon\globalPlugins\visionAssistant\dialogs\settings.py:738
 msgid "Setup Local AI"
 msgstr "Konfiguracja lokalnej AI"
 
 #. Translators: Label for Custom API URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:4908
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:96
 msgid "API URL:"
 msgstr "Adres URL API:"
 
 #. Translators: Label for Custom API Type selection
-#: addon\globalPlugins\visionAssistant\__init__.py:4913
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:101
 msgid "API Type:"
 msgstr "Typ API:"
 
 #. Translators: AI API compatibility types
-#: addon\globalPlugins\visionAssistant\__init__.py:4915
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:103
 msgid "OpenAI Compatible"
 msgstr "Zgodny z OpenAI"
 
-#: addon\globalPlugins\visionAssistant\__init__.py:4915
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:103
 msgid "Gemini Compatible"
 msgstr "Zgodny z Gemini"
 
 #. Translators: Label for Custom Model Name input
-#: addon\globalPlugins\visionAssistant\__init__.py:4921
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:109
 msgid "Model Name (Manual):"
 msgstr "Nazwa modelu (ręcznie):"
 
 #. Translators: Checkbox to indicate if custom provider supports file upload
-#: addon\globalPlugins\visionAssistant\__init__.py:4927
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:115
 msgid "Supports File Upload"
 msgstr "Obsługuje przesyłanie plików"
 
 #. Advanced Endpoints Section
 #. Translators: Checkbox to toggle advanced endpoint URLs
-#: addon\globalPlugins\visionAssistant\__init__.py:4934
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:122
 msgid "Advanced Endpoint Configuration"
 msgstr "Adresy usług"
 
 #. Translators: Label for Custom Models List URL
-#: addon\globalPlugins\visionAssistant\__init__.py:4943
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:131
 msgid "Models List URL:"
 msgstr "URL listy modeli:"
 
 #. Translators: Label for Custom OCR URL
-#: addon\globalPlugins\visionAssistant\__init__.py:4948
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:136
 msgid "OCR Endpoint URL:"
 msgstr "URL punktu końcowego OCR:"
 
 #. Translators: Label for Custom OCR Model
-#: addon\globalPlugins\visionAssistant\__init__.py:4953
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:141
 msgid "Custom OCR Model (Optional):"
 msgstr "Niestandardowy model OCR (opcjonalnie):"
 
 #. Translators: Label for Custom STT URL
-#: addon\globalPlugins\visionAssistant\__init__.py:4959
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:147
 msgid "Speech-to-Text (STT) URL:"
 msgstr "URL rozpoznawania mowy (STT):"
 
 #. Translators: Label for Custom STT Model
-#: addon\globalPlugins\visionAssistant\__init__.py:4964
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:152
 msgid "Custom STT Model (Optional):"
 msgstr "Niestandardowy model STT (opcjonalnie):"
 
 #. Translators: Label for Custom TTS URL
-#: addon\globalPlugins\visionAssistant\__init__.py:4970
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:158
 msgid "Text-to-Speech (TTS) URL:"
 msgstr "URL syntezy mowy (TTS):"
 
 #. Translators: Label for Custom TTS Model
-#: addon\globalPlugins\visionAssistant\__init__.py:4975
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:163
 msgid "Custom TTS Model (Optional):"
 msgstr "Niestandardowy model TTS (opcjonalnie):"
 
 #. Translators: Label for a text field in the "Custom Provider Settings"
 #. section of settings where the user enters the AI Operator URL.
-#: addon\globalPlugins\visionAssistant\__init__.py:4981
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:169
 msgid "AI Operator URL:"
 msgstr "URL Operatora AI:"
 
 #. Translators: Label for a text field in the "Custom Provider Settings"
 #. section of settings where the user manually enters the model name for AI
 #. Operator.
-#: addon\globalPlugins\visionAssistant\__init__.py:4986
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:174
 msgid "Custom Operator Model (Optional):"
 msgstr "Niestandardowy model Operatora (opcjonalne):"
 
 #. Translators: Label for Custom TTS Voice Name
-#: addon\globalPlugins\visionAssistant\__init__.py:4992
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:180
 msgid "Custom TTS Voice Name (Optional):"
 msgstr "Niestandardowa nazwa głosu TTS (opcjonalnie):"
 
 #. Standard Fetch & Model Logic
 #. Translators: Button to fetch available models from the selected provider
-#: addon\globalPlugins\visionAssistant\__init__.py:5003
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:191
 msgid "Fetch Models"
 msgstr "Pobierz modele"
 
 #. Translators: Label for AI Model selection choice box
-#. Translators: Accessible name for the AI model selection combo box.
-#: addon\globalPlugins\visionAssistant\__init__.py:5008
-#: addon\globalPlugins\visionAssistant\__init__.py:5011
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:195 addon\globalPlugins\visionAssistant\dialogs\settings.py:198
 msgid "AI Model:"
 msgstr "Model AI:"
 
 #. Advanced Model Routing Box
 #. Translators: Checkbox to toggle advanced model routing
-#: addon\globalPlugins\visionAssistant\__init__.py:5017
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:204
 msgid "Advanced Model Routing (Task-specific)"
 msgstr "Osobny model dla każdego zadania"
 
 #. Translators: Label for OCR model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:5024
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:211
 msgid "OCR / Vision Model:"
 msgstr "Model dla OCR / rozpoznawania obrazów:"
 
 #. Translators: Label for STT model selection
-#: addon\globalPlugins\visionAssistant\__init__.py:5031
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:218
 msgid "Speech-to-Text (STT) Model:"
 msgstr "Model rozpoznawania mowy (STT):"
 
 #. Translators: Label for TTS model selection (Assigning to self to toggle
 #. visibility)
-#: addon\globalPlugins\visionAssistant\__init__.py:5038
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:225
 msgid "Text-to-Speech (TTS) Model:"
 msgstr "Model syntezy mowy (TTS):"
 
 #. Translators: Label for a dropdown menu in the "Advanced Model Routing"
 #. section of settings to choose a specific model for AI Operator tasks.
-#: addon\globalPlugins\visionAssistant\__init__.py:5045
-msgid "AI Operator Model:"
-msgstr "Model Operatora AI:"
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:232
+msgid "AI Operator / CAPTCHA Model:"
+msgstr "Model Operatora AI i CAPTCHA:"
 
 #. Translators: Label for the Video Analysis model selection in the Advanced
 #. Model Routing section.
-#: addon\globalPlugins\visionAssistant\__init__.py:5051
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:238
 msgid "Video Analysis Model (Gemini only):"
 msgstr "Model analizy wideo (tylko Gemini):"
 
 #. Translators: Label for the Live Assistant model selection in the Advanced
 #. Model Routing section (Gemini only).
-#: addon\globalPlugins\visionAssistant\__init__.py:5058
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:245
 msgid "Live Assistant Model (Gemini only):"
 msgstr "Model asystenta głosowego (tylko Gemini):"
 
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\__init__.py:5068
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:255
 msgid "Proxy URL:"
-msgstr "Adres URl servera proxy:"
+msgstr "Adres URL serwera proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on startup
-#: addon\globalPlugins\visionAssistant\__init__.py:5072
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:259
 msgid "Check for updates on startup"
 msgstr "Sprawdzaj aktualizacje przy uruchomieniu"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\__init__.py:5075
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:262
 msgid "Clean Markdown in Chat"
 msgstr "Czyść Markdown w czacie"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:5078
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:265
 msgid "Copy AI responses to clipboard"
 msgstr "Kopiuj odpowiedzi AI do schowka"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\__init__.py:5081
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:268
 msgid "Direct Output (No Chat Window)"
 msgstr "Tryb bezpośredni (nie pokazuje okna czatu)"
 
 #. Translators: Checkbox to start the Live Assistant without its conversation
 #. window (open it later with the Show Last Result key).
-#: addon\globalPlugins\visionAssistant\__init__.py:5084
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:271
 msgid "Live Assistant: Direct Output (No Window)"
 msgstr "Asystent głosowy: tryb bezpośredni (bez okna)"
 
 #. --- AI Behavior Group ---
 #. Translators: Title of the settings group for AI behavior
-#: addon\globalPlugins\visionAssistant\__init__.py:5090
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:278 addon\globalPlugins\visionAssistant\dialogs\settings.py:680
 msgid "AI Behavior"
 msgstr "Zachowanie AI"
 
 #. Translators: Label for AI Temperature setting
-#: addon\globalPlugins\visionAssistant\__init__.py:5095
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:283
 msgid "Creativity (Temperature, does not affect OCR/Translation):"
 msgstr "Kreatywność (temperatura, nie wpływa na OCR/tłumaczenie):"
 
 #. --- Translation Languages Group ---
 #. Translators: Title of the settings group for translation languages
 #. configuration
-#: addon\globalPlugins\visionAssistant\__init__.py:5106
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:295
 msgid "Translation Languages"
 msgstr "Języki tłumaczenia"
 
-#. Translators: Label for Source Language selection
-#: addon\globalPlugins\visionAssistant\__init__.py:5111
-msgid "Source:"
-msgstr "Źródłowy:"
-
-#. Translators: Label for Target Language selection
-#. Translators: Label for target language
-#: addon\globalPlugins\visionAssistant\__init__.py:5116
-#: addon\globalPlugins\visionAssistant\__init__.py:5908
-msgid "Target:"
-msgstr "Docelowy:"
-
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\__init__.py:5126
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:314
 msgid "Smart Swap"
 msgstr "Zamiana"
 
-#. --- Document Reader Settings ---
-#. Translators: Title of settings group for Document Reader features
-#. Translators: Title of the Document Reader window.
-#: addon\globalPlugins\visionAssistant\__init__.py:5132
-#: addon\globalPlugins\visionAssistant\__init__.py:6142
-msgid "Document Reader"
-msgstr "Czytnik dokumentów"
-
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\__init__.py:5137
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:326
 msgid "OCR Engine:"
 msgstr "Silnik OCR:"
 
 #. Translators: Label for the OCR batch size setting. Set to 0 to process all
 #. pages in a single request.
-#: addon\globalPlugins\visionAssistant\__init__.py:5145
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:334
 msgid "OCR Batch Size (Pages per request, 0 to disable):"
 msgstr "Porcja OCR (stron na żądanie, 0 = wyłączone):"
 
-#. Translators: Label for TTS Voice selection (Assigning to self to toggle
-#. visibility)
-#. Translators: Label for TTS Voice selection
-#: addon\globalPlugins\visionAssistant\__init__.py:5151
-#: addon\globalPlugins\visionAssistant\__init__.py:6245
-msgid "TTS Voice:"
-msgstr "Głos TTS:"
+#. Translators: Label for the checkbox that enables image descriptions during
+#. OCR
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:340
+msgid "Describe images inline during document OCR"
+msgstr "Wplataj opisy obrazów w tekst podczas OCR dokumentu"
+
+#. Translators: Label for the checkbox that enables page numbers when
+#. exporting documents
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:345
+msgid "Include page numbers when exporting documents"
+msgstr "Dołączaj numery stron przy eksporcie dokumentów"
 
 #. Translators: Label for Video Chunk Size setting. Explains the trade-off
 #. between chunk size, API requests, and description quality.
-#: addon\globalPlugins\visionAssistant\__init__.py:5167
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:365
 msgid ""
 "Video Chunk Size for Audio Description (Minutes, 0 to disable):\n"
 "Tip: Higher values use fewer API requests but rely on luck to succeed. Lower values guarantee highly detailed and precise descriptions."
@@ -1842,1819 +2705,1047 @@ msgstr ""
 "Rozmiar fragmentu wideo dla audiodeskrypcji (minuty, 0 wyłącza):\n"
 "Wskazówka: wyższe wartości zużywają mniej zapytań API, ale ich powodzenie zależy od szczęścia. Niższe wartości gwarantują bardzo szczegółowe i precyzyjne opisy."
 
-#. Translators: Checkbox label to add character list as the first subtitle in
-#. video SRT output.
-#: addon\globalPlugins\visionAssistant\__init__.py:5173
-#: addon\globalPlugins\visionAssistant\__init__.py:7141
-msgid "Add character list as first subtitle"
-msgstr "Dodaj listę postaci jako pierwszy napis"
-
-#. Translators: Checkbox label to add an AI warning disclaimer at the
-#. beginning of the video SRT output.
-#: addon\globalPlugins\visionAssistant\__init__.py:5178
-#: addon\globalPlugins\visionAssistant\__init__.py:7147
-msgid "Add AI disclaimer at the beginning"
-msgstr "Dodaj zastrzeżenie AI na początku"
+#. Translators: Label for the checkbox that enables or disables the automated
+#. CAPTCHA solver feature.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:389
+msgid "Enable Visual CAPTCHA Solver"
+msgstr "Włącz rozwiązywanie CAPTCHA obrazkowej"
 
 #. Translators: Label for CAPTCHA capture method selection.
-#: addon\globalPlugins\visionAssistant\__init__.py:5191
-msgid "Capture Method:"
-msgstr "Metoda przechwytywania:"
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:393
+msgid "Text CAPTCHA Method:"
+msgstr "Metoda dla CAPTCHA tekstowej:"
 
 #. Translators: A choice for capture method. Captures only the specific object
 #. under the cursor.
-#: addon\globalPlugins\visionAssistant\__init__.py:5193
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:395 addon\globalPlugins\visionAssistant\features\quick_settings.py:51
 msgid "Navigator Object"
 msgstr "Obiekt nawigatora"
 
 #. Translators: A choice for capture method. Captures the entire visible
 #. screen area.
-#: addon\globalPlugins\visionAssistant\__init__.py:5195
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:397 addon\globalPlugins\visionAssistant\features\quick_settings.py:51
 msgid "Full Screen"
 msgstr "Cały ekran"
 
 #. --- Prompts Group ---
 #. Translators: Title of the settings group for prompt management.
-#: addon\globalPlugins\visionAssistant\__init__.py:5206
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:409
 msgid "Prompts"
 msgstr "Polecenia"
 
 #. Translators: Description for the prompt manager button.
-#: addon\globalPlugins\visionAssistant\__init__.py:5211
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:414
 msgid "Manage default and custom prompts."
 msgstr "Zarządzaj domyślnymi i niestandardowymi poleceniami."
 
 #. Translators: Button label to open prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:5213
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:416
 msgid "Manage Prompts..."
 msgstr "Zarządzaj poleceniami..."
 
+#. Translators: Checkbox label to enable dedicated add-on logging to file
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:433
+msgid "Enable dedicated log file"
+msgstr "Włącz osobny plik dziennika"
+
+#. Translators: Log level choice: Debug (Logs all detailed technical events,
+#. API calls, and raw responses)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:438
+msgid "Debug (All Details)"
+msgstr "Diagnostyka (wszystkie szczegóły)"
+
+#. Translators: Log level choice: Info (Logs general operational events and
+#. task completions)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:440
+msgid "Info (General Information)"
+msgstr "Informacje (ogólne)"
+
+#. Translators: Log level choice: Warning (Logs warnings and non-fatal
+#. retries)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:442
+msgid "Warning (Warnings Only)"
+msgstr "Ostrzeżenia (tylko ostrzeżenia)"
+
+#. Translators: Log level choice: Error (Logs errors and critical exceptions
+#. only)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:444
+msgid "Error (Errors Only)"
+msgstr "Błędy (tylko błędy)"
+
+#. Translators: Label for Log Level selection
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:447
+msgid "Log Level:"
+msgstr "Poziom szczegółowości dziennika:"
+
+#. Translators: Label for Log Retention Duration selection
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:457
+msgid "Keep Logs For:"
+msgstr "Przechowuj dziennik przez:"
+
+#. Log management buttons
+#. Translators: Group box title for log management buttons
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:467
+msgid "Log Management"
+msgstr "Zarządzanie dziennikiem"
+
+#. Translators: Button to open log file
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:471
+msgid "Open Log File"
+msgstr "Otwórz plik dziennika"
+
+#. Translators: Button to open log folder
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:476
+msgid "Open Log Folder"
+msgstr "Otwórz folder dziennika"
+
+#. Translators: Button to clear log file
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:481
+msgid "Clear Log File"
+msgstr "Wyczyść plik dziennika"
+
 #. Translators: Summary text for prompt counts in settings.
-#: addon\globalPlugins\visionAssistant\__init__.py:5273
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:543
 #, python-brace-format
 msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
 msgstr "Polecenia domyślne: {defaultCount}, niestandardowe: {customCount}"
 
 #. Translators: Prompt message to select local AI engine
-#: addon\globalPlugins\visionAssistant\__init__.py:5444
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:740
 msgid "Select the local AI engine you are running:"
 msgstr "Wybierz uruchomiony silnik lokalnej AI:"
 
 #. Translators: Progress message shown when testing connection to local AI
-#: addon\globalPlugins\visionAssistant\__init__.py:5465
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:761
 msgid "Connecting to Local AI..."
 msgstr "Łączenie z lokalną AI..."
 
 #. Translators: Error message when connection to local AI fails
-#: addon\globalPlugins\visionAssistant\__init__.py:5494
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:792
 #, python-brace-format
-msgid ""
-"Could not connect to the selected local AI. Make sure it is running on {url}"
-msgstr ""
-"Nie udało się połączyć z wybraną lokalną AI. Upewnij się, że działa pod "
-"adresem {url}"
+msgid "Could not connect to the selected local AI. Make sure it is running on {url}"
+msgstr "Nie udało się połączyć z wybraną lokalną AI. Upewnij się, że działa pod adresem {url}"
 
 #. Translators: Announcement message when local AI setup succeeds
-#: addon\globalPlugins\visionAssistant\__init__.py:5507
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:805
 msgid "Local AI configured successfully!"
 msgstr "Lokalna AI skonfigurowana pomyślnie!"
 
-#. Translators: Title of an error dialog box
-#: addon\globalPlugins\visionAssistant\__init__.py:5511
-#: addon\globalPlugins\visionAssistant\__init__.py:5831
-#: addon\globalPlugins\visionAssistant\__init__.py:6474
-#: addon\globalPlugins\visionAssistant\__init__.py:6687
-#: addon\globalPlugins\visionAssistant\__init__.py:6694
-#: addon\globalPlugins\visionAssistant\__init__.py:6756
-#: addon\globalPlugins\visionAssistant\__init__.py:6797
-#: addon\globalPlugins\visionAssistant\__init__.py:6804
-#: addon\globalPlugins\visionAssistant\__init__.py:6858
-msgid "Error"
-msgstr "Błąd"
-
 #. Translators: Progress message shown while fetching AI models from the
 #. server
-#: addon\globalPlugins\visionAssistant\__init__.py:5530
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:827
 msgid "Fetching models..."
 msgstr "Pobieranie modeli..."
 
 #. Translators: Option to follow the main model selected in the primary
 #. dropdown
-#. Translators: Option to follow the main model selected in the primary
-#. dropdown.
-#: addon\globalPlugins\visionAssistant\__init__.py:5550
-#: addon\globalPlugins\visionAssistant\__init__.py:5615
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:847 addon\globalPlugins\visionAssistant\dialogs\settings.py:911
 msgid "Default (Main Model)"
 msgstr "Domyślny (model główny)"
 
 #. Translators: Option for the system to automatically choose the best model
 #. for this specific task
-#. Translators: Option for the system to automatically choose the best model
-#. for this task.
-#: addon\globalPlugins\visionAssistant\__init__.py:5552
-#: addon\globalPlugins\visionAssistant\__init__.py:5617
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:849 addon\globalPlugins\visionAssistant\dialogs\settings.py:912
 msgid "Auto (Optimized)"
 msgstr "Auto (zoptymalizowane)"
 
 #. Translators: Status message when the AI models list is successfully
 #. refreshed.
-#: addon\globalPlugins\visionAssistant\__init__.py:5600
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:897
 msgid "Models updated"
 msgstr "Modele zaktualizowane"
 
 #. Translators: Error message shown when the add-on cannot retrieve the list
 #. of models from the server.
-#: addon\globalPlugins\visionAssistant\__init__.py:5603
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:900
 msgid "Failed to fetch models"
 msgstr "Pobieranie modeli nie powiodło się"
 
-#. Translators: Error message shown when saving settings fails.
-#. Translators: Error message shown when saving a file fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:5831
-#: addon\globalPlugins\visionAssistant\__init__.py:6858
-#, python-brace-format
-msgid "Save Error: {error}"
-msgstr "Błąd zapisu: {error}"
+#. Translators: Message reported when log file is cleared.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1163
+msgid "Log file cleared."
+msgstr "Wyczyszczono plik dziennika."
 
 #. Translators: Notification showing the number of items found after filtering
 #. the model list.
-#: addon\globalPlugins\visionAssistant\__init__.py:5877
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1211
 #, python-brace-format
 msgid "{count} items found"
 msgstr "Pozycje: {count}"
 
-#. Translators: Title of the PDF and document options dialog (range,
-#. translation, etc.)
-#: addon\globalPlugins\visionAssistant\__init__.py:5882
-msgid "Options"
-msgstr "Opcje"
-
-#. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:5885
-#, python-brace-format
-msgid "Total Pages (All Files): {count}"
-msgstr "Łączna liczba stron (wszystkie pliki): {count}"
-
-#. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\__init__.py:5888
-msgid "Range"
-msgstr "Zakres"
-
-#. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\__init__.py:5891
-msgid "From:"
-msgstr "Od:"
-
-#. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\__init__.py:5895
-msgid "To:"
-msgstr "Do:"
-
-#. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\__init__.py:5904
-msgid "Translate Output"
-msgstr "Przetłumacz wynik"
-
-#. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\__init__.py:5919
-msgid "Start"
-msgstr "Rozpocznij"
-
-#. Translators: Button to cancel
-#: addon\globalPlugins\visionAssistant\__init__.py:5922
-msgid "Cancel"
-msgstr "Anuluj"
-
-#. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:5947
-msgid "Ask about Document"
-msgstr "Zapytaj o dokument"
-
-#. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\__init__.py:5956
-#, python-brace-format
-msgid "File: {name}"
-msgstr "Plik: {name}"
-
-#. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\__init__.py:5961
-msgid "Uploading to AI...\n"
-msgstr "Przesyłanie do AI...\n"
-
-#. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\__init__.py:5965
-msgid "Your Question:"
-msgstr "Twoje pytanie:"
-
-#. Translators: Message shown in the chat area when the file is uploaded and
-#. the AI is ready to answer questions.
-#: addon\globalPlugins\visionAssistant\__init__.py:6023
-msgid "Ready! Ask your questions.\n"
-msgstr "Gotowe! Zadawaj pytania.\n"
-
-#. Translators: Placeholder text used in document chat when the text is still
-#. being extracted or is empty.
-#: addon\globalPlugins\visionAssistant\__init__.py:6076
-msgid "[Text extraction in progress or empty]"
-msgstr "[Wyodrębnianie tekstu w toku lub puste]"
-
-#. Translators: Initial status message
-#. Translators: Initial status message in the text box
-#: addon\globalPlugins\visionAssistant\__init__.py:6190
-#: addon\globalPlugins\visionAssistant\__init__.py:7261
-msgid "Initializing..."
-msgstr "Inicjowanie..."
-
-#. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\__init__.py:6196
-msgid "Previous (Ctrl+PageUp)"
-msgstr "Poprzednia (Ctrl+PageUp)"
-
-#. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\__init__.py:6200
-msgid "Next (Ctrl+PageDown)"
-msgstr "Następna (Ctrl+PageDown)"
-
-#. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\__init__.py:6204
-msgid "Go to:"
-msgstr "Przejdź do:"
-
-#. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\__init__.py:6215
-msgid "Ask AI (Alt+A)"
-msgstr "Zapytaj AI (Alt+A)"
-
-#. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\__init__.py:6220
-msgid "Re-scan with AI (Alt+R)"
-msgstr "Ponowne skanowanie AI (Alt+R)"
-
-#. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\__init__.py:6225
-msgid "Generate Audio (Alt+G)"
-msgstr "Generuj audio (Alt+G)"
-
-#. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\__init__.py:6236
-msgid "Save (Alt+S)"
-msgstr "Zapisz (Alt+S)"
-
-#. Translators: Message reported when extracting text from a file
-#: addon\globalPlugins\visionAssistant\__init__.py:6301
-#: addon\globalPlugins\visionAssistant\__init__.py:9622
-msgid "Extracting Text..."
-msgstr "Wyodrębnianie tekstu..."
-
-#. Translators: Status message showing page-by-page progress during file OCR.
-#: addon\globalPlugins\visionAssistant\__init__.py:6354
-#: addon\globalPlugins\visionAssistant\__init__.py:9604
-#: addon\globalPlugins\visionAssistant\__init__.py:9678
-#, python-brace-format
-msgid "Processing page {current} of {total}..."
-msgstr "Przetwarzanie strony {current} z {total}..."
-
-#. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\__init__.py:6362
-#, python-brace-format
-msgid "Page {num} ready"
-msgstr "Strona {num} gotowa"
-
-#. Translators: Message shown when a PDF has no text layer.
-#. Translators: Error message shown when a user tries to use "None (Extract
-#. Text)" engine on image files.
-#. Translators: Error message when "None" engine is used on images via F key.
-#. Translators: Error message shown when the 'None' engine is used on image-
-#. based content or scanned PDFs.
-#: addon\globalPlugins\visionAssistant\__init__.py:6379
-#: addon\globalPlugins\visionAssistant\__init__.py:8413
-#: addon\globalPlugins\visionAssistant\__init__.py:9484
-#: addon\globalPlugins\visionAssistant\__init__.py:9613
-msgid ""
-"The 'None (Extract Text Layer)' engine cannot process image-based content. "
-"Please change the OCR Engine to 'Chrome' or 'AI (Advanced)' in settings."
-msgstr ""
-"Silnik „Wyodrębnij tekst (offline)” nie obsługuje treści graficznych. Zmień "
-"silnik OCR na „Chrome” albo „AI (Advanced)” w ustawieniach."
-
-#. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\__init__.py:6392
-msgid "[OCR failed. Try a different AI model or provider.]"
-msgstr "[OCR nie powiodło się. Spróbuj innego modelu AI lub dostawcy.]"
-
-#. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\__init__.py:6410
-msgid "Error processing page."
-msgstr "Błąd przetwarzania strony."
-
-#. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\__init__.py:6415
-#, python-brace-format
-msgid "Page {current} of {total}"
-msgstr "Strona {current} z {total}"
-
-#. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\__init__.py:6422
-msgid "Processing in background..."
-msgstr "Przetwarzanie w tle..."
-
-#. Translators: Spoken message when switching pages
-#. Translators: Heading for each page in the formatted content view.
-#: addon\globalPlugins\visionAssistant\__init__.py:6433
-#: addon\globalPlugins\visionAssistant\__init__.py:6452
-#: addon\globalPlugins\visionAssistant\__init__.py:6843
-#, python-brace-format
-msgid "Page {num}"
-msgstr "Strona {num}"
-
-#. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\__init__.py:6465
-msgid "Formatted Content"
-msgstr "Sformatowana treść"
-
-#. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\__init__.py:6478
-msgid "Current Page"
-msgstr "Bieżąca strona"
-
-#. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:6480
-msgid "All Pages (In Range)"
-msgstr "Wszystkie strony (w zakresie)"
-
-#. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\__init__.py:6490
-msgid "Scanning with AI..."
-msgstr "Skanowanie AI..."
-
-#. Translators: Error shown when a specific page scan fails.
-#. Translators: Error message shown in the document viewer when a specific
-#. page scan fails. The {err} placeholder is replaced with the error details.
-#: addon\globalPlugins\visionAssistant\__init__.py:6506
-#: addon\globalPlugins\visionAssistant\__init__.py:6587
-#: addon\globalPlugins\visionAssistant\__init__.py:6661
-#: addon\globalPlugins\visionAssistant\__init__.py:6668
-#, python-brace-format
-msgid "[Scan failed: {err}]"
-msgstr "[Skanowanie nie powiodło się: {err}]"
-
-#. Translators: Message shown when OCR returns no text for a page.
-#: addon\globalPlugins\visionAssistant\__init__.py:6511
-msgid "[No text detected]"
-msgstr "[Nie wykryto tekstu]"
-
-#. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:6516
-msgid "Scan complete"
-msgstr "Skanowanie zakończone"
-
-#. Translators: Generic system error message inside the document viewer.
-#: addon\globalPlugins\visionAssistant\__init__.py:6519
-#, python-brace-format
-msgid "[Error: {msg}]"
-msgstr "[Błąd: {msg}]"
-
-#. Translators: Status message for local text extraction
-#: addon\globalPlugins\visionAssistant\__init__.py:6532
-msgid "Extracting text layer..."
-msgstr "Wyodrębnianie tekstu..."
-
-#. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\__init__.py:6539
-#: addon\globalPlugins\visionAssistant\__init__.py:6604
-msgid "Batch Processing Started"
-msgstr "Rozpoczęto przetwarzanie wsadowe"
-
-#. Translators: Status message showing the progress of document scanning.
-#. {start} and {end} are page numbers.
-#: addon\globalPlugins\visionAssistant\__init__.py:6558
-#: addon\globalPlugins\visionAssistant\__init__.py:6622
-#, python-brace-format
-msgid "Processing pages {start} to {end}..."
-msgstr "Przetwarzanie stron {start} do {end}..."
-
-#. Translators: Success message shown when all batches of the document have
-#. been processed.
-#: addon\globalPlugins\visionAssistant\__init__.py:6600
-#: addon\globalPlugins\visionAssistant\__init__.py:6682
-msgid "All document pages have been processed."
-msgstr "Wszystkie strony dokumentu zostały przetworzone."
-
-#. Translators: Error shown in the document reader when the AI returns an
-#. empty response for a batch of pages.
-#: addon\globalPlugins\visionAssistant\__init__.py:6644
-msgid ""
-"[Error: Empty response received from AI. Try reducing the batch size in "
-"settings or scanning page-by-page.]"
-msgstr ""
-"[Błąd: otrzymano pustą odpowiedź od AI. Zmniejsz rozmiar wsadu w "
-"ustawieniach lub skanuj strona po stronie.]"
-
-#. Translators: Error shown in the document reader when a page is dropped
-#. because the AI output exceeded its limit during batch processing.
-#: addon\globalPlugins\visionAssistant\__init__.py:6652
-msgid ""
-"[Error: Page skipped during batch processing due to model output limits. Try"
-" a smaller batch size in settings.]"
-msgstr ""
-"[Błąd: pominięto stronę podczas przetwarzania wsadowego z powodu limitów "
-"wyjścia modelu. Zmniejsz rozmiar wsadu w ustawieniach.]"
-
-#. Translators: Error message when trying to use TTS with an unsupported
-#. provider
-#: addon\globalPlugins\visionAssistant\__init__.py:6687
-msgid "TTS is not supported by the current provider or configuration."
-msgstr "Bieżący dostawca lub konfiguracja nie obsługuje syntezy mowy."
-
-#. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\__init__.py:6699
-msgid "Generate for Current Page"
-msgstr "Generuj dla bieżącej strony"
-
-#. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\__init__.py:6701
-msgid "Generate for All Pages (In Range)"
-msgstr "Generuj dla wszystkich stron (w zakresie)"
-
-#. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\__init__.py:6711
-msgid "No text to read."
-msgstr "Brak tekstu do odczytu."
-
-#. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\__init__.py:6721
-msgid "Gathering text for audio..."
-msgstr "Zbieranie tekstu do audio..."
-
-#. Translators: Placeholder text shown in the document reader when processing
-#. takes too long
-#: addon\globalPlugins\visionAssistant\__init__.py:6728
-#: addon\globalPlugins\visionAssistant\__init__.py:6837
-msgid "[Processing timeout]"
-msgstr "[Przekroczono czas przetwarzania]"
-
-#. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\__init__.py:6735
-msgid "Save Audio"
-msgstr "Zapisz audio"
-
-#. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\__init__.py:6746
-msgid "Generating Audio..."
-msgstr "Generowanie audio..."
-
-#. Translators: Fallback error message during text-to-speech generation.
-#: addon\globalPlugins\visionAssistant\__init__.py:6754
-msgid "Unknown Error"
-msgstr "Nieznany błąd"
-
-#. Translators: Error message shown when text-to-speech generation fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:6756
-#: addon\globalPlugins\visionAssistant\__init__.py:6797
-#, python-brace-format
-msgid "TTS Error: {error}"
-msgstr "Błąd TTS: {error}"
-
-#. Translators: Error message when the MP3 encoder (LAME) is missing.
-#: addon\globalPlugins\visionAssistant\__init__.py:6773
-msgid "lame.exe not found in lib folder."
-msgstr "Nie znaleziono lame.exe w folderze lib."
-
-#. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:6787
-msgid "Audio Saved"
-msgstr "Audio zapisane"
-
-#. Translators: Success message after generating TTS audio.
-#: addon\globalPlugins\visionAssistant\__init__.py:6792
-msgid "Audio file generated and saved successfully."
-msgstr "Plik audio został wygenerowany i zapisany."
-
-#. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\__init__.py:6819
-msgid "Save"
-msgstr "Zapisz"
-
-#. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\__init__.py:6830
-#, python-brace-format
-msgid "Saving Page {num}..."
-msgstr "Zapisywanie strony {num}..."
-
-#. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:6853
-msgid "Saved"
-msgstr "Zapisano"
-
-#. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\__init__.py:6855
-msgid "File saved successfully."
-msgstr "Plik zapisany."
-
 #. Translators: Title of the Label Manager dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:6951
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:45
 #, python-brace-format
 msgid "Label Manager - {app}"
 msgstr "Menedżer etykiet — {app}"
 
 #. Translators: Instruction for managing labels using the list view.
-#: addon\globalPlugins\visionAssistant\__init__.py:6962
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:56
 msgid "Check items to delete, or select one to rename:"
 msgstr "Zaznacz elementy do usunięcia lub wybierz jeden do zmiany nazwy:"
 
 #. Translators: Header for the label name column in the manager list.
-#: addon\globalPlugins\visionAssistant\__init__.py:6970
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:64
 msgid "Label Name"
 msgstr "Nazwa etykiety"
 
 #. Translators: Header for the role column in the manager list.
-#: addon\globalPlugins\visionAssistant\__init__.py:6972
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:66
 msgid "Role"
 msgstr "Rola"
 
 #. Translators: Button to check all items in the list.
-#: addon\globalPlugins\visionAssistant\__init__.py:6990
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:84
 msgid "Select &All"
 msgstr "Zaznacz &wszystko"
 
 #. Translators: Button to uncheck all items in the list.
-#: addon\globalPlugins\visionAssistant\__init__.py:6993
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:87
 msgid "Deselect A&ll"
 msgstr "Odznacz w&szystko"
 
 #. Translators: Button to rename the currently focused label.
-#: addon\globalPlugins\visionAssistant\__init__.py:7002
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:96
 msgid "&Rename"
 msgstr "Z&mień nazwę"
 
 #. Translators: Button to delete all checked labels.
-#: addon\globalPlugins\visionAssistant\__init__.py:7005
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:99
 msgid "&Delete Checked"
 msgstr "&Usuń zaznaczone"
 
 #. Translators: Button to trigger a new full scan of the application.
-#: addon\globalPlugins\visionAssistant\__init__.py:7008
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:102
 msgid "Re&scan"
 msgstr "Sk&anuj ponownie"
 
 #. Translators: Button to close the label manager.
-#: addon\globalPlugins\visionAssistant\__init__.py:7011
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:105
 msgid "&Close"
 msgstr "&Zamknij"
 
 #. Translators: Error message shown when no item is selected for renaming.
-#: addon\globalPlugins\visionAssistant\__init__.py:7068
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:162
 msgid "Please select an item from the list to rename."
 msgstr "Wybierz element z listy, by zmienić jego nazwę."
 
 #. Translators: Prompt message for entering a new label name.
-#: addon\globalPlugins\visionAssistant\__init__.py:7074
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:168
 msgid "Enter new name:"
 msgstr "Podaj nową nazwę:"
 
 #. Translators: Window title for the rename dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:7076
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:170
 msgid "Rename Label"
 msgstr "Zmień nazwę etykiety"
 
 #. Translators: Error message shown when no items are checked for deletion.
-#: addon\globalPlugins\visionAssistant\__init__.py:7093
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:187
 msgid "Please check at least one item to delete."
 msgstr "Zaznacz co najmniej jeden element do usunięcia."
 
-#. Translators: Title of the video analysis dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:7106
+#. Translators: Instruction for the elements list dialog
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:200
+msgid "UI Elements Explorer"
+msgstr "Eksplorator elementów interfejsu"
+
+#. Translators: Instruction for the elements list dialog
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:211
+msgid "Select an element:"
+msgstr "Wybierz element:"
+
+#. Translators: Button to click the selected element
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:221
+msgid "&Click"
+msgstr "&Kliknij"
+
+#. Translators: Button to add a label for the selected element
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:227
+msgid "&Add Label"
+msgstr "&Dodaj etykietę"
+
+#. Translators: Error message shown when a screen object cannot be located.
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:264
+msgid "Could not find object at coordinates."
+msgstr "Nie znaleziono obiektu w tym miejscu."
+
+#. Translators: Error message shown when a unique signature cannot be created
+#. for a screen object.
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:273
+msgid "Could not generate signature for this object."
+msgstr "Nie udało się utworzyć sygnatury tego obiektu."
+
+#. Translators: Success message when a label is added to a UI element.
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:280
 #, python-brace-format
-msgid "{name} - Analyze Video"
-msgstr "{name} - Analiza wideo"
-
-#. Translators: Label instructing the user to enter a URL or browse for a
-#. local video
-#: addon\globalPlugins\visionAssistant\__init__.py:7112
-msgid ""
-"Enter Video URL (YouTube, Instagram, Twitter, TikTok) or Browse for a local "
-"video:"
-msgstr ""
-"Wprowadź adres URL wideo (YouTube, Instagram, Twitter, TikTok) lub wskaż "
-"lokalny plik wideo:"
-
-#. Translators: Button to browse for a local video file
-#: addon\globalPlugins\visionAssistant\__init__.py:7120
-msgid "&Browse..."
-msgstr "&Przeglądaj..."
-
-#. Translators: Dialog choice for generating an audio description SRT file.
-#: addon\globalPlugins\visionAssistant\__init__.py:7127
-#: addon\globalPlugins\visionAssistant\__init__.py:10125
-msgid "Generate Audio Description (SRT File)"
-msgstr "Generuj audiodeskrypcję (plik SRT)"
-
-#. Translators: Label for the video action radio box
-#: addon\globalPlugins\visionAssistant\__init__.py:7131
-msgid "Action"
-msgstr "Akcja"
-
-#. Translators: Filter for video files in the file dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:7160
-msgid "Video Files"
-msgstr "Pliki wideo"
-
-#. Translators: Title of the file dialog for selecting a video
-#: addon\globalPlugins\visionAssistant\__init__.py:7162
-msgid "Select Local Video"
-msgstr "Wybierz lokalne wideo"
-
-#. Translators: Title of the progress dialog when generating SRT
-#: addon\globalPlugins\visionAssistant\__init__.py:7176
-#, python-brace-format
-msgid "{name} - Generating Audio Description"
-msgstr "{name} - Generowanie audiodeskrypcji"
-
-#. Translators: Label for the status log text box
-#: addon\globalPlugins\visionAssistant\__init__.py:7188
-msgid "Process Status / Subtitle Content:"
-msgstr "Stan procesu / treść napisów:"
-
-#. Translators: Label for selecting the offline Windows TTS voice
-#: addon\globalPlugins\visionAssistant\__init__.py:7195
-msgid "Offline Narration Voice:"
-msgstr "Głos narracji offline:"
-
-#. Translators: Label for selecting the eSpeak voice variant
-#: addon\globalPlugins\visionAssistant\__init__.py:7205
-msgid "eSpeak Voice Variant:"
-msgstr "Wariant głosu eSpeak:"
-
-#. Translators: Button to download missing eSpeak-NG
-#: addon\globalPlugins\visionAssistant\__init__.py:7218
-msgid "Download eSpeak-NG"
-msgstr "Pobierz eSpeak-NG"
-
-#. Translators: Button to save the generated SRT file
-#: addon\globalPlugins\visionAssistant\__init__.py:7232
-msgid "&Save SRT"
-msgstr "&Zapisz SRT"
-
-#. Translators: Button to generate a synced MP3 narration using offline TTS
-#: addon\globalPlugins\visionAssistant\__init__.py:7237
-msgid "&Generate Synced Narration (MP3)"
-msgstr "&Generuj zsynchronizowaną narrację (MP3)"
-
-#. Translators: Button to regenerate the audio description
-#: addon\globalPlugins\visionAssistant\__init__.py:7242
-msgid "&Regenerate"
-msgstr "&Generuj ponownie"
-
-#. Translators: Button to close the dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:7247
-msgid "&Close / Cancel"
-msgstr "&Zamknij / Anuluj"
-
-#. Translators: Status message when downloading eSpeak-NG
-#: addon\globalPlugins\visionAssistant\__init__.py:7488
-msgid "Downloading eSpeak-NG, please wait..."
-msgstr "Pobieranie eSpeak-NG, proszę czekać..."
-
-#. Translators: Status message when extracting eSpeak-NG
-#: addon\globalPlugins\visionAssistant\__init__.py:7500
-msgid "Extracting eSpeak-NG..."
-msgstr "Wypakowywanie eSpeak-NG..."
-
-#. Translators: Success message after eSpeak-NG download completes
-#: addon\globalPlugins\visionAssistant\__init__.py:7509
-msgid "eSpeak-NG downloaded successfully!"
-msgstr "Pobrano eSpeak-NG."
-
-#. Translators: Error message when eSpeak-NG download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:7516
-#, python-brace-format
-msgid "Failed to download eSpeak-NG: {error}"
-msgstr "Nie udało się pobrać eSpeak-NG: {error}"
-
-#. Translators: Option for eSpeak voice matching the user's current NVDA voice
-#. settings
-#: addon\globalPlugins\visionAssistant\__init__.py:7535
-msgid "eSpeak (Current NVDA Language)"
-msgstr "eSpeak (bieżący język NVDA)"
-
-#. Translators: Option for default English eSpeak voice
-#: addon\globalPlugins\visionAssistant\__init__.py:7539
-msgid "eSpeak (English Default)"
-msgstr "eSpeak (domyślny angielski)"
-
-#. Translators: Success announcement when generation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:7602
-msgid ""
-"Audio description generated successfully! You can read the subtitle content "
-"in the text box."
-msgstr ""
-"Audiodeskrypcja wygenerowana! Treść napisów możesz przeczytać w polu "
-"tekstowym."
-
-#. Translators: Status message when an error occurs during SRT generation
-#: addon\globalPlugins\visionAssistant\__init__.py:7608
-#, python-brace-format
-msgid "Error: {err}"
-msgstr "Błąd: {err}"
-
-#. Translators: Status message when restarting generation
-#: addon\globalPlugins\visionAssistant\__init__.py:7625
-msgid "Re-initializing..."
-msgstr "Ponowna inicjalizacja..."
-
-#. Translators: File dialog title for saving the generated SRT file
-#: addon\globalPlugins\visionAssistant\__init__.py:7642
-msgid "Save Audio Description"
-msgstr "Zapisz audiodeskrypcję"
-
-#. Translators: Success message when SRT file is saved
-#: addon\globalPlugins\visionAssistant\__init__.py:7654
-msgid "SRT file saved successfully."
-msgstr "Zapisano plik SRT."
-
-#. Translators: Error when SRT parsing finds no valid subtitle blocks
-#: addon\globalPlugins\visionAssistant\__init__.py:7716
-msgid "No valid subtitle blocks found in the SRT content."
-msgstr "Nie znaleziono prawidłowych bloków napisów w treści SRT."
-
-#. Translators: Error when no voice is selected
-#: addon\globalPlugins\visionAssistant\__init__.py:7728
-msgid "Please select an offline voice from the list."
-msgstr "Wybierz głos offline z listy."
-
-#. Translators: Warning prompt for online videos indicating that the output
-#. will only contain narration.
-#: addon\globalPlugins\visionAssistant\__init__.py:7766
-msgid ""
-"Because the source is an online video, the final file will ONLY contain the "
-"AI voice narration (synced to the timestamps) and will NOT include the "
-"original background audio of the video. Do you want to proceed?"
-msgstr ""
-"Ponieważ źródłem jest wideo online, plik końcowy będzie zawierał WYŁĄCZNIE "
-"narrację głosem AI (zsynchronizowaną ze znacznikami czasu) i NIE będzie "
-"zawierał oryginalnego dźwięku tła wideo. Kontynuować?"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:7767
-msgid "Online Video Mode"
-msgstr "Tryb wideo online"
-
-#. Translators: Title of the narration mode selection dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:7774
-msgid "Select Narration Mode"
-msgstr "Wybierz tryb narracji"
-
-#. Translators: Instruction prompt for narration mode selection.
-#: addon\globalPlugins\visionAssistant\__init__.py:7776
-msgid "Choose how the narration should be mixed with the video audio:"
-msgstr "Wybierz, jak narracja ma być zmiksowana z dźwiękiem wideo:"
-
-#. Translators: Option for mixing voice directly over the video without
-#. pausing.
-#: addon\globalPlugins\visionAssistant\__init__.py:7779
-msgid "Standard AD (Mix voice directly over audio - No Pausing)"
-msgstr "Standardowa AD (miksuj głos wprost na dźwięku - bez pauz)"
-
-#. Translators: Option for pausing the background video audio during
-#. descriptions.
-#: addon\globalPlugins\visionAssistant\__init__.py:7781
-msgid "Extended AD (Pause background audio during descriptions)"
-msgstr "Rozszerzona AD (pauzuj dźwięk tła podczas opisów)"
-
-#. Translators: Prompt asking whether to lower the background video audio
-#. during the descriptions.
-#: addon\globalPlugins\visionAssistant\__init__.py:7797
-msgid ""
-"Do you want to fade/duck the background video audio during the descriptions?"
-msgstr "Czy przyciszyć dźwięk tła wideo podczas opisów?"
-
-#. Translators: Title for the audio ducking prompt.
-#: addon\globalPlugins\visionAssistant\__init__.py:7799
-msgid "Audio Ducking"
-msgstr "Przyciszanie dźwięku tła"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:7811
-msgid "Save Synced Narration"
-msgstr "Zapisz zsynchronizowaną narrację"
-
-#. Translators: Status message when narration generation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:7836
-msgid "Generating offline synced narration. This may take a few moments..."
-msgstr ""
-"Generowanie zsynchronizowanej narracji offline. Może to chwilę potrwać..."
-
-#. Translators: Status message shown when extracting the original video audio
-#. tracks.
-#: addon\globalPlugins\visionAssistant\__init__.py:7952
-msgid "Extracting original video audio..."
-msgstr "Wyodrębnianie oryginalnego dźwięku wideo..."
-
-#. Translators: Error message shown when extraction of the video's original
-#. audio fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:7970
-msgid "Failed to extract video audio."
-msgstr "Nie udało się wyodrębnić dźwięku wideo."
-
-#. Translators: Status message shown when analyzing the video's audio to
-#. detect periods of silence.
-#: addon\globalPlugins\visionAssistant\__init__.py:7979
-msgid "Analyzing video for natural silences..."
-msgstr "Analiza wideo pod kątem naturalnych cisz..."
-
-#. Translators: Progress message during narration generation. {current} is the
-#. current block number, {total} is total blocks.
-#: addon\globalPlugins\visionAssistant\__init__.py:7990
-#, python-brace-format
-msgid "Generating narration: part {current} of {total}..."
-msgstr "Generowanie narracji: część {current} z {total}..."
-
-#. Translators: Status message when combining audio blocks
-#: addon\globalPlugins\visionAssistant\__init__.py:8027
-msgid "Arranging audio track... Please wait."
-msgstr "Układanie ścieżki dźwiękowej... Proszę czekać."
-
-#. Translators: Status message when mixing generated narration with original
-#. video audio
-#: addon\globalPlugins\visionAssistant\__init__.py:8084
-msgid "Mixing narration with original video audio..."
-msgstr "Miksowanie narracji z oryginalnym dźwiękiem wideo..."
-
-#. Translators: Status message when slicing and splicing the audio file with
-#. natural pauses.
-#: addon\globalPlugins\visionAssistant\__init__.py:8107
-msgid "Splicing audio based on natural pauses..."
-msgstr "Sklejanie dźwięku na podstawie naturalnych pauz..."
-
-#. Translators: Status message shown when converting the final raw WAV mix to
-#. MP3 format.
-#: addon\globalPlugins\visionAssistant\__init__.py:8142
-msgid "Converting final audio to MP3..."
-msgstr "Konwersja końcowego dźwięku do MP3..."
-
-#. Translators: Message spoken on successful save of the synced narration.
-#: addon\globalPlugins\visionAssistant\__init__.py:8158
-msgid "Synced extended narration with silence detection saved successfully."
-msgstr "Zapisano zsynchronizowaną rozszerzoną narrację z wykrywaniem ciszy."
-
-#. Translators: Success message shown when narration generation is
-#. successfully completed with silence detection.
-#: addon\globalPlugins\visionAssistant\__init__.py:8160
-msgid ""
-"Synced extended audio narration file generated successfully with smart "
-"silence matching."
-msgstr ""
-"Wygenerowano zsynchronizowany rozszerzony plik narracji dźwiękowej z "
-"dopasowaniem do naturalnych cisz."
-
-#. Translators: Error message shown when the final MP3 conversion fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:8163
-msgid "Failed to generate the final MP3 file."
-msgstr "Nie udało się wygenerować końcowego pliku MP3."
-
-#. Translators: Error message shown when narration generation fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:8168
-#, python-brace-format
-msgid "Narration Error: {error}"
-msgstr "Błąd narracji: {error}"
-
-#. Translators: Message announced when user cancels the process
-#: addon\globalPlugins\visionAssistant\__init__.py:8191
-msgid "Process cancelled."
-msgstr "Proces anulowany."
-
-#. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:8229
-msgid "&Document Reader..."
-msgstr "&Czytnik dokumentów..."
-
-#. Translators: Menu item for Audio Transcription
-#: addon\globalPlugins\visionAssistant\__init__.py:8233
-msgid "Transcribe &Audio File..."
-msgstr "Transkrybuj plik &audio..."
-
-#. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:8237
-msgid "Analyze &Video URL..."
-msgstr "Analizuj adres URL &wideo..."
-
-#. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:8243
-msgid "&Settings..."
-msgstr "&Ustawienia..."
-
-#. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:8247
-msgid "Check for &Update"
-msgstr "Sprawdź &aktualizację"
-
-#. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:8251
-msgid "Docu&mentation"
-msgstr "Doku&mentacja"
-
-#. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:8255
-msgid "D&onate"
-msgstr "W&esprzyj"
-
-#. Translators: Menu item to open the Telegram channel
-#: addon\globalPlugins\visionAssistant\__init__.py:8259
-msgid "Telegram &Channel"
-msgstr "Kanał w &Telegramie"
-
-#. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
-#: addon\globalPlugins\visionAssistant\__init__.py:8264
-msgid "Vision Assistant"
-msgstr "Vision Assistant"
-
-#. Translators: Announcement when an in-progress OCR extraction is stopped by
-#. the user.
-#: addon\globalPlugins\visionAssistant\__init__.py:8304
-msgid "OCR operation stopped."
-msgstr "Zatrzymano operację OCR."
-
-#. Translators: Title of the dialog asking whether to resume an OCR operation
-#. that did not finish (for example after NVDA closed unexpectedly).
-#: addon\globalPlugins\visionAssistant\__init__.py:8319
-msgid "Unfinished Operation"
-msgstr "Niedokończona operacja"
-
-#. Translators: Message asking whether to continue an interrupted OCR
-#. extraction. {done} is the number of pages already processed, {total} is the
-#. total number of pages, and {files} is the number of files involved.
-#: addon\globalPlugins\visionAssistant\__init__.py:8321
-#, python-brace-format
-msgid ""
-"You have an unfinished operation: {done} of {total} pages processed across "
-"{files} file(s). Would you like to continue from where it stopped?"
-msgstr ""
-"Masz niedokończoną operację: przetworzono stron {done} z {total} w plikach: "
-"{files}. Kontynuować od miejsca zatrzymania?"
-
-#. Translators: Standard title for opening a file
-#: addon\globalPlugins\visionAssistant\__init__.py:8387
-#: addon\globalPlugins\visionAssistant\__init__.py:8768
-#: addon\globalPlugins\visionAssistant\__init__.py:9203
-msgid "Open"
-msgstr "Otwórz"
-
-#. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:8396
-msgid "Supported Files"
-msgstr "Obsługiwane pliki"
-
-#. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:8404
-#: addon\globalPlugins\visionAssistant\__init__.py:9495
-msgid "PyMuPDF library is missing."
-msgstr "Brak biblioteki PyMuPDF."
-
-#. Translators: Title of the error dialog shown when the selected OCR engine
-#. cannot process the chosen image-based files.
-#: addon\globalPlugins\visionAssistant\__init__.py:8415
-#: addon\globalPlugins\visionAssistant\__init__.py:9485
-msgid "OCR Engine Error"
-msgstr "Błąd silnika OCR"
-
-#. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:8422
-#: addon\globalPlugins\visionAssistant\__init__.py:9501
-msgid "No readable pages found."
-msgstr "Nie znaleziono stron do odczytu."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8470
-msgid "Activates the Command Layer for quick access to all features."
-msgstr ""
-"Aktywuje warstwę poleceń umożliwiającą szybki dostęp do wszystkich funkcji."
-
-#. Translators: Script description for Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:8532
-#: addon\globalPlugins\visionAssistant\__init__.py:11331
-msgid "Asks the AI Operator to perform an action or describe the screen."
-msgstr "Aktywuje okno operatora ai."
-
-#. Translators: Script description for Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:8533
-#: addon\globalPlugins\visionAssistant\__init__.py:11252
-msgid "Toggles the interactive UI elements explorer."
-msgstr "Przełącza interaktywny eksplorator elementów interfejsu."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8534
-#: addon\globalPlugins\visionAssistant\__init__.py:8995
-msgid "Translates the selected text or navigator object."
-msgstr "Tłumaczy zaznaczony tekst lub obiekt nawigatora."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8535
-#: addon\globalPlugins\visionAssistant\__init__.py:11166
-msgid "Translates the text currently in the clipboard."
-msgstr "Tłumaczy tekst znajdujący się w schowku."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8536
-#: addon\globalPlugins\visionAssistant\__init__.py:9139
-msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
-msgstr ""
-"Otwiera menu do wyjaśniania, podsumowywania lub poprawiania zaznaczonego "
-"tekstu."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8537
-#: addon\globalPlugins\visionAssistant\__init__.py:9877
-msgid "Performs OCR and description on the entire screen."
-msgstr "Wykonuje OCR i opis całego ekranu."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8538
-#: addon\globalPlugins\visionAssistant\__init__.py:9885
-msgid "Describes the current object (Navigator Object)."
-msgstr "Opisuje bieżący obiekt (obiekt nawigatora)."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8539
-#: addon\globalPlugins\visionAssistant\__init__.py:9780
-msgid ""
-"Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
-msgstr ""
-"Otwiera czytnik dokumentów do szczegółowej analizy strona po stronie "
-"(PDF/obrazy)."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8540
-msgid ""
-"Performs smart actions (OCR or Description) on a selected image or PDF file."
-msgstr ""
-"Wykonuje inteligentne akcje (OCR lub opis) na wybranym pliku obrazu lub PDF."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8541
-#: addon\globalPlugins\visionAssistant\__init__.py:10033
-msgid "Transcribes a selected audio file."
-msgstr "Transkrybuje wybrany plik audio."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8542
-msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
-msgstr ""
-"Analizuje adres URL wideo z YouTube, Instagrama, Twittera lub TikToka."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8543
-#: addon\globalPlugins\visionAssistant\__init__.py:10793
-msgid "Starts or stops local video recording of the screen."
-msgstr "Rozpoczyna lub zatrzymuje lokalne nagrywanie ekranu."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8544
-#: addon\globalPlugins\visionAssistant\__init__.py:11018
-msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
-msgstr "Próbuje rozwiązać CAPTCHA na ekranie lub w obiekcie nawigatora."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8545
-#: addon\globalPlugins\visionAssistant\__init__.py:8875
-msgid "Records voice, transcribes it using AI, and types the result."
-msgstr "Nagrywa głos, transkrybuje go przy użyciu AI i wpisuje wynik."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8546
-#: addon\globalPlugins\visionAssistant\__init__.py:8561
-msgid "Announces the current status of the add-on."
-msgstr "Odczytuje bieżący stan dodatku."
-
-#. Translators: Script description for the 'Label Object' command in the Input
-#. Gestures dialog. This command sends the current UI element to AI to
-#. generate a descriptive name.
-#: addon\globalPlugins\visionAssistant\__init__.py:8547
-#: addon\globalPlugins\visionAssistant\__init__.py:11724
-msgid "Labels the current navigator object using AI."
-msgstr "Nadaje etykietę bieżącemu obiektowi nawigatora za pomocą AI."
-
-#. Translators: Script description for managing existing labels or starting a
-#. full app scan.
-#: addon\globalPlugins\visionAssistant\__init__.py:8548
-#: addon\globalPlugins\visionAssistant\__init__.py:11802
-msgid ""
-"Manages existing labels or scans the entire app to label unnamed elements."
-msgstr ""
-"Zarządza istniejącymi etykietami lub skanuje całą aplikację w poszukiwaniu "
-"elementów bez nich."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8549
-#: addon\globalPlugins\visionAssistant\__init__.py:11082
-msgid "Checks for updates manually."
-msgstr "Ręcznie sprawdza dostępność aktualizacji."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8550
-#: addon\globalPlugins\visionAssistant\__init__.py:11181
-msgid ""
-"Shows the last AI response in a chat dialog for review or follow-up "
-"questions."
-msgstr ""
-"Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub zadawania "
-"dodatkowych pytań."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8551
-msgid "Shows a list of available commands in the layer."
-msgstr "Wyświetla listę dostępnych poleceń w warstwie."
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8552
-#: addon\globalPlugins\visionAssistant\__init__.py:8569
-msgid "Starts or ends a live voice conversation with the AI assistant."
-msgstr "Rozpoczyna lub kończy rozmowę głosową z asystentem AI."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8553
-#: addon\globalPlugins\visionAssistant\__init__.py:8581
-msgid "Opens the Vision Assistant settings dialog."
-msgstr "Otwiera okno ustawień Vision Assistant."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8554
-msgid "Reports the number of banned Gemini API keys and their unban time."
-msgstr ""
-"Podaje liczbę zablokowanych kluczy API Gemini i czas ich odblokowania."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8555
-#: addon\globalPlugins\visionAssistant\__init__.py:8651
-msgid "Reports the AI models selected in advanced routing."
-msgstr "Podaje modele AI wybrane w osobnym modelu dla każdego zadania."
-
-#. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:8558
-#, python-brace-format
-msgid "{name} Help"
-msgstr "Pomoc {name}"
-
-#. Translators: Error shown when the Live Assistant is used with a non-Gemini
-#. provider.
-#: addon\globalPlugins\visionAssistant\__init__.py:8577
-msgid ""
-"The Live Assistant is only supported with the Gemini provider (or a Custom "
-"provider with API type set to Gemini)."
-msgstr ""
-"Asystent głosowy działa tylko z dostawcą Gemini (lub niestandardowym "
-"dostawcą z typem API ustawionym na Gemini)."
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8586
-msgid ""
-"Reports the number of Gemini API keys that have exceeded their daily quota "
-"and their reset time."
-msgstr ""
-"Podaje liczbę kluczy API Gemini, które przekroczyły dzienny limit i czas ich"
-" zresetowania."
-
-#. Translators: Message shown when a user tries to check Gemini API quotas but
-#. another provider is active.
-#: addon\globalPlugins\visionAssistant\__init__.py:8591
-msgid "This feature is only available for Google Gemini."
-msgstr "Ta funkcja jest dostępna tylko dla Google Gemini."
-
-#. Translators: Message when no API keys are out of quota
-#: addon\globalPlugins\visionAssistant\__init__.py:8622
-msgid "No API keys have exceeded their daily quota."
-msgstr "Żaden klucz API nie przekroczył dziennego limitu."
-
-#. Translators: Prefix for time when the daily quota resets on the next day
-#: addon\globalPlugins\visionAssistant\__init__.py:8645
-#, python-brace-format
-msgid "tomorrow at {time}"
-msgstr "jutro o {time}"
-
-#. Translators: Status message for API keys that are out of daily quota
-#: addon\globalPlugins\visionAssistant\__init__.py:8647
-#, python-brace-format
-msgid ""
-"{count} key(s) exceeded daily quota for model {model} (resets around "
-"{time_str})"
-msgstr ""
-"Klucze, które przekroczyły dzienny limit dla modelu {model}: {count} (reset "
-"około {time_str})"
-
-#. Translators: Prefix for main model status
-#: addon\globalPlugins\visionAssistant\__init__.py:8662
-#, python-brace-format
-msgid "Main: {model}"
-msgstr "Główny: {model}"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8671
-msgid "STT"
-msgstr "STT"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:8672
-msgid "TTS"
-msgstr "TTS"
-
-#. Translators: Labels for the AI and User in chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:8673
-#: addon\globalPlugins\visionAssistant\__init__.py:11527
-msgid "Operator"
-msgstr "Operator"
-
-#. Translators: Message when no specific AI models are selected in advanced
-#. routing
-#: addon\globalPlugins\visionAssistant\__init__.py:8679
-msgid "No specific models selected."
-msgstr "Nie wybrano konkretnych modeli."
-
-#. Translators: Line appended to the conversation when the live session has
-#. ended.
-#: addon\globalPlugins\visionAssistant\__init__.py:8758
-msgid "--- Session ended ---"
-msgstr "--- Sesja zakończona ---"
-
-#. Translators: Message announced by NVDA when the live voice conversation
-#. ends.
-#: addon\globalPlugins\visionAssistant\__init__.py:8764
-msgid "Live conversation ended."
-msgstr "Rozmowa głosowa zakończona."
-
-#. Translators: Message of a dialog which may pop up while performing an AI
-#. call
-#: addon\globalPlugins\visionAssistant\__init__.py:8861
-#: addon\globalPlugins\visionAssistant\__init__.py:8868
-#, python-brace-format
-msgid "File Upload Error: {error}"
-msgstr "Błąd przesyłania pliku: {error}"
+msgid "Label added successfully: {name}"
+msgstr "Dodano etykietę: {name}"
 
 #. Translators: Message in an error dialog which can pop up while trying
 #. dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:8886
-#: addon\globalPlugins\visionAssistant\__init__.py:8895
-#: addon\globalPlugins\visionAssistant\__init__.py:8904
+#. Translators: Message reported when dictation starts
+#: addon\globalPlugins\visionAssistant\features\audio.py:51 addon\globalPlugins\visionAssistant\features\audio.py:60 addon\globalPlugins\visionAssistant\features\audio.py:67 addon\globalPlugins\visionAssistant\features\audio.py:153 addon\globalPlugins\visionAssistant\features\audio.py:161
+#: addon\globalPlugins\visionAssistant\features\audio.py:168
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Błąd sprzętu audio: {error}"
 
-#. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\__init__.py:8900
+#: addon\globalPlugins\visionAssistant\features\audio.py:64 addon\globalPlugins\visionAssistant\features\audio.py:165
 msgid "Listening..."
 msgstr "Nasłuchiwanie..."
 
-#. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\__init__.py:8914
-msgid "Typing..."
-msgstr "Wpisywanie..."
-
 #. Translators: Message in an error dialog which can pop up while trying
 #. dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:8919
+#: addon\globalPlugins\visionAssistant\features\audio.py:79 addon\globalPlugins\visionAssistant\features\audio.py:180
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Błąd zapisu nagrania: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\__init__.py:8934
-#: addon\globalPlugins\visionAssistant\__init__.py:8961
+#: addon\globalPlugins\visionAssistant\features\audio.py:94 addon\globalPlugins\visionAssistant\features\audio.py:121 addon\globalPlugins\visionAssistant\features\audio.py:194 addon\globalPlugins\visionAssistant\features\audio.py:235
 msgid "No speech detected."
 msgstr "Nie wykryto mowy."
 
+#. Translators: Message reported when processing dictation
+#: addon\globalPlugins\visionAssistant\features\audio.py:104
+msgid "Typing..."
+msgstr "Wpisywanie..."
+
 #. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\__init__.py:8971
+#: addon\globalPlugins\visionAssistant\features\audio.py:129 addon\globalPlugins\visionAssistant\features\audio.py:242
 msgid "No speech recognized or Error."
 msgstr "Nie rozpoznano mowy lub wystąpił błąd."
 
+#. Translators: Message reported when calling translation command
+#: addon\globalPlugins\visionAssistant\features\audio.py:204 addon\globalPlugins\visionAssistant\features\vision.py:1439
+msgid "Translating..."
+msgstr "Tłumaczenie..."
+
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\__init__.py:8990
+#: addon\globalPlugins\visionAssistant\features\audio.py:262
 #, python-brace-format
 msgid "Typed: {text}"
 msgstr "Wpisano: {text}"
 
-#. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:9002
-msgid "No text found."
-msgstr "Brak tekstu."
+#. Translators: Options for the media file action menu
+#: addon\globalPlugins\visionAssistant\features\audio.py:290
+msgid "Transcribe (Original Language)"
+msgstr "Transkrybuj (język oryginału)"
 
-#. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:9007
-msgid "Translating..."
-msgstr "Tłumaczenie..."
+#: addon\globalPlugins\visionAssistant\features\audio.py:290
+msgid "Transcribe and Translate (Target Language)"
+msgstr "Transkrybuj i przetłumacz (język docelowy)"
 
-#. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\__init__.py:9049
-#, python-brace-format
-msgid "Translated: {text}"
-msgstr "Przetłumaczono: {text}"
-
-#. Translators: Dialog title for Translation results
-#: addon\globalPlugins\visionAssistant\__init__.py:9074
-#, python-brace-format
-msgid "{name} - Translation"
-msgstr "{name} - Tłumaczenie"
+#. Translators: Option in media action menu to live translate/dub audio
+#: addon\globalPlugins\visionAssistant\features\audio.py:292
+msgid "Dub and Translate (Target Language)"
+msgstr "Zdubbinguj i przetłumacz (język docelowy)"
 
 #. Translators: Title of the Refine dialog
-#. Translators: Instruction prompt and window title for the menu that appears
-#. when a user performs an action on a single image file.
-#. Translators: Title of the quick action dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:9168
-#: addon\globalPlugins\visionAssistant\__init__.py:9521
-#: addon\globalPlugins\visionAssistant\__init__.py:10131
+#. Translators: Title and prompt for the video action selection dialog.
+#. Translators: Title of the Refine dialog
+#: addon\globalPlugins\visionAssistant\features\audio.py:298 addon\globalPlugins\visionAssistant\features\video.py:91 addon\globalPlugins\visionAssistant\features\vision.py:73 addon\globalPlugins\visionAssistant\features\vision.py:393
 msgid "Choose action:"
 msgstr "Wybierz czynność:"
 
-#. Translators: Message while processing request of the refine text command
-#. Translators: Status reported when AI starts processing a command
-#: addon\globalPlugins\visionAssistant\__init__.py:9213
-#: addon\globalPlugins\visionAssistant\__init__.py:11360
-msgid "Processing..."
-msgstr "Przetwarzanie..."
-
-#. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\__init__.py:9291
-msgid "Uploading file..."
-msgstr "Przesyłanie pliku..."
-
-#. Translators: Message reported when executing the refine command
-#. Translators: Message reported when calling the audio transcription command
-#. Translators: Progress message spoken when the add-on has sent the image to
-#. the AI and is waiting for the AI to return a label.
-#: addon\globalPlugins\visionAssistant\__init__.py:9364
-#: addon\globalPlugins\visionAssistant\__init__.py:10067
-#: addon\globalPlugins\visionAssistant\__init__.py:11769
-msgid "Analyzing..."
-msgstr "Analizowanie..."
-
-#. Translators: Title of Refine Result dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:9435
-#, python-brace-format
-msgid "{name} - Refine Result"
-msgstr "{name} - Wynik poprawiania"
-
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:9447
-msgid "Performs smart actions on a selected image or PDF file."
-msgstr "Wykonuje inteligentne akcje na wybranym pliku obrazu lub PDF."
-
-#. Translators: Status reported when an image found in the clipboard is being
-#. processed.
-#: addon\globalPlugins\visionAssistant\__init__.py:9467
-#: addon\globalPlugins\visionAssistant\__init__.py:9803
-msgid "Processing clipboard image..."
-msgstr "Przetwarzanie obrazu ze schowka..."
-
-#. Translators: Options for the image file action menu
-#: addon\globalPlugins\visionAssistant\__init__.py:9517
-msgid "Extract Text (OCR)"
-msgstr "Wyodrębnij tekst (OCR)"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:9517
-msgid "Describe Image"
-msgstr "Opisz obraz"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:9521
-msgid "Image File"
-msgstr "Plik obrazu"
-
-#. Translators: Status reported when an image file is being analyzed
-#: addon\globalPlugins\visionAssistant\__init__.py:9534
-msgid "Analyzing Image File..."
-msgstr "Analizowanie pliku obrazu..."
-
-#. Translators: Error message shown when the OCR process fails to detect any
-#. text in the file or an unknown error occurs during extraction.
-#: addon\globalPlugins\visionAssistant\__init__.py:9695
-msgid "No text detected or error occurred."
-msgstr "Nie wykryto tekstu lub wystąpił błąd."
-
-#. Translators: Status message showing batch progress during file OCR.
-#: addon\globalPlugins\visionAssistant\__init__.py:9715
-#, python-brace-format
-msgid "Analyzing batch {start}-{end}..."
-msgstr "Analizowanie porcji {start}–{end}..."
-
-#. Translators: Error message shown when the upload fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:9734
-#, python-brace-format
-msgid "Failed to upload document batch {start}-{end} after multiple attempts."
-msgstr ""
-"Nie udało się przesłać wsadu dokumentów {start}-{end} po kilku próbach."
-
-#. Translators: Error message shown when the connection to the server times
-#. out
-#: addon\globalPlugins\visionAssistant\__init__.py:9764
-msgid "Connection Timeout"
-msgstr "Przekroczono czas połączenia"
-
-#. Translators: Error message shown when the AI processing fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:9766
-#, python-brace-format
-msgid "Failed to process document batch {start}-{end}: {error}"
-msgstr "Błąd przetwarzania wsadu dokumentów {start}-{end}: {error}"
-
-#. Translators: Dialog title for a Chat dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:9865
-#, python-brace-format
-msgid "{name} - Chat"
-msgstr "{name} - Czat"
-
-#. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\__init__.py:9897
-msgid "Scanning..."
-msgstr "Skanowanie..."
-
-#. Translators: Message reported when calling an image analysis command
-#. Translators: Error message reported when screen or object capture fails for
-#. CAPTCHA solving.
-#: addon\globalPlugins\visionAssistant\__init__.py:9902
-#: addon\globalPlugins\visionAssistant\__init__.py:11040
-msgid "Capture failed."
-msgstr "Przechwytywanie nie powiodło się."
-
-#. Translators: Dialog title for Image Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:10020
-#, python-brace-format
-msgid "{name} - Image Analysis"
-msgstr "{name} - Analiza obrazu"
+#: addon\globalPlugins\visionAssistant\features\audio.py:298
+msgid "Media File"
+msgstr "Plik multimedialny"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\__init__.py:10049
+#: addon\globalPlugins\visionAssistant\features\audio.py:333
 msgid "Uploading..."
 msgstr "Przesyłanie..."
 
-#. Translators: Script description for Input Gestures dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:10083
-msgid "Analyzes a local video file or an online video URL."
-msgstr "Analizuje lokalny plik wideo lub adres URL wideo online."
+#. Translators: Status message when extracting audio and connecting to Gemini
+#. for dubbing
+#: addon\globalPlugins\visionAssistant\features\audio.py:372
+msgid "Extracting audio and connecting to Gemini..."
+msgstr "Wyodrębnianie dźwięku i łączenie z Gemini..."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:10131
+#. Translators: Error message shown when Live Translate cannot connect to the
+#. server.
+#: addon\globalPlugins\visionAssistant\features\audio.py:458
+msgid "WebSocket connection failed for all available API keys."
+msgstr "Połączenie WebSocket nie powiodło się dla żadnego z dostępnych kluczy API."
+
+#. Translators: Error message shown when the Live translation setup fails.
+#: addon\globalPlugins\visionAssistant\features\audio.py:489
+#, python-brace-format
+msgid "Failed to setup Live translation session. Error: {error}"
+msgstr "Nie udało się rozpocząć sesji tłumaczenia Live. Błąd: {error}"
+
+#. Translators: Status message part showing estimated time remaining and
+#. completion time.
+#: addon\globalPlugins\visionAssistant\features\audio.py:502
+#, python-brace-format
+msgid " (approx. {mins} min {secs} sec, finishing around {time})"
+msgstr " (około {mins} min {secs} s, koniec około {time})"
+
+#. Translators: Status message part showing estimated seconds remaining and
+#. completion time.
+#: addon\globalPlugins\visionAssistant\features\audio.py:504
+#, python-brace-format
+msgid " (approx. {secs} sec, finishing around {time})"
+msgstr " (około {secs} s, koniec około {time})"
+
+#. Translators: Status message when live dubbing is actively streaming
+#: addon\globalPlugins\visionAssistant\features\audio.py:507
+msgid "Dubbing in progress..."
+msgstr "Trwa dubbing..."
+
+#. Translators: Error message shown when live dubbing fails to return any
+#. audio
+#: addon\globalPlugins\visionAssistant\features\audio.py:598
+msgid "Dubbing failed. No audio returned. Check NVDA log for details."
+msgstr "Dubbing nie powiódł się. Nie zwrócono dźwięku. Szczegóły w dzienniku NVDA."
+
+#. Translators: Dialog title when saving a dubbed media file
+#: addon\globalPlugins\visionAssistant\features\audio.py:631
+msgid "Save dubbed audio as"
+msgstr "Zapisz zdubbingowany dźwięk jako"
+
+#. Translators: Message reported when dubbed file is successfully saved
+#: addon\globalPlugins\visionAssistant\features\audio.py:643
+#, python-brace-format
+msgid "Dubbed file saved: {path}"
+msgstr "Zapisano zdubbingowany plik: {path}"
+
+#. Translators: Status message when dubbing process finishes
+#: addon\globalPlugins\visionAssistant\features\audio.py:651
+msgid "Dubbing finished."
+msgstr "Dubbing zakończony."
+
+#. Translators: Error message when live translate fails
+#: addon\globalPlugins\visionAssistant\features\audio.py:656
+msgid "Dubbing failed."
+msgstr "Dubbing nie powiódł się."
+
+#. Translators: Status message when UI Explorer starts
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:46
+msgid "UI Explorer Active"
+msgstr "Eksplorator interfejsu aktywny"
+
+#. Translators: Status message when UI Explorer stops
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:51 addon\globalPlugins\visionAssistant\features\operator_captcha.py:132
+msgid "UI Explorer Stopped"
+msgstr "Eksplorator interfejsu zatrzymany"
+
+#. Translators: Generic error message for AI failures
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:74
+msgid "Unknown AI Error"
+msgstr "Nieznany błąd AI"
+
+#. Translators: Error shown when AI fails to find UI elements
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:105
+msgid "AI failed to identify UI elements."
+msgstr "AI nie rozpoznało elementów interfejsu."
+
+#. Translators: Announcement when the AI Operator is manually stopped
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:143
+msgid "AI Operator stopped."
+msgstr "Operator AI zatrzymany."
+
+#. Translators: Title and message for AI Operator command dialog
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:152
+msgid "What should I do or what is your question?"
+msgstr "Co mam zrobić lub jakie jest twoje pytanie?"
+
+#. Translators: Message while processing request of the refine text command
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:162 addon\globalPlugins\visionAssistant\features\vision.py:436
+msgid "Processing..."
+msgstr "Przetwarzanie..."
+
+#. Translators: Internal history label for user actions in operator sessions
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:235
+msgid "Action performed. Checking result..."
+msgstr "Akcja wykonana. Sprawdzanie wyniku..."
+
+#. Translators: The title of the interactive chat dialog for the AI Operator
+#. feature.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:300
+#, python-brace-format
+msgid "{name} - AI Operator"
+msgstr "{name} – Operator AI"
+
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:312
+msgid "You"
+msgstr "Ty"
+
+#. Translators: Announcement when the visual CAPTCHA solver is manually
+#. aborted
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:659
+msgid "Visual CAPTCHA solver aborted."
+msgstr "Przerwano rozwiązywanie CAPTCHA z obrazu."
+
+#. Translators: Message reported by NVDA when the user triggers the CAPTCHA
+#. solving command.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:675
+msgid "Solving..."
+msgstr "Rozwiązywanie..."
+
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:682 addon\globalPlugins\visionAssistant\features\vision.py:1041
+msgid "Capture failed."
+msgstr "Przechwytywanie nie powiodło się."
+
+#. Translators: Message reported by NVDA when the AI cannot detect any CAPTCHA
+#. in the captured image.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:703
+msgid "No CAPTCHA detected."
+msgstr "Nie wykryto kodu CAPTCHA."
+
+#. Translators: Message reported when a visual CAPTCHA (like reCAPTCHA) is
+#. detected.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:707
+msgid "Visual CAPTCHA detected. Entering solving mode... This may take a little while."
+msgstr "Wykryto CAPTCHA obrazkową. Rozpoczynam rozwiązywanie... To potrwa chwilę."
+
+#. Translators: Message reported when a visual CAPTCHA is detected but the
+#. solver is disabled.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:711
+msgid "Visual CAPTCHA detected, but the solver is disabled in settings."
+msgstr "Wykryto CAPTCHA obrazkową, ale rozwiązywanie jest wyłączone w ustawieniach."
+
+#. Translators: Message reported when image capture fails or AI returns empty.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:714
+msgid "Capture failed or AI returned empty response."
+msgstr "Przechwytywanie nie powiodło się albo AI zwróciła pustą odpowiedź."
+
+#. Translators: Message reported by NVDA after successfully solving a text
+#. CAPTCHA, announcing the characters found.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:733
+#, python-brace-format
+msgid "Captcha: {text}"
+msgstr "Captcha: {text}"
+
+#. Translators: Message reported when a visual CAPTCHA is successfully solved.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:780
+msgid "Visual CAPTCHA solved!"
+msgstr "CAPTCHA obrazkowa rozwiązana!"
+
+#. Translators: Message reported when AI fails to solve the visual CAPTCHA
+#. after max attempts.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:835
+msgid "Failed to solve CAPTCHA after maximum attempts."
+msgstr "Nie udało się rozwiązać CAPTCHA po maksymalnej liczbie prób."
+
+#. Translators: Value representing the ON state for a toggle setting (e.g., in
+#. quick settings).
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:50 addon\globalPlugins\visionAssistant\features\quick_settings.py:52 addon\globalPlugins\visionAssistant\features\quick_settings.py:53
+msgid "On"
+msgstr "Włączone"
+
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:50 addon\globalPlugins\visionAssistant\features\quick_settings.py:52 addon\globalPlugins\visionAssistant\features\quick_settings.py:53
+msgid "Off"
+msgstr "Wyłączone"
+
+#. Translators: Announced when navigating to AI Model quick settings
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:68
+#, python-brace-format
+msgid "{setting}, Current: {val}. Use left and right arrows to change."
+msgstr "{setting}, obecnie: {val}. Zmieniaj strzałkami w lewo i w prawo."
+
+#. Translators: Warning when models list is not fetched
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:128
+#, python-brace-format
+msgid "No models fetched for {provider}. Please update models list from settings."
+msgstr "Nie pobrano modeli dla dostawcy {provider}. Zaktualizuj listę modeli w ustawieniach."
+
+#: addon\globalPlugins\visionAssistant\features\video.py:91
 msgid "Video Action"
 msgstr "Akcja wideo"
 
+#. Translators: Prompt asking the user to manually input YouTube video
+#. duration.
+#: addon\globalPlugins\visionAssistant\features\video.py:107 addon\globalPlugins\visionAssistant\features\video.py:196
+msgid ""
+"Please enter the YouTube video duration in minutes (e.g., 10 or 10.5).\n"
+"If you enter an incorrect duration, the audio description may not be complete."
+msgstr ""
+"Podaj długość filmu z YouTube w minutach (na przykład 10 albo 10.5).\n"
+"Przy błędnej długości audiodeskrypcja może być niepełna."
+
+#. Translators: Title for the YouTube duration input dialog.
+#: addon\globalPlugins\visionAssistant\features\video.py:109 addon\globalPlugins\visionAssistant\features\video.py:197
+msgid "YouTube Video Duration"
+msgstr "Długość filmu z YouTube"
+
+#. Translators: Error message shown when the entered YouTube duration is
+#. invalid.
+#: addon\globalPlugins\visionAssistant\features\video.py:126 addon\globalPlugins\visionAssistant\features\video.py:213
+msgid "Invalid duration entered. Video analysis cancelled."
+msgstr "Podano nieprawidłową długość. Anulowano analizę wideo."
+
 #. Translators: Error message when video analysis is attempted with a non-
 #. Gemini provider.
-#: addon\globalPlugins\visionAssistant\__init__.py:10165
+#: addon\globalPlugins\visionAssistant\features\video.py:154
 msgid "Video analysis is only supported by Gemini providers."
 msgstr "Analiza wideo jest obsługiwana wyłącznie przez dostawcę Gemini."
 
 #. Translators: Error message when the provided video URL is not valid.
-#: addon\globalPlugins\visionAssistant\__init__.py:10304
+#: addon\globalPlugins\visionAssistant\features\video.py:314
 msgid "Error: Invalid URL."
 msgstr "Błąd: nieprawidłowy adres URL."
 
 #. Translators: Error message when the video URL is from an unsupported
 #. website.
-#: addon\globalPlugins\visionAssistant\__init__.py:10316
-msgid ""
-"Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
-"are supported."
-msgstr ""
-"Błąd: nieobsługiwana platforma. Obsługiwane są tylko YouTube, Instagram, "
-"Twitter i TikTok."
+#: addon\globalPlugins\visionAssistant\features\video.py:322
+msgid "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok are supported."
+msgstr "Błąd: nieobsługiwana platforma. Obsługiwane są tylko YouTube, Instagram, Twitter i TikTok."
 
 #. Translators: Disclaimer added at the beginning of AI-generated SRT files.
-#: addon\globalPlugins\visionAssistant\__init__.py:10324
-msgid ""
-"Disclaimer: This audio description was generated by AI. Some details, "
-"including character identities or events, may not be entirely accurate."
-msgstr ""
-"Zastrzeżenie: ta audiodeskrypcja została wygenerowana przez AI. Niektóre "
-"szczegóły, w tym tożsamość postaci lub przebieg zdarzeń, mogą nie być w "
-"pełni dokładne."
+#: addon\globalPlugins\visionAssistant\features\video.py:345
+msgid "Disclaimer: This audio description was generated by AI. Some details, including character identities or events, may not be entirely accurate."
+msgstr "Zastrzeżenie: ta audiodeskrypcja została wygenerowana przez AI. Niektóre szczegóły, w tym tożsamość postaci lub przebieg zdarzeń, mogą nie być w pełni dokładne."
 
 #. Translators: Status message when the AI is analyzing the whole video to
 #. extract character names and appearances.
-#: addon\globalPlugins\visionAssistant\__init__.py:10418
+#: addon\globalPlugins\visionAssistant\features\video.py:445
 msgid "Extracting characters (First pass)..."
 msgstr "Wyodrębnianie postaci (pierwsze przejście)..."
 
 #. Translators: Header for the list of extracted characters in the generated
 #. subtitle.
-#: addon\globalPlugins\visionAssistant\__init__.py:10463
+#: addon\globalPlugins\visionAssistant\features\video.py:495
 msgid "GLOBAL CHARACTER DICTIONARY:"
 msgstr "GLOBALNY SŁOWNIK POSTACI:"
 
 #. Translators: Status message shown when the add-on pauses briefly between
 #. API requests to prevent hitting server rate limits.
-#: addon\globalPlugins\visionAssistant\__init__.py:10480
+#: addon\globalPlugins\visionAssistant\features\video.py:512
 #, python-brace-format
 msgid "Cooling down to prevent rate limits ({seconds} seconds)..."
 msgstr "Przerwa, aby uniknąć limitów zapytań ({seconds} s)..."
 
+#. Translators: Header for the list of characters introduced up to the current
+#. video scene.
+#: addon\globalPlugins\visionAssistant\features\video.py:546
+msgid "GLOBAL CHARACTER DICTIONARY (Active characters in this scene):"
+msgstr "GLOBALNY SPIS POSTACI (postacie obecne w tej scenie):"
+
 #. Translators: Status message reporting which segment of the video is
 #. currently being analyzed. {current} is the current segment number and
 #. {total} is the total segment count.
-#: addon\globalPlugins\visionAssistant\__init__.py:10516
+#: addon\globalPlugins\visionAssistant\features\video.py:562
 #, python-brace-format
 msgid "Analyzing video segment {current} of {total}..."
 msgstr "Analiza segmentu wideo {current} z {total}..."
 
 #. Translators: Message reported when AI is analyzing the video
-#. Translators: Message when AI is analyzing the recorded video
-#: addon\globalPlugins\visionAssistant\__init__.py:10519
-#: addon\globalPlugins\visionAssistant\__init__.py:10986
+#: addon\globalPlugins\visionAssistant\features\video.py:564 addon\globalPlugins\visionAssistant\features\video.py:786
 msgid "Analyzing video..."
 msgstr "Analiza wideo..."
 
 #. Translators: Status message shown when a video segment finishes processing
 #. and the system is moving to the next one. {current} is the completed
 #. segment number.
-#: addon\globalPlugins\visionAssistant\__init__.py:10574
+#: addon\globalPlugins\visionAssistant\features\video.py:613
 #, python-brace-format
 msgid "Segment {current} finished. Preparing next..."
 msgstr "Segment {current} ukończony. Przygotowanie następnego..."
 
 #. Translators: Status message when all segments are done and it is
 #. finalizing.
-#: addon\globalPlugins\visionAssistant\__init__.py:10577
+#: addon\globalPlugins\visionAssistant\features\video.py:616
 msgid "Finalizing..."
 msgstr "Finalizowanie..."
 
 #. Translators: Error message shown when the AI output cannot be converted
 #. into a valid SRT subtitle file.
-#: addon\globalPlugins\visionAssistant\__init__.py:10598
+#: addon\globalPlugins\visionAssistant\features\video.py:634
 msgid "Failed to parse AI output into SRT."
 msgstr "Nie udało się przetworzyć wyniku AI na SRT."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:10603
+#. Translators: Error message reported when video segment analysis fails after
+#. multiple retries due to network issues.
+#: addon\globalPlugins\visionAssistant\features\video.py:645
 msgid "Connection failed after retries."
 msgstr "Połączenie nie powiodło się po ponownych próbach."
 
-#. Translators: Title of dialog asking user to download ffmpeg
-#: addon\globalPlugins\visionAssistant\__init__.py:10679
-msgid "Download ffmpeg?"
-msgstr "Pobrać ffmpeg?"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:10682
-msgid ""
-"Screen recording requires ffmpeg (approximately 70MB download).\n"
-"\n"
-"Download ffmpeg now to the addon's lib folder?\n"
-"\n"
-"This is a one-time download."
-msgstr ""
-"Nagrywanie ekranu wymaga ffmpeg (pobranie około 70MB).\n"
-"\n"
-"Pobrać teraz ffmpeg do folderu lib dodatku?\n"
-"\n"
-"To jednorazowe pobranie."
-
-#. Translators: Message when user cancels ffmpeg download
-#: addon\globalPlugins\visionAssistant\__init__.py:10707
-msgid "Recording cancelled. ffmpeg is required for video recording."
-msgstr "Nagrywanie anulowane. ffmpeg jest wymagany do nagrywania wideo."
-
-#. Translators: Status message when downloading ffmpeg
-#: addon\globalPlugins\visionAssistant\__init__.py:10715
-msgid "Downloading ffmpeg, please wait..."
-msgstr "Pobieranie ffmpeg, proszę czekać..."
-
-#. Translators: Progress message during ffmpeg download, {percent} is download
-#. percentage
-#: addon\globalPlugins\visionAssistant\__init__.py:10739
-#, python-brace-format
-msgid "Downloading ffmpeg: {percent}%"
-msgstr "Pobieranie ffmpeg: {percent}%"
-
-#. Translators: Status message when extracting ffmpeg
-#: addon\globalPlugins\visionAssistant\__init__.py:10745
-msgid "Extracting ffmpeg..."
-msgstr "Wypakowywanie ffmpeg..."
-
-#. Translators: Success message after ffmpeg download completes
-#: addon\globalPlugins\visionAssistant\__init__.py:10777
-msgid "ffmpeg downloaded successfully!"
-msgstr "Pobrano ffmpeg."
-
-#. Translators: Error message when ffmpeg download fails
-#: addon\globalPlugins\visionAssistant\__init__.py:10787
-#, python-brace-format
-msgid "Failed to download ffmpeg: {error}"
-msgstr "Nie udało się pobrać ffmpeg: {error}"
-
 #. Translators: Error message when video recording is attempted with a non-
 #. Gemini provider
-#: addon\globalPlugins\visionAssistant\__init__.py:10807
+#: addon\globalPlugins\visionAssistant\features\video.py:668
 msgid "Video recording is only supported by Gemini providers."
 msgstr "Nagrywanie wideo jest obsługiwane tylko przez dostawców Gemini."
 
 #. Translators: Status message reported when starting video recording
-#: addon\globalPlugins\visionAssistant\__init__.py:10824
+#: addon\globalPlugins\visionAssistant\features\video.py:680
 msgid "Starting recording..."
 msgstr "Rozpoczynanie nagrywania..."
 
 #. Translators: Message when window capture fails and switches to full screen
 #. capture
-#: addon\globalPlugins\visionAssistant\__init__.py:10904
+#: addon\globalPlugins\visionAssistant\features\video.py:722
 msgid "Window capture failed. Trying full screen..."
 msgstr "Nie udało się przechwycić okna. Próba całego ekranu..."
 
 #. Translators: Error message when ffmpeg fails completely
-#: addon\globalPlugins\visionAssistant\__init__.py:10908
+#: addon\globalPlugins\visionAssistant\features\video.py:726
 msgid "Recording failed to start. FFmpeg encountered a fatal error."
 msgstr "Nie udało się rozpocząć nagrywania. FFmpeg napotkał błąd krytyczny."
 
 #. Translators: Message when video recording starts
-#: addon\globalPlugins\visionAssistant\__init__.py:10914
+#: addon\globalPlugins\visionAssistant\features\video.py:731
 msgid "Recording started. Press the same shortcut again to stop."
-msgstr ""
-"Rozpoczęto nagrywanie. Naciśnij ten sam skrót ponownie, aby zatrzymać."
+msgstr "Rozpoczęto nagrywanie. Naciśnij ten sam skrót ponownie, aby zatrzymać."
 
 #. Translators: Error message when recording fails to start
-#: addon\globalPlugins\visionAssistant\__init__.py:10926
+#: addon\globalPlugins\visionAssistant\features\video.py:742
 #, python-brace-format
 msgid "Failed to start recording: {error}"
 msgstr "Nie udało się rozpocząć nagrywania: {error}"
 
 #. Translators: Error when recorded video file is not found
-#: addon\globalPlugins\visionAssistant\__init__.py:10952
+#: addon\globalPlugins\visionAssistant\features\video.py:758
 msgid "Recording file not found."
 msgstr "Nie znaleziono pliku nagrania."
 
 #. Translators: Error when recorded video file is too small/corrupted
-#: addon\globalPlugins\visionAssistant\__init__.py:10961
-msgid ""
-"The recording was too short or the video file is corrupted. Please try "
-"recording for at least a few seconds."
-msgstr ""
-"Nagranie było za krótkie lub plik wideo jest uszkodzony. Spróbuj nagrywać "
-"przez co najmniej kilka sekund."
+#: addon\globalPlugins\visionAssistant\features\video.py:766
+msgid "The recording was too short or the video file is corrupted. Please try recording for at least a few seconds."
+msgstr "Nagranie było za krótkie lub plik wideo jest uszkodzony. Spróbuj nagrywać przez co najmniej kilka sekund."
 
 #. Translators: Status message showing recording info, {duration} is seconds,
 #. {size} is MB
-#: addon\globalPlugins\visionAssistant\__init__.py:10965
+#: addon\globalPlugins\visionAssistant\features\video.py:770
 #, python-brace-format
 msgid "Recording stopped ({duration:.0f} seconds, {size:.1f} MB)"
 msgstr "Zatrzymano nagrywanie ({duration:.0f} s, {size:.1f} MB)"
 
 #. Translators: Error message when processing recorded video fails
-#: addon\globalPlugins\visionAssistant\__init__.py:11005
+#: addon\globalPlugins\visionAssistant\features\video.py:800
 #, python-brace-format
 msgid "Failed to process recording: {error}"
 msgstr "Nie udało się przetworzyć nagrania: {error}"
 
-#. Translators: Message reported by NVDA when the user triggers the CAPTCHA
-#. solving command.
-#: addon\globalPlugins\visionAssistant\__init__.py:11035
-msgid "Solving..."
-msgstr "Rozwiązywanie..."
-
-#. Translators: Message reported by NVDA when the AI cannot detect any CAPTCHA
-#. in the captured image.
-#: addon\globalPlugins\visionAssistant\__init__.py:11059
-msgid "No CAPTCHA detected."
-msgstr "Nie wykryto kodu CAPTCHA."
-
-#. Translators: Message reported by NVDA after successfully solving a text
-#. CAPTCHA, announcing the characters found.
-#: addon\globalPlugins\visionAssistant\__init__.py:11077
+#. Translators: Message reported when calling translation command
+#: addon\globalPlugins\visionAssistant\features\vision.py:61
 #, python-brace-format
-msgid "Captcha: {text}"
-msgstr "Captcha: {text}"
+msgid "Translated: {text}"
+msgstr "Przetłumaczono: {text}"
 
-#. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:11086
-msgid "Checking for updates..."
-msgstr "Sprawdzanie aktualizacji..."
+#. Translators: Options for the image file action menu
+#: addon\globalPlugins\visionAssistant\features\vision.py:70
+msgid "Extract Text (OCR)"
+msgstr "Wyodrębnij tekst (OCR)"
 
-#. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:11172
-msgid "Translating Clipboard..."
-msgstr "Tłumaczenie schowka..."
+#: addon\globalPlugins\visionAssistant\features\vision.py:70
+msgid "Describe Image"
+msgstr "Opisz obraz"
 
-#. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\__init__.py:11177
-msgid "Clipboard empty."
-msgstr "Schowek jest pusty."
+#: addon\globalPlugins\visionAssistant\features\vision.py:73
+msgid "Image File"
+msgstr "Plik obrazu"
+
+#. Translators: Status reported when an image file is being analyzed
+#: addon\globalPlugins\visionAssistant\features\vision.py:86
+msgid "Analyzing Image File..."
+msgstr "Analizowanie pliku obrazu..."
+
+#. Translators: Dialog title for a Chat dialog
+#: addon\globalPlugins\visionAssistant\features\vision.py:352
+#, python-brace-format
+msgid "{name} - Chat"
+msgstr "{name} - Czat"
+
+#. Translators: Title of Refine Result dialog
+#: addon\globalPlugins\visionAssistant\features\vision.py:504
+#, python-brace-format
+msgid "{name} - Refine Result"
+msgstr "{name} - Wynik poprawiania"
+
+#. Translators: Dialog title for Translation results
+#: addon\globalPlugins\visionAssistant\features\vision.py:544
+#, python-brace-format
+msgid "{name} - Translation"
+msgstr "{name} - Tłumaczenie"
+
+#. Translators: Dialog title for Image Analysis
+#: addon\globalPlugins\visionAssistant\features\vision.py:627
+#, python-brace-format
+msgid "{name} - Image Analysis"
+msgstr "{name} - Analiza obrazu"
+
+#. Translators: Error message shown when the OCR process fails to detect any
+#. text in the file or an unknown error occurs during extraction.
+#: addon\globalPlugins\visionAssistant\features\vision.py:829
+msgid "No text detected or error occurred."
+msgstr "Nie wykryto tekstu lub wystąpił błąd."
+
+#. Translators: Error message shown when the upload fails.
+#: addon\globalPlugins\visionAssistant\features\vision.py:899
+#, python-brace-format
+msgid "Failed to process document batch {start}-{end} after multiple attempts."
+msgstr "Nie udało się przetworzyć wsadu dokumentów {start}-{end} po kilku próbach."
+
+#. Translators: Error message shown when the connection to the server times
+#. out
+#: addon\globalPlugins\visionAssistant\features\vision.py:921
+msgid "Connection Timeout"
+msgstr "Przekroczono czas połączenia"
+
+#: addon\globalPlugins\visionAssistant\features\vision.py:922
+#, python-brace-format
+msgid "Failed to process document batch {start}-{end}: {error}"
+msgstr "Błąd przetwarzania wsadu dokumentów {start}-{end}: {error}"
+
+#. Translators: Message reported when calling an image analysis command
+#: addon\globalPlugins\visionAssistant\features\vision.py:1037
+msgid "Scanning..."
+msgstr "Skanowanie..."
+
+#. Translators: Message reported when executing the refine command
+#: addon\globalPlugins\visionAssistant\features\vision.py:1153
+msgid "Uploading file..."
+msgstr "Przesyłanie pliku..."
+
+#. Translators: Status reported when an image found in the clipboard is being
+#. processed.
+#: addon\globalPlugins\visionAssistant\features\vision.py:1328 addon\globalPlugins\visionAssistant\features\vision.py:1405
+msgid "Processing clipboard image..."
+msgstr "Przetwarzanie obrazu ze schowka..."
 
 #. Translators: Message reported when the user tries to show the last result
 #. but none is stored.
-#: addon\globalPlugins\visionAssistant\__init__.py:11189
+#: addon\globalPlugins\visionAssistant\features\vision.py:1378
 msgid "No previous result to show."
 msgstr "Brak poprzedniego wyniku do wyświetlenia."
 
-#. Translators: Message when opening documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:11227
-msgid "Opening documentation..."
-msgstr "Otwieranie dokumentacji..."
+#. Translators: Message when calling the command to translate from clipboard
+#: addon\globalPlugins\visionAssistant\features\vision.py:1420
+msgid "Translating Clipboard..."
+msgstr "Tłumaczenie schowka..."
 
-#. Translators: Error when help file is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:11237
-msgid "Documentation file not found."
-msgstr "Nie znaleziono pliku dokumentacji."
+#. Translators: Message when the clipboard contains no text to translate
+#: addon\globalPlugins\visionAssistant\features\vision.py:1425
+msgid "Clipboard empty."
+msgstr "Schowek jest pusty."
 
-#. Translators: Status message when UI Explorer starts
-#: addon\globalPlugins\visionAssistant\__init__.py:11258
-msgid "UI Explorer Active"
-msgstr "Eksplorator interfejsu aktywny"
+#. Translators: Message reported when calling translation command
+#: addon\globalPlugins\visionAssistant\features\vision.py:1435
+msgid "No text found."
+msgstr "Brak tekstu."
 
-#. Translators: Status message when UI Explorer stops
-#: addon\globalPlugins\visionAssistant\__init__.py:11263
-#: addon\globalPlugins\visionAssistant\__init__.py:11328
-msgid "UI Explorer Stopped"
-msgstr "Eksplorator interfejsu zatrzymany"
+#. Translators: Title of dialog asking user to download ffmpeg
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:106
+msgid "Download ffmpeg?"
+msgstr "Pobrać ffmpeg?"
 
-#. Translators: Generic error message for AI failures
-#: addon\globalPlugins\visionAssistant\__init__.py:11284
-msgid "Unknown AI Error"
-msgstr "Nieznany błąd AI"
-
-#. Translators: Error shown when AI fails to find UI elements
-#: addon\globalPlugins\visionAssistant\__init__.py:11299
-msgid "AI failed to identify UI elements."
-msgstr "AI nie rozpoznało elementów interfejsu."
-
-#. Translators: Instruction for the elements list dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:11314
-msgid "Select an element to click:"
-msgstr "Wybierz element do kliknięcia:"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:11314
-msgid "UI Elements Explorer"
-msgstr "Eksplorator elementów interfejsu"
-
-#. Translators: Announcement when the AI Operator is manually stopped
-#: addon\globalPlugins\visionAssistant\__init__.py:11340
-msgid "AI Operator stopped."
-msgstr "Operator AI zatrzymany."
-
-#. Translators: Title and message for AI Operator command dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:11348
-msgid "What should I do or what is your question?"
-msgstr "Co mam zrobić lub jakie jest twoje pytanie?"
-
-#. Translators: Internal history label for user actions in operator sessions
-#: addon\globalPlugins\visionAssistant\__init__.py:11441
-msgid "Action performed. Checking result..."
-msgstr "Akcja wykonana. Sprawdzanie wyniku..."
-
-#. Translators: The title of the interactive chat dialog for the AI Operator
-#. feature.
-#: addon\globalPlugins\visionAssistant\__init__.py:11516
-#, python-brace-format
-msgid "{name} - AI Operator"
-msgstr "{name} – Operator AI"
-
-#: addon\globalPlugins\visionAssistant\__init__.py:11527
-msgid "You"
-msgstr "Ty"
-
-#. Translators: Message shown when a user tries to use AI labeling in a web
-#. browser.
-#: addon\globalPlugins\visionAssistant\__init__.py:11736
-#: addon\globalPlugins\visionAssistant\__init__.py:11809
-msgid "AI Labeling is currently not supported in web browsers."
+#. Translators: Message in dialog asking user to download ffmpeg for video
+#. processing
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:108
+msgid ""
+"Video processing requires ffmpeg (approximately 70MB download).\n"
+"\n"
+"Download ffmpeg now to the addon's lib folder?\n"
+"\n"
+"This is a one-time download."
 msgstr ""
-"Etykietowanie AI nie jest obecnie obsługiwane w przeglądarkach "
-"internetowych."
+"Przetwarzanie wideo wymaga ffmpeg (pobieranie około 70 MB).\n"
+"\n"
+"Pobrać ffmpeg teraz do folderu lib dodatku?\n"
+"\n"
+"Pobieranie jest jednorazowe."
 
-#. Translators: Message spoken by NVDA when the current object already has a
-#. custom or AI-generated label. {name} is replaced with the existing label
-#. text.
-#: addon\globalPlugins\visionAssistant\__init__.py:11755
+#. Translators: Message reported when user cancels downloading ffmpeg required
+#. for video processing
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:122 addon\globalPlugins\visionAssistant\utils\media_capture.py:156
+msgid "Operation cancelled. ffmpeg is required for video processing."
+msgstr "Anulowano. Do przetwarzania wideo potrzebny jest ffmpeg."
+
+#. Translators: Status message when downloading ffmpeg
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:164
+msgid "Downloading ffmpeg, please wait..."
+msgstr "Pobieranie ffmpeg, proszę czekać..."
+
+#. Translators: Progress message during ffmpeg download, {percent} is download
+#. percentage
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:183
 #, python-brace-format
-msgid "Already labeled as: {name}"
-msgstr "Już oznaczono jako: {name}"
+msgid "Downloading ffmpeg: {percent}%"
+msgstr "Pobieranie ffmpeg: {percent}%"
 
-#. Translators: Progress message spoken when the add-on starts taking a
-#. screenshot of the current focused object.
-#: addon\globalPlugins\visionAssistant\__init__.py:11760
-msgid "Identifying object..."
-msgstr "Rozpoznawanie obiektu..."
+#. Translators: Status message when extracting ffmpeg
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:186
+msgid "Extracting ffmpeg..."
+msgstr "Wypakowywanie ffmpeg..."
 
-#. Translators: Success message spoken when the AI successfully assigns a new
-#. label to the object. {name} is replaced with the AI-generated label.
-#: addon\globalPlugins\visionAssistant\__init__.py:11793
+#. Translators: Success message after ffmpeg download completes
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:203
+msgid "ffmpeg downloaded successfully!"
+msgstr "Pobrano ffmpeg."
+
+#. Translators: Error message when ffmpeg download fails
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:211
 #, python-brace-format
-msgid "Labeled as: {name}"
-msgstr "Etykieta jako: {name}"
+msgid "Failed to download ffmpeg: {error}"
+msgstr "Nie udało się pobrać ffmpeg: {error}"
 
-#. Translators: Confirmation message shown after labels are deleted or
-#. renamed.
-#: addon\globalPlugins\visionAssistant\__init__.py:11828
-msgid "Labels updated."
-msgstr "Etykiety zaktualizowane."
+#. Translators: Error message shown when processing a local video file fails.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:389
+msgid "Error processing local video."
+msgstr "Błąd przetwarzania lokalnego wideo."
 
-#. Translators: Progress message spoken when the add-on begins scanning the
-#. current application window to find UI elements (like buttons or icons) that
-#. do not have accessibility names.
-#: addon\globalPlugins\visionAssistant\__init__.py:11846
-msgid "Scanning application UI..."
-msgstr "Skanowanie interfejsu aplikacji..."
+#. Translators: Status message when compressing a local video file before
+#. uploading.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:400
+msgid "Compressing video (this may take a moment)..."
+msgstr "Kompresja wideo (może chwilę potrwać)..."
 
-#. Translators: Message spoken when the add-on finishes the UI scan but finds
-#. no unnamed elements to label (everything already has a name).
-#: addon\globalPlugins\visionAssistant\__init__.py:11882
-msgid "No unnamed elements found."
-msgstr "Nie ma niezaetykietowanych elementów."
+#. Translators: Error message shown when video compression fails or was
+#. cancelled by the user.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:404
+msgid "Error: Video compression failed or was cancelled."
+msgstr "Błąd: kompresja wideo nie powiodła się lub została anulowana."
 
-#. Translators: Progress message spoken when the add-on has found unnamed
-#. elements and is now sending the full application screenshot to AI for batch
-#. labeling.
-#: addon\globalPlugins\visionAssistant\__init__.py:11886
-msgid "Analyzing application..."
-msgstr "Analizowanie aplikacji..."
+#. Translators: Error message shown when processing an online video fails.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:427 addon\globalPlugins\visionAssistant\utils\media_capture.py:490
+msgid "Error processing video."
+msgstr "Błąd przetwarzania wideo."
 
-#. Translators: Success message spoken when the AI finishes analyzing the app
-#. and successfully names multiple elements in the background.
-#: addon\globalPlugins\visionAssistant\__init__.py:11944
-msgid "Application labeling complete."
-msgstr "Etykietowanie aplikacji zakończone."
+#. Translators: Message reported when the add-on starts processing an online
+#. video link.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:434 addon\globalPlugins\visionAssistant\utils\media_capture.py:521
+msgid "Processing Video..."
+msgstr "Przetwarzanie wideo..."
 
-#. Translators: Error message spoken when the add-on fails to parse or map the
-#. labels returned by the AI (e.g., due to invalid AI response format).
-#: addon\globalPlugins\visionAssistant\__init__.py:11950
-msgid "Batch labeling failed."
-msgstr "Zbiorcze etykietowanie nie powiodło się."
+#. Translators: Error message when the add-on fails to get a direct download
+#. link for an Instagram video.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:441
+msgid "Error: Could not extract Instagram video."
+msgstr "Błąd: nie udało się pobrać wideo z Instagrama."
+
+#. Translators: Error message when the add-on fails to get a direct download
+#. link for a Twitter/X video.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:445
+msgid "Error: Could not extract Twitter video."
+msgstr "Błąd: nie udało się pobrać wideo z Twittera."
+
+#. Translators: Error message when the add-on fails to get a direct download
+#. link for a TikTok video.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:449
+msgid "Error: Could not extract TikTok video."
+msgstr "Błąd: nie udało się pobrać wideo z TikToka."
+
+#. Translators: Message reported when the add-on is downloading the video from
+#. the extracted link.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:465
+msgid "Downloading Video..."
+msgstr "Pobieranie wideo..."
+
+#. Translators: Error message when downloading the online video fails.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:470
+msgid "Error: Download failed."
+msgstr "Błąd: pobieranie nie powiodło się."
+
+#. Translators: Error message displayed when access to the Live voice service
+#. is blocked or forbidden (HTTP 403 Forbidden).
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1109
+msgid "Access denied (HTTP 403 Forbidden). Please check your Proxy/VPN or API key."
+msgstr "Odmowa dostępu (HTTP 403 Forbidden). Sprawdź proxy lub VPN albo klucz API."
+
+#. Translators: Error message announced when connecting to the Live service
+#. fails. {error} is replaced with the technical connection error details.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1118
+#, python-brace-format
+msgid "Could not connect to the Live service: {error}"
+msgstr "Nie udało się połączyć z usługą asystenta głosowego: {error}"
+
+#. Translators: Error shown when the microphone cannot be opened for the live
+#. session.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1164
+msgid "Could not open the microphone."
+msgstr "Nie udało się otworzyć mikrofonu."
+
+#. Translators: Line shown when the live server unexpectedly closes the
+#. connection. {reason} is the server's reason.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1220
+#, python-brace-format
+msgid "[Connection closed: {reason}]"
+msgstr "[Połączenie zamknięte: {reason}]"
+
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1220
+msgid "unknown"
+msgstr "nieznany"
+
+#. Translators: Message announced by NVDA when the live voice conversation
+#. starts.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1239
+msgid "Live conversation started. You can speak now."
+msgstr "Rozmowa głosowa rozpoczęta. Możesz teraz mówić."
+
+#. Translators: Prefix for the user's transcribed speech line in the Live
+#. Assistant history.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1286
+msgid "You: "
+msgstr "Ty: "
+
+#. Translators: Title of update confirmation dialog
+#: addon\globalPlugins\visionAssistant\utils\updater.py:30
+msgid "Update Available"
+msgstr "Dostępna jest aktualizacja"
+
+#. Translators: Message asking user to update. {version} is version number.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:37
+#, python-brace-format
+msgid "A new version ({version}) of {name} is available."
+msgstr "Dostępna jest nowa wersja ({version}) dodatku {name}."
+
+#. Translators: Label for the changes text box
+#: addon\globalPlugins\visionAssistant\utils\updater.py:42
+msgid "Changes:"
+msgstr "Zmiany:"
+
+#. Translators: Question to download and install
+#: addon\globalPlugins\visionAssistant\utils\updater.py:49
+msgid "Download and Install?"
+msgstr "Pobrać i zainstalować?"
+
+#. Translators: Button to accept update
+#: addon\globalPlugins\visionAssistant\utils\updater.py:54
+msgid "&Yes"
+msgstr "&Tak"
+
+#. Translators: Button to reject update
+#: addon\globalPlugins\visionAssistant\utils\updater.py:56
+msgid "&No"
+msgstr "&Nie"
+
+#. Translators: Error message when an update is found but the addon file is
+#. missing from GitHub.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:100
+msgid "Update found but no .nvda-addon file in release."
+msgstr "Znaleziono aktualizację, ale brak pliku .nvda-addon w wydaniu."
+
+#. Translators: Status message informing the user they are already on the
+#. latest version.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:104
+msgid "You have the latest version."
+msgstr "Masz najnowszą wersję."
+
+#. Translators: Error message shown when the add-on fails to check for
+#. updates. The {error} placeholder is replaced with specific error details.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:109
+#, python-brace-format
+msgid "Update check failed: {error}"
+msgstr "Sprawdzanie aktualizacji nie powiodło się: {error}"
+
+#. Translators: Message shown while downloading update
+#: addon\globalPlugins\visionAssistant\utils\updater.py:137
+msgid "Downloading update, please wait..."
+msgstr "Pobieranie aktualizacji, czekaj..."
+
+#. Translators: Progress message during update download
+#: addon\globalPlugins\visionAssistant\utils\updater.py:154
+#, python-brace-format
+msgid "Downloading update: {percent}%"
+msgstr "Pobieranie aktualizacji: {percent}%"
+
+#. Translators: Error message for download failure
+#: addon\globalPlugins\visionAssistant\utils\updater.py:161
+#, python-brace-format
+msgid "Download failed: {error}"
+msgstr "Pobieranie nie powiodło się: {error}"
 
 #. Add-on summary/title, usually the user visible name of the add-on
 #. Translators: Summary/title for this add-on
@@ -3678,8 +3769,10 @@ msgid ""
 "- Document Reader (D)\n"
 "- File OCR (F)\n"
 "- CAPTCHA Solver (C)\n"
-"- Audio Transcription (A)\n"
+"- Direct Chat (Shift+C)\n"
+"- Media Transcription & Dubbing (M)\n"
 "- Smart Dictation (S)\n"
+"        - Voice Translation (Control+T)\n"
 "- Announce Status (I)\n"
 "- Label Object (L)\n"
 "- Manage/Scan Labels (Shift+L)\n"
@@ -3690,7 +3783,8 @@ msgid ""
 "- Commands Help (H)\n"
 "- Open Settings (Alt+S)\n"
 "- Report Quota Exhausted Keys (Alt+Q)\n"
-"- Report Advanced Routing (Alt+M)"
+"- Report Advanced Routing (Alt+M)\n"
+"- Quick Settings (Up/Down/Left/Right)"
 msgstr ""
 "Asystent AI dla NVDA korzystający z modeli Gemini.\n"
 "Warstwa poleceń: naciśnij NVDA+Shift+V, następnie:\n"
@@ -3702,8 +3796,10 @@ msgstr ""
 "- Czytnik dokumentów (D)\n"
 "- OCR pliku (F)\n"
 "- Rozwiązywanie CAPTCHA (C)\n"
-"- Transkrypcja dźwięku (A)\n"
+"- Czat (Shift+C)\n"
+"- Transkrypcja i dubbing mediów (M)\n"
 "- Dyktowanie (S)\n"
+"- Tłumaczenie mowy (Control+T)\n"
 "- Ogłoś stan (I)\n"
 "- Etykietuj obiekt (L)\n"
 "- Zarządzaj/skanuj etykiety (Shift+L)\n"
@@ -3714,48 +3810,227 @@ msgstr ""
 "- Pomoc poleceń (H)\n"
 "- Otwórz ustawienia (Alt+S)\n"
 "- Zgłoś klucze z wyczerpanym limitem (Alt+Q)\n"
-"- Zgłoś przydział modeli (Alt+M)"
+"- Zgłoś przydział modeli (Alt+M)\n"
+"- Szybkie ustawienia (strzałki góra/dół/lewo/prawo)"
 
 #. Brief changelog for this version
 #. Translators: what's new content for the add-on version to be shown in the
 #. add-on store
-#: buildVars.py:39
+#: buildVars.py:42
 msgid ""
-"## Changes for 2026.07.15\n"
+"## Changes for 2026.08.06\n"
 "\n"
-"*   **Intelligent API Model Filtering**: Complete overhaul of the model filtering system to use a pure blacklist approach instead of whitelists. Added stronger filtering keywords (`embedding`, `bison`, `gecko`, `audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, `computer`) to ensure the main chat model dropdown remains perfectly clean and future-proof, while keeping all specialized models accessible in the Advanced Routing section.\n"
-"*   **Advanced Routing Search**: All Advanced Model Routing dropdowns (OCR, STT, TTS, Operator, Video, Live) and the eSpeak Variant selector are now fully searchable. You can quickly type to filter and find your desired model or variant.\n"
-"*   **New Command Layer Shortcuts**:\n"
-"    *   **Settings (`Alt + S`)**: Instantly opens the Vision Assistant Pro settings dialog.\n"
-"    *   **Quota Exhausted Keys Report (`Alt + Q`)**: Reports the exact number of Gemini API keys that have exceeded their daily quota, identifying which specific model they are exhausted on, and announces their exact reset time.\n"
-"    *   **Routing Audit (`Alt + M`)**: Audits and announces your current Advanced Routing configuration, reading out which models are actively selected for specialized tasks (skipping default settings).\n"
-"*   **Video Analyzer Complete Overhaul**: The Video Analyzer has been completely transformed! Previously, it only provided a basic description of online videos. Now, it is a comprehensive video processing suite tailored for blind users:\n"
-"    *   **Local Screen Recording (`Control+V`)**: You can now record silent videos directly from your screen. The AI will analyze the recorded segment and provide a highly detailed description of the scene, layout, and actions.\n"
-"    *   **Audio Description Generation (SRT)**: The add-on can now generate highly detailed Audio Description scripts (in standard SRT format) for videos, complete with smart gap-timing to intelligently anchor descriptions to natural pauses in the audio track, and verbatim OCR for any on-screen text.\n"
-"    *   **Synchronized Audio Narration (MP3 Export)**: Beyond text-based subtitles, the add-on can synthesize the Audio Description into speech, automatically mix it with the video's original audio track, apply audio ducking (lowering background volume during descriptions), and export the final synchronized result as an MP3 file!\n"
-"    *   **Smart Video File Action**: If you focus on a local video file and press the video shortcut, the add-on will automatically detect it and process the file directly.\n"
-"    *   **Advanced Character Tracking**: The AI now performs a character extraction pre-pass. It builds a global character dictionary and tracks characters accurately segment-by-segment without confusing identities.\n"
-"    *   **Video Analysis Configuration**: Added new settings to control SRT chunk sizes, character subtitling, and disclaimers.\n"
-"    *   **Extended Model Routing**: You can now explicitly select specialized video models (`gemini_video_model`, `custom_video_model`) in the Advanced Model Routing settings.\n"
-"*   **Smart API Quota Management**: Enhanced handling of 429 (Daily Limit) errors by tracking quotas per-model. If a key hits its daily limit on one model, it is intelligently quarantined for that specific model only, leaving the key available for use with other models."
+"*   **UI Explorer Labeling**: You can now add labels directly to found elements inside the UI Explorer! A new \"Add Label\" button has been added, and the interface smartly stays open and preserves focus so you can rapidly label multiple objects without interruption.\n"
+"*   **Quick Settings Layer Enhancement**: The Vision Assistant layer (`Insert+Shift+V`) is now persistent and highly interactive! You can use `Up/Down` arrows to navigate between quick settings (Provider, Model, AI Response Language, TTS Model) and `Left/Right` arrows to instantly change their values with smart, concise voice "
+"feedback. Your selections take effect immediately (including auto-enabling advanced routing when necessary), and the layer stays alive while you configure.\n"
+"*   **Direct Chat (`Shift+C`)**: Added a new command to the layer! Press `Shift+C` to instantly open a \"Direct Chat\" window. This provides a clean, text-based conversational interface with the AI right away, without needing an image or document as a starting point.\n"
+"*   **Flawless Chat History Recall**: Fixed a major bug where pressing `Space` to recall the last result would lose your subsequent chat history. Now, the add-on globally tracks your conversation. If you chat, close the dialog, and press `Space` to recall it, your entire back-and-forth history is perfectly restored! Works for Direct "
+"Chat, Vision Analysis, Document Chat, and Translation.\n"
+"*   **Inline Image Descriptions in OCR**: Added an optional feature to describe images inline during document OCR. You can toggle this setting in the add-on's OCR settings, within the Document Reader options before extraction, and quickly on-the-fly via the Quick Settings layer.\n"
+"*   **Voice Translation (`Control+T`)**: Added a powerful new feature! Dictate speech and instantly translate and type it using AI based on your configured source and target languages.\n"
+"*   **Update Downloader Improvements**: The update download dialog now correctly displays download progress in percentages, and a bug where a phantom \"Downloading update\" message appeared upon canceling the installation has been fixed.\n"
+"*   **eSpeak-NG Downloader Improvements**: Added percentage progress tracking for eSpeak-NG downloads.\n"
+"*   **Batch OCR Resilience**: Fixed an issue in batch PDF OCR where the process would halt if the active API key reached its quota midway; it now automatically switches to the next available key and resumes the process.\n"
+"*   **Visual Captcha Support**: Added robust support for visual captcha solving. It attempts to automatically solve complex image challenges like hCaptcha and reCAPTCHA, significantly enhancing accessibility on challenging web forms.\n"
+"*   **Audio Transcriber Overhaul**: The Audio Transcriber module has been completely rebuilt and now supports both audio and video files. It features 3 distinct operation modes: \"Transcribe (Original Language)\", \"Transcribe and Translate (Target Language)\", and a new powerful \"Dub and Translate (Target Language)\" option "
+"(exclusive to Gemini) that generates a translated audio dub of the original speech.\n"
+"*   **Optional Page Numbers in Document Reader**: Added a new setting to toggle the inclusion of page numbers and separators in multi-page document outputs. You can easily manage this option from the main settings or toggle it on-the-fly via the Quick Settings layer. This feature applies to both text/HTML file exports and the inline "
+"\"View Formatted\" window, allowing you to read combined documents seamlessly.\n"
+"*   **Unlimited Gemini Live TTS for Video Descriptions**: You can now select \"Gemini Live TTS\" as the voice engine when generating Synchronized Audio Narration (MP3) for videos. This utilizes the Gemini Live API to synthesize high-quality audio descriptions without any character limits or length restrictions.\n"
+"*   **Codebase Modularization**: Refactored the add-on structure from a single file to a multi-file modular architecture for improved maintainability.\n"
+"*   **Settings UI Redesign**: Completely redesigned the Settings dialog to use a modern, tab-based interface instead of a grouped layout, providing better organization and easier navigation while keeping all existing options.\n"
+"*   **Global & Dedicated File Logging**: Added an optional global file logging system under the new \"Advanced\" settings tab. Automatically captures operational events, API traffic, and errors across all add-on modules into a dedicated file (`vision_assistant.log`). Supports configurable log verbosity levels (Debug, Info, Warning, "
+"Error), automated retention periods (1 hour to 90 days), and direct log opening or clearing from settings with zero performance impact or NVDA log interference.\n"
+"*   **Gemini Upload Progress Tracking**: Added real-time percentage progress announcements when uploading large files (video, audio, documents) to the Google Gemini API."
 msgstr ""
-"## Zmiany w wersji 2026.07.15\n"
+"## Zmiany w wersji 2026.08.06\n"
 "\n"
-"*   **Filtrowanie modeli API**: Całkowita przebudowa systemu filtrowania modeli na podejście czystej czarnej listy zamiast białych list. Dodano mocniejsze słowa kluczowe filtrowania (`embedding`, `bison`, `gecko`, `audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, `computer`), aby lista rozwijana głównego modelu czatu pozostawała czysta i odporna na przyszłe zmiany, przy jednoczesnym zachowaniu dostępu do wszystkich wyspecjalizowanych modeli w sekcji osobnego modelu dla każdego zadania.\n"
-"*   **Wyszukiwanie w przydziale modeli**: Wszystkie listy rozwijane osobnego modelu dla każdego zadania (OCR, STT, TTS, Operator, Wideo, Asystent głosowy) oraz selektor wariantu eSpeak są teraz w pełni przeszukiwalne. Można szybko wpisać frazę, aby przefiltrować i znaleźć żądany model lub wariant.\n"
-"*   **Nowe skróty warstwy poleceń**:\n"
-"    *   **Ustawienia (`Alt + S`)**: Natychmiast otwiera okno ustawień Vision Assistant Pro.\n"
-"    *   **Raport kluczy z wyczerpanym limitem (`Alt + Q`)**: Podaje dokładną liczbę kluczy API Gemini, które przekroczyły dzienny limit, wskazuje, na którym modelu się wyczerpały, i ogłasza dokładny czas ich zresetowania.\n"
-"    *   **Audyt przydziału (`Alt + M`)**: Sprawdza i ogłasza bieżącą konfigurację osobnego modelu dla każdego zadania, odczytując, które modele są aktywnie wybrane do wyspecjalizowanych zadań (pomijając ustawienia domyślne).\n"
-"*   **Całkowita przebudowa analizatora wideo**: Analizator wideo, który wcześniej udostępniał tylko podstawowy opis filmów online, robi teraz znacznie więcej:\n"
-"    *   **Lokalne nagrywanie ekranu (`Control+V`)**: Można teraz nagrywać bezgłośne filmy bezpośrednio z ekranu. AI przeanalizuje nagrany fragment i poda szczegółowy opis sceny, układu i akcji.\n"
-"    *   **Generowanie audiodeskrypcji (SRT)**: Dodatek potrafi teraz generować szczegółowe skrypty audiodeskrypcji (w standardowym formacie SRT) dla filmów, wraz z dopasowaniem czasu do przerw, aby zakotwiczyć opisy w naturalnych pauzach ścieżki dźwiękowej, oraz dosłownym OCR tekstu na ekranie.\n"
-"    *   **Zsynchronizowana narracja dźwiękowa (eksport MP3)**: Poza napisami tekstowymi dodatek potrafi zsyntetyzować audiodeskrypcję na mowę, automatycznie zmiksować ją z oryginalną ścieżką dźwiękową filmu, zastosować przyciszanie tła (obniżenie głośności tła podczas opisów) i wyeksportować gotowy zsynchronizowany wynik jako plik MP3!\n"
-"    *   **Akcja na pliku wideo**: Jeśli ustawisz fokus na lokalnym pliku wideo i naciśniesz skrót wideo, dodatek automatycznie go wykryje i przetworzy plik bezpośrednio.\n"
-"    *   **Śledzenie postaci**: AI wykonuje teraz wstępne przejście wyodrębniające postacie. Buduje globalny słownik postaci i śledzi je dokładnie segment po segmencie, nie myląc tożsamości.\n"
-"    *   **Konfiguracja analizy wideo**: Dodano nowe ustawienia sterujące rozmiarem fragmentów SRT, napisami postaci i zastrzeżeniami.\n"
-"    *   **Rozszerzony przydział modeli**: Można teraz jawnie wybrać wyspecjalizowane modele wideo (`gemini_video_model`, `custom_video_model`) w ustawieniach osobnego modelu dla każdego zadania.\n"
-"*   **Zarządzanie limitami API**: Ulepszona obsługa błędów 429 (dzienny limit) przez śledzenie limitów per model. Jeśli klucz osiągnie dzienny limit na jednym modelu, zostaje odizolowany tylko dla tego konkretnego modelu, pozostając dostępny dla innych modeli."
+"*   **Etykietowanie w Eksploratorze interfejsu**: teraz można dodawać etykiety wprost do znalezionych elementów w Eksploratorze interfejsu. Doszedł przycisk „Dodaj etykietę\", a okno zostaje otwarte i utrzymuje fokus, więc kilka obiektów da się opisać jeden po drugim bez przerywania pracy.\n"
+"*   **Rozbudowana warstwa szybkich ustawień**: warstwa Vision Assistant (`Insert+Shift+V`) jest teraz trwała i w pełni interaktywna. Strzałkami góra i dół przechodzi się między szybkimi ustawieniami (dostawca, model, język odpowiedzi AI, model TTS), a strzałkami lewo i prawo od razu zmienia ich wartości, z krótkim komunikatem "
+"głosowym. Wybory działają natychmiast (łącznie z automatycznym włączeniem osobnego modelu dla zadania, jeśli jest potrzebny), a warstwa pozostaje aktywna przez cały czas konfiguracji.\n"
+"*   **Czat (`Shift+C`)**: nowe polecenie w warstwie. `Shift+C` otwiera okno czatu — czysty interfejs tekstowy do rozmowy z AI, bez potrzeby zaczynania od obrazu czy dokumentu.\n"
+"*   **Poprawne przywoływanie historii rozmowy**: naprawiony poważny błąd, przez który naciśnięcie `Spacji` w celu przywołania ostatniego wyniku gubiło dalszą historię rozmowy. Dodatek śledzi teraz całą rozmowę globalnie. Po zamknięciu okna i naciśnięciu `Spacji` wraca pełna historia wymiany. Działa dla czatu, analizy obrazu, rozmowy "
+"o dokumencie i tłumaczenia.\n"
+"*   **Opisy obrazów wplecione w tekst przy OCR**: doszła opcja, która przy OCR dokumentu wplata opis obrazu dokładnie tam, gdzie w dokumencie znajduje się ten obraz. Można ją przełączyć w ustawieniach OCR dodatku, w opcjach czytnika dokumentów przed wyodrębnieniem oraz na bieżąco w warstwie szybkich ustawień.\n"
+"*   **Tłumaczenie mowy (`Control+T`)**: nowa funkcja. Dyktujesz, a AI od razu tłumaczy wypowiedź i wpisuje ją jako tekst, zgodnie z ustawionym językiem źródłowym i docelowym.\n"
+"*   **Poprawki pobierania aktualizacji**: okno pobierania aktualizacji pokazuje teraz poprawnie postęp w procentach, a błąd, przez który po anulowaniu instalacji pojawiał się fantomowy komunikat „Pobieranie aktualizacji\", został naprawiony.\n"
+"*   **Poprawki pobierania eSpeak-NG**: doszedł postęp pobierania eSpeak-NG w procentach.\n"
+"*   **Odporność wsadowego OCR**: naprawiony błąd we wsadowym OCR plików PDF, przez który przetwarzanie zatrzymywało się, gdy aktywny klucz API wyczerpał limit w połowie pracy. Teraz dodatek sam przełącza się na kolejny dostępny klucz i kontynuuje.\n"
+"*   **Obsługa CAPTCHA obrazkowej**: doszła solidna obsługa rozwiązywania CAPTCHA z obrazu. Dodatek próbuje automatycznie rozwiązywać złożone zagadki obrazkowe w rodzaju hCaptcha i reCAPTCHA, co wyraźnie poprawia dostępność trudnych formularzy internetowych.\n"
+"*   **Przebudowana transkrypcja dźwięku**: moduł transkrypcji został napisany od nowa i obsługuje teraz zarówno pliki dźwiękowe, jak i wideo. Ma trzy tryby pracy: „Transkrybuj (język oryginału)\", „Transkrybuj i przetłumacz (język docelowy)\" oraz nowy „Zdubbinguj i przetłumacz (język docelowy)\" — ten ostatni dostępny wyłącznie w "
+"Gemini, tworzy przetłumaczoną ścieżkę głosową oryginalnej wypowiedzi.\n"
+"*   **Numery stron w czytniku dokumentów**: doszło ustawienie, które włącza i wyłącza numery stron oraz separatory w dokumentach wielostronicowych. Opcja jest w ustawieniach głównych i w warstwie szybkich ustawień. Działa zarówno przy eksporcie do pliku tekstowego i HTML, jak i w oknie „Pokaż sformatowane\", dzięki czemu połączone "
+"dokumenty czyta się bez przerw.\n"
+"*   **Gemini Live TTS bez limitu dla opisów wideo**: przy tworzeniu zsynchronizowanej narracji dźwiękowej (MP3) do filmów można teraz wybrać silnik głosu „Gemini Live TTS\". Korzysta on z Gemini Live API i tworzy wysokiej jakości audiodeskrypcję bez ograniczeń długości ani liczby znaków.\n"
+"*   **Modularyzacja kodu**: struktura dodatku została przebudowana z jednego pliku na architekturę wielomodułową, co ułatwia utrzymanie.\n"
+"*   **Przeprojektowane ustawienia**: okno ustawień zostało w całości przebudowane na nowoczesny układ z zakładkami zamiast grup. Porządek i nawigacja są wygodniejsze, a wszystkie dotychczasowe opcje zostają.\n"
+"*   **Globalny dziennik w osobnym pliku**: doszedł opcjonalny globalny dziennik pod nową zakładką ustawień „Zaawansowane\". Zapisuje zdarzenia, ruch do API i błędy ze wszystkich modułów dodatku do osobnego pliku (`vision_assistant.log`). Obsługuje poziomy szczegółowości (diagnostyka, informacje, ostrzeżenia, błędy) i automatyczne "
+"przechowywanie (od godziny do 90 dni), a plik można otworzyć lub wyczyścić wprost z ustawień. Bez wpływu na wydajność i bez zaśmiecania dziennika NVDA.\n"
+"*   **Postęp wysyłania do Gemini**: doszły komunikaty o postępie w procentach przy wysyłaniu dużych plików (wideo, dźwięk, dokumenty) do Google Gemini API."
+
+#, python-brace-format
+#~ msgid "{name} Error"
+#~ msgstr "Błąd {name}"
+
+#~ msgid "The Screen Curtain is currently enabled. Please disable it (NVDA+Control+Escape) before using visual recognition features."
+#~ msgstr "Kurtyna ekranowa jest obecnie włączona. Wyłącz ją (NVDA+Control+Escape) przed użyciem funkcji rozpoznawania obrazu."
+
+#~ msgid "Downloading update..."
+#~ msgstr "Pobieranie aktualizacji..."
+
+#~ msgid "AI Operator Model:"
+#~ msgstr "Model Operatora AI:"
+
+#~ msgid "Capture Method:"
+#~ msgstr "Metoda przechwytywania:"
+
+#~ msgid "Offline Narration Voice:"
+#~ msgstr "Głos narracji offline:"
+
+#~ msgid "Transcribe &Audio File..."
+#~ msgstr "Transkrybuj plik &audio..."
+
+#~ msgid "Analyze &Video URL..."
+#~ msgstr "Analizuj adres URL &wideo..."
+
+#~ msgid "Transcribes a selected audio file."
+#~ msgstr "Transkrybuje wybrany plik audio."
+
+#~ msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
+#~ msgstr "Analizuje adres URL wideo z YouTube, Instagrama, Twittera lub TikToka."
+
+#~ msgid "Reports the number of banned Gemini API keys and their unban time."
+#~ msgstr "Podaje liczbę zablokowanych kluczy API Gemini i czas ich odblokowania."
+
+#, python-brace-format
+#~ msgid "{count} key(s) exceeded daily quota for model {model} (resets around {time_str})"
+#~ msgstr "Klucze, które przekroczyły dzienny limit dla modelu {model}: {count} (reset około {time_str})"
+
+#~ msgid "Performs smart actions on a selected image or PDF file."
+#~ msgstr "Wykonuje inteligentne akcje na wybranym pliku obrazu lub PDF."
+
+#, python-brace-format
+#~ msgid "Analyzing batch {start}-{end}..."
+#~ msgstr "Analizowanie porcji {start}–{end}..."
+
+#, python-brace-format
+#~ msgid "Failed to upload document batch {start}-{end} after multiple attempts."
+#~ msgstr "Nie udało się przesłać wsadu dokumentów {start}-{end} po kilku próbach."
+
+#~ msgid ""
+#~ "Screen recording requires ffmpeg (approximately 70MB download).\n"
+#~ "\n"
+#~ "Download ffmpeg now to the addon's lib folder?\n"
+#~ "\n"
+#~ "This is a one-time download."
+#~ msgstr ""
+#~ "Nagrywanie ekranu wymaga ffmpeg (pobranie około 70MB).\n"
+#~ "\n"
+#~ "Pobrać teraz ffmpeg do folderu lib dodatku?\n"
+#~ "\n"
+#~ "To jednorazowe pobranie."
+
+#~ msgid "Recording cancelled. ffmpeg is required for video recording."
+#~ msgstr "Nagrywanie anulowane. ffmpeg jest wymagany do nagrywania wideo."
+
+#~ msgid "Opening documentation..."
+#~ msgstr "Otwieranie dokumentacji..."
+
+#~ msgid "Documentation file not found."
+#~ msgstr "Nie znaleziono pliku dokumentacji."
+
+#~ msgid "Select an element to click:"
+#~ msgstr "Wybierz element do kliknięcia:"
+
+#~ msgid ""
+#~ "An advanced AI assistant for NVDA using Gemini models.\n"
+#~ "Command Layer: Press NVDA+Shift+V, then:\n"
+#~ "- Smart Translator (T) / Clipboard (Shift+T)\n"
+#~ "- Text Refiner (R)\n"
+#~ "- Describe Object (V) / Full Screen (O)\n"
+#~ "- Video Analysis (Shift+V)\n"
+#~ "- Local Video Recording (Control+V)\n"
+#~ "- Document Reader (D)\n"
+#~ "- File OCR (F)\n"
+#~ "- CAPTCHA Solver (C)\n"
+#~ "- Audio Transcription (A)\n"
+#~ "- Smart Dictation (S)\n"
+#~ "- Announce Status (I)\n"
+#~ "- Label Object (L)\n"
+#~ "- Manage/Scan Labels (Shift+L)\n"
+#~ "- UI Explorer (E)\n"
+#~ "- AI Operator (Shift+A)\n"
+#~ "- Check Update (U)\n"
+#~ "- Recall Last Result (Space)\n"
+#~ "- Commands Help (H)\n"
+#~ "- Open Settings (Alt+S)\n"
+#~ "- Report Quota Exhausted Keys (Alt+Q)\n"
+#~ "- Report Advanced Routing (Alt+M)"
+#~ msgstr ""
+#~ "Asystent AI dla NVDA korzystający z modeli Gemini.\n"
+#~ "Warstwa poleceń: naciśnij NVDA+Shift+V, następnie:\n"
+#~ "- Tłumacz (T) / Schowek (Shift+T)\n"
+#~ "- Poprawianie tekstu (R)\n"
+#~ "- Opis obiektu (V) / Cały ekran (O)\n"
+#~ "- Analiza wideo (Shift+V)\n"
+#~ "- Nagrywanie ekranu (Control+V)\n"
+#~ "- Czytnik dokumentów (D)\n"
+#~ "- OCR pliku (F)\n"
+#~ "- Rozwiązywanie CAPTCHA (C)\n"
+#~ "- Transkrypcja dźwięku (A)\n"
+#~ "- Dyktowanie (S)\n"
+#~ "- Ogłoś stan (I)\n"
+#~ "- Etykietuj obiekt (L)\n"
+#~ "- Zarządzaj/skanuj etykiety (Shift+L)\n"
+#~ "- Eksplorator interfejsu (E)\n"
+#~ "- Operator AI (Shift+A)\n"
+#~ "- Sprawdź aktualizację (U)\n"
+#~ "- Przywołaj ostatni wynik (Spacja)\n"
+#~ "- Pomoc poleceń (H)\n"
+#~ "- Otwórz ustawienia (Alt+S)\n"
+#~ "- Zgłoś klucze z wyczerpanym limitem (Alt+Q)\n"
+#~ "- Zgłoś przydział modeli (Alt+M)"
+
+#~ msgid ""
+#~ "## Changes for 2026.07.15\n"
+#~ "\n"
+#~ "*   **Intelligent API Model Filtering**: Complete overhaul of the model filtering system to use a pure blacklist approach instead of whitelists. Added stronger filtering keywords (`embedding`, `bison`, `gecko`, `audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, `computer`) to ensure the main chat model dropdown "
+#~ "remains perfectly clean and future-proof, while keeping all specialized models accessible in the Advanced Routing section.\n"
+#~ "*   **Advanced Routing Search**: All Advanced Model Routing dropdowns (OCR, STT, TTS, Operator, Video, Live) and the eSpeak Variant selector are now fully searchable. You can quickly type to filter and find your desired model or variant.\n"
+#~ "*   **New Command Layer Shortcuts**:\n"
+#~ "    *   **Settings (`Alt + S`)**: Instantly opens the Vision Assistant Pro settings dialog.\n"
+#~ "    *   **Quota Exhausted Keys Report (`Alt + Q`)**: Reports the exact number of Gemini API keys that have exceeded their daily quota, identifying which specific model they are exhausted on, and announces their exact reset time.\n"
+#~ "    *   **Routing Audit (`Alt + M`)**: Audits and announces your current Advanced Routing configuration, reading out which models are actively selected for specialized tasks (skipping default settings).\n"
+#~ "*   **Video Analyzer Complete Overhaul**: The Video Analyzer has been completely transformed! Previously, it only provided a basic description of online videos. Now, it is a comprehensive video processing suite tailored for blind users:\n"
+#~ "    *   **Local Screen Recording (`Control+V`)**: You can now record silent videos directly from your screen. The AI will analyze the recorded segment and provide a highly detailed description of the scene, layout, and actions.\n"
+#~ "    *   **Audio Description Generation (SRT)**: The add-on can now generate highly detailed Audio Description scripts (in standard SRT format) for videos, complete with smart gap-timing to intelligently anchor descriptions to natural pauses in the audio track, and verbatim OCR for any on-screen text.\n"
+#~ "    *   **Synchronized Audio Narration (MP3 Export)**: Beyond text-based subtitles, the add-on can synthesize the Audio Description into speech, automatically mix it with the video's original audio track, apply audio ducking (lowering background volume during descriptions), and export the final synchronized result as an MP3 "
+#~ "file!\n"
+#~ "    *   **Smart Video File Action**: If you focus on a local video file and press the video shortcut, the add-on will automatically detect it and process the file directly.\n"
+#~ "    *   **Advanced Character Tracking**: The AI now performs a character extraction pre-pass. It builds a global character dictionary and tracks characters accurately segment-by-segment without confusing identities.\n"
+#~ "    *   **Video Analysis Configuration**: Added new settings to control SRT chunk sizes, character subtitling, and disclaimers.\n"
+#~ "    *   **Extended Model Routing**: You can now explicitly select specialized video models (`gemini_video_model`, `custom_video_model`) in the Advanced Model Routing settings.\n"
+#~ "*   **Smart API Quota Management**: Enhanced handling of 429 (Daily Limit) errors by tracking quotas per-model. If a key hits its daily limit on one model, it is intelligently quarantined for that specific model only, leaving the key available for use with other models."
+#~ msgstr ""
+#~ "## Zmiany w wersji 2026.07.15\n"
+#~ "\n"
+#~ "*   **Filtrowanie modeli API**: Całkowita przebudowa systemu filtrowania modeli na podejście czystej czarnej listy zamiast białych list. Dodano mocniejsze słowa kluczowe filtrowania (`embedding`, `bison`, `gecko`, `audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, `computer`), aby lista rozwijana głównego modelu "
+#~ "czatu pozostawała czysta i odporna na przyszłe zmiany, przy jednoczesnym zachowaniu dostępu do wszystkich wyspecjalizowanych modeli w sekcji osobnego modelu dla każdego zadania.\n"
+#~ "*   **Wyszukiwanie w przydziale modeli**: Wszystkie listy rozwijane osobnego modelu dla każdego zadania (OCR, STT, TTS, Operator, Wideo, Asystent głosowy) oraz selektor wariantu eSpeak są teraz w pełni przeszukiwalne. Można szybko wpisać frazę, aby przefiltrować i znaleźć żądany model lub wariant.\n"
+#~ "*   **Nowe skróty warstwy poleceń**:\n"
+#~ "    *   **Ustawienia (`Alt + S`)**: Natychmiast otwiera okno ustawień Vision Assistant Pro.\n"
+#~ "    *   **Raport kluczy z wyczerpanym limitem (`Alt + Q`)**: Podaje dokładną liczbę kluczy API Gemini, które przekroczyły dzienny limit, wskazuje, na którym modelu się wyczerpały, i ogłasza dokładny czas ich zresetowania.\n"
+#~ "    *   **Audyt przydziału (`Alt + M`)**: Sprawdza i ogłasza bieżącą konfigurację osobnego modelu dla każdego zadania, odczytując, które modele są aktywnie wybrane do wyspecjalizowanych zadań (pomijając ustawienia domyślne).\n"
+#~ "*   **Całkowita przebudowa analizatora wideo**: Analizator wideo, który wcześniej udostępniał tylko podstawowy opis filmów online, robi teraz znacznie więcej:\n"
+#~ "    *   **Lokalne nagrywanie ekranu (`Control+V`)**: Można teraz nagrywać bezgłośne filmy bezpośrednio z ekranu. AI przeanalizuje nagrany fragment i poda szczegółowy opis sceny, układu i akcji.\n"
+#~ "    *   **Generowanie audiodeskrypcji (SRT)**: Dodatek potrafi teraz generować szczegółowe skrypty audiodeskrypcji (w standardowym formacie SRT) dla filmów, wraz z dopasowaniem czasu do przerw, aby zakotwiczyć opisy w naturalnych pauzach ścieżki dźwiękowej, oraz dosłownym OCR tekstu na ekranie.\n"
+#~ "    *   **Zsynchronizowana narracja dźwiękowa (eksport MP3)**: Poza napisami tekstowymi dodatek potrafi zsyntetyzować audiodeskrypcję na mowę, automatycznie zmiksować ją z oryginalną ścieżką dźwiękową filmu, zastosować przyciszanie tła (obniżenie głośności tła podczas opisów) i wyeksportować gotowy zsynchronizowany wynik jako "
+#~ "plik MP3!\n"
+#~ "    *   **Akcja na pliku wideo**: Jeśli ustawisz fokus na lokalnym pliku wideo i naciśniesz skrót wideo, dodatek automatycznie go wykryje i przetworzy plik bezpośrednio.\n"
+#~ "    *   **Śledzenie postaci**: AI wykonuje teraz wstępne przejście wyodrębniające postacie. Buduje globalny słownik postaci i śledzi je dokładnie segment po segmencie, nie myląc tożsamości.\n"
+#~ "    *   **Konfiguracja analizy wideo**: Dodano nowe ustawienia sterujące rozmiarem fragmentów SRT, napisami postaci i zastrzeżeniami.\n"
+#~ "    *   **Rozszerzony przydział modeli**: Można teraz jawnie wybrać wyspecjalizowane modele wideo (`gemini_video_model`, `custom_video_model`) w ustawieniach osobnego modelu dla każdego zadania.\n"
+#~ "*   **Zarządzanie limitami API**: Ulepszona obsługa błędów 429 (dzienny limit) przez śledzenie limitów per model. Jeśli klucz osiągnie dzienny limit na jednym modelu, zostaje odizolowany tylko dla tego konkretnego modelu, pozostając dostępny dla innych modeli."
 
 #~ msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 #~ msgstr "Analiza YouTube / Instagram / Twitter / TikTok"
@@ -3775,7 +4050,8 @@ msgstr ""
 #~ msgstr ""
 #~ "## Zmiany w wersji 6.5.0\n"
 #~ "\n"
-#~ "*   **Asystent głosowy**: Dodano funkcję asystenta głosowego i ekranowego w czasie rzeczywistym, dostępną wyłącznie dla dostawcy Google Gemini (lub zgodnych z Gemini dostawców niestandardowych). Obejmuje interaktywną zmianę głosu i głębi myślenia bezpośrednio w oknie dialogowym, z automatycznym ponownym połączeniem po zmianie ustawień.\n"
+#~ "*   **Asystent głosowy**: Dodano funkcję asystenta głosowego i ekranowego w czasie rzeczywistym, dostępną wyłącznie dla dostawcy Google Gemini (lub zgodnych z Gemini dostawców niestandardowych). Obejmuje interaktywną zmianę głosu i głębi myślenia bezpośrednio w oknie dialogowym, z automatycznym ponownym połączeniem po zmianie "
+#~ "ustawień.\n"
 #~ "*   **Dostawca MiniMax**: Zintegrowano MiniMax jako równorzędnego dostawcę z pełną obsługą multimodalną (czat, obraz, OCR), własnym TTS z ponad 300 dynamicznymi głosami oraz automatycznym usuwaniem bloków rozumowania (np. `<think>...</think>`) z odpowiedzi.\n"
 #~ "*   **Tłumaczenie w czytniku dokumentów**: Naprawiono ciche niepowodzenie tłumaczenia u osób korzystających z NVDA w językach innych niż angielski, dbając o to, by do Google Translate trafiał standardowy dwuliterowy kod języka zamiast zlokalizowanej nazwy.\n"
 #~ "*   **Ponawianie skanowania wsadowego PDF**: Wprowadzono zoptymalizowaną, osobną i cichą logikę ponawiania przy skanowaniu wsadowym dokumentów PDF, aby zapobiec zbędnym przesłaniom i uniknąć uciążliwych okienek z błędami podczas ponawiania.\n"
@@ -3791,7 +4067,8 @@ msgstr ""
 #~ "*   **Universal Local AI Integration (Setup Local AI)**: Added a new **\"Setup Local AI\"** button in Custom Provider Settings. Users can now automatically configure local AI engines, including **Ollama**, **LM Studio**, **Jan.ai**, and **KoboldCPP** instantly.\n"
 #~ "*   **Intelligent Local Proxy Bypass**: Rebuilt the connection logic with an advanced proxy bypass mechanism. The add-on is now smart enough to completely bypass Windows system proxies for local loopback connections, ensuring stable local AI connections even when your VPN/TUN-mode is active.\n"
 #~ "*   **AI Operator Emergency Cancel (Shift+A)**: Added a highly requested stop/cancel safety trigger. Pressing the AI Operator command (**Shift+A** inside the command layer) while an autonomous operation is running will instantly abort the loop and announce *\"AI Operator stopped.\"*\n"
-#~ "*   **Ultra-Stable AI Labeling (v2)**: Replaced absolute screen coordinate keys with an advanced, hybrid **Object Signature** system. Labels now rely on programmatic identifiers (UIA **AutomationId** or Win32 **ControlID**) and window-relative coordinates, making your custom labels completely resistant to window resizing, moving, monitor switching, or scaling.\n"
+#~ "*   **Ultra-Stable AI Labeling (v2)**: Replaced absolute screen coordinate keys with an advanced, hybrid **Object Signature** system. Labels now rely on programmatic identifiers (UIA **AutomationId** or Win32 **ControlID**) and window-relative coordinates, making your custom labels completely resistant to window resizing, moving, "
+#~ "monitor switching, or scaling.\n"
 #~ "*   **Seamless Automatic Label Migration**: Upgrading is completely transparent. The add-on will automatically migrate your older legacy coordinate-based labels to the new stable fingerprint format in the background upon first focus, with zero data loss."
 #~ msgstr ""
 #~ "## Zmiany w wersji 6.1.0\n"
@@ -3799,7 +4076,8 @@ msgstr ""
 #~ "*   **Uniwersalna integracja lokalnej AI (Konfiguracja lokalnej AI)**: Dodano nowy przycisk **„Konfiguracja lokalnej AI”** w ustawieniach niestandardowego dostawcy. Teraz można od razu automatycznie skonfigurować lokalne silniki AI, w tym **Ollama**, **LM Studio**, **Jan.ai** i **KoboldCPP**.\n"
 #~ "*   **Ominięcie lokalnego proxy**: Przebudowano logikę połączenia z zaawansowanym mechanizmem omijania proxy. Dodatek całkowicie omija systemowe proxy Windows przy połączeniach lokalnych, dzięki czemu połączenie z lokalną AI jest stabilne nawet przy aktywnym VPN lub trybie TUN.\n"
 #~ "*   **Awaryjne zatrzymanie Operatora AI (Shift+A)**: Dodano często wyczekiwany wyzwalacz zatrzymania. Naciśnięcie polecenia Operatora AI (**Shift+A** w warstwie poleceń) podczas trwającej operacji autonomicznej natychmiast przerywa pętlę i ogłasza *„Operator AI zatrzymany.”*\n"
-#~ "*   **Bardzo stabilne etykietowanie AI (v2)**: Zastąpiono klucze oparte na bezwzględnych współrzędnych ekranu zaawansowanym, hybrydowym systemem **sygnatur obiektów**. Etykiety opierają się teraz na identyfikatorach programowych (UIA **AutomationId** lub Win32 **ControlID**) oraz współrzędnych względem okna, dzięki czemu są całkowicie odporne na zmianę rozmiaru, przesuwanie, zmianę monitora czy skalowanie okna.\n"
+#~ "*   **Bardzo stabilne etykietowanie AI (v2)**: Zastąpiono klucze oparte na bezwzględnych współrzędnych ekranu zaawansowanym, hybrydowym systemem **sygnatur obiektów**. Etykiety opierają się teraz na identyfikatorach programowych (UIA **AutomationId** lub Win32 **ControlID**) oraz współrzędnych względem okna, dzięki czemu są "
+#~ "całkowicie odporne na zmianę rozmiaru, przesuwanie, zmianę monitora czy skalowanie okna.\n"
 #~ "*   **Płynna automatyczna migracja etykiet**: Aktualizacja jest całkowicie przezroczysta. Dodatek automatycznie przeniesie starsze etykiety oparte na współrzędnych do nowego, stabilnego formatu sygnatur w tle przy pierwszym ustawieniu fokusu, bez utraty danych."
 
 #~ msgid "Copy USDT (TRC20) Address"
@@ -3876,11 +4154,14 @@ msgstr ""
 #~ "## Changes for 5.5 (The Automation Update)\n"
 #~ "\n"
 #~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown jewel of v5.5. Vision Assistant Pro has graduated from being a passive assistant to becoming your personal **AI Operator**. It doesn't just describe the screen—it takes command.\n"
-#~ "    *   *How it works:* You can now give verbal instructions to operate your PC. For example, in a completely inaccessible application where your screen reader stays silent, you can press **Shift+A** and type: *\"Click on the Settings button\"* or *\"Find the search field, type 'Latest News' and press enter.\"* The AI visually identifies the elements, moves the mouse, and executes the task for you.\n"
+#~ "    *   *How it works:* You can now give verbal instructions to operate your PC. For example, in a completely inaccessible application where your screen reader stays silent, you can press **Shift+A** and type: *\"Click on the Settings button\"* or *\"Find the search field, type 'Latest News' and press enter.\"* The AI visually "
+#~ "identifies the elements, moves the mouse, and executes the task for you.\n"
 #~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 Flash (Preview)**, delivering incredibly fast and intelligent responses that can handle even the most complex UI layouts.\n"
 #~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" exactly what's happening to be accurate, it sends a high-resolution screenshot with every step. Please note that frequent use will consume your API quota much faster than standard text-based tasks.\n"
-#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled buttons\"? Press **E** to activate the UI Explorer. The AI will scan the entire window and generate a list of every clickable element it sees—including icons, graphics, and menus. Simply pick an item from the list, and the AI Operator will click it for you. It's like having an \"accessible layer\" on top of any app.\n"
-#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been completely overhauled. It no longer assumes you only want OCR. When you select a single image, it now intelligently asks for your intent: you can choose a **Detailed Visual Description** to understand the scene or a **Structured Text Extraction (OCR)** for reading. The menu adapts dynamically based on the file type and your active AI engine.\n"
+#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled buttons\"? Press **E** to activate the UI Explorer. The AI will scan the entire window and generate a list of every clickable element it sees—including icons, graphics, and menus. Simply pick an item from the list, and the AI Operator will click it for you. "
+#~ "It's like having an \"accessible layer\" on top of any app.\n"
+#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been completely overhauled. It no longer assumes you only want OCR. When you select a single image, it now intelligently asks for your intent: you can choose a **Detailed Visual Description** to understand the scene or a **Structured Text Extraction (OCR)** for "
+#~ "reading. The menu adapts dynamically based on the file type and your active AI engine.\n"
 #~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on's internal logic, removing unused legacy functions and redundant code. This results in a leaner, faster, and more reliable experience for all users."
 #~ msgstr ""
 #~ "## Zmiany w 5.5.2\n"
@@ -3892,11 +4173,14 @@ msgstr ""
 #~ "## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
 #~ "\n"
 #~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.\n"
-#~ "    *   *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
+#~ "    *   *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* "
+#~ "AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
 #~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.\n"
 #~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi „widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.\n"
-#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po „nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak „warstwa dostępności\" nałożona na dowolną aplikację.\n"
-#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz „F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
+#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po „nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak "
+#~ "„warstwa dostępności\" nałożona na dowolną aplikację.\n"
+#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz „F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** "
+#~ "do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
 #~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla wszystkich użytkowników."
 
 #~ msgid "Default (Auto)"
@@ -3912,21 +4196,27 @@ msgstr ""
 #~ "## Changes for 5.5 (The Automation Update)\n"
 #~ "\n"
 #~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown jewel of v5.5. Vision Assistant Pro has graduated from being a passive assistant to becoming your personal **AI Operator**. It doesn't just describe the screen—it takes command.\n"
-#~ "    *   *How it works:* You can now give verbal instructions to operate your PC. For example, in a completely inaccessible application where your screen reader stays silent, you can press **Shift+A** and type: *\"Click on the Settings button\"* or *\"Find the search field, type 'Latest News' and press enter.\"* The AI visually identifies the elements, moves the mouse, and executes the task for you.\n"
+#~ "    *   *How it works:* You can now give verbal instructions to operate your PC. For example, in a completely inaccessible application where your screen reader stays silent, you can press **Shift+A** and type: *\"Click on the Settings button\"* or *\"Find the search field, type 'Latest News' and press enter.\"* The AI visually "
+#~ "identifies the elements, moves the mouse, and executes the task for you.\n"
 #~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 Flash (Preview)**, delivering incredibly fast and intelligent responses that can handle even the most complex UI layouts.\n"
 #~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" exactly what's happening to be accurate, it sends a high-resolution screenshot with every step. Please note that frequent use will consume your API quota much faster than standard text-based tasks.\n"
-#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled buttons\"? Press **E** to activate the UI Explorer. The AI will scan the entire window and generate a list of every clickable element it sees—including icons, graphics, and menus. Simply pick an item from the list, and the AI Operator will click it for you. It’s like having an \"accessible layer\" on top of any app.\n"
-#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been completely overhauled. It no longer assumes you only want OCR. When you select a single image, it now intelligently asks for your intent: you can choose a **Detailed Visual Description** to understand the scene or a **Structured Text Extraction (OCR)** for reading. The menu adapts dynamically based on the file type and your active AI engine.\n"
+#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled buttons\"? Press **E** to activate the UI Explorer. The AI will scan the entire window and generate a list of every clickable element it sees—including icons, graphics, and menus. Simply pick an item from the list, and the AI Operator will click it for you. "
+#~ "It’s like having an \"accessible layer\" on top of any app.\n"
+#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been completely overhauled. It no longer assumes you only want OCR. When you select a single image, it now intelligently asks for your intent: you can choose a **Detailed Visual Description** to understand the scene or a **Structured Text Extraction (OCR)** for "
+#~ "reading. The menu adapts dynamically based on the file type and your active AI engine.\n"
 #~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on’s internal logic, removing unused legacy functions and redundant code. This results in a leaner, faster, and more reliable experience for all users."
 #~ msgstr ""
 #~ "## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
 #~ "\n"
 #~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.\n"
-#~ "    *   *Jak to działa:* Możesz teraz wydawać polecenia głosowe dla obsługi swojego komputera. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
+#~ "    *   *Jak to działa:* Możesz teraz wydawać polecenia głosowe dla obsługi swojego komputera. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI "
+#~ "wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
 #~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.\n"
 #~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi \"widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.\n"
-#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po \"nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak \"warstwa dostępności\" nałożona na dowolną aplikację.\n"
-#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz \"F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
+#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po \"nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak "
+#~ "\"warstwa dostępności\" nałożona na dowolną aplikację.\n"
+#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz \"F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** "
+#~ "do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
 #~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla wszystkich użytkowników."
 
 #~ msgid "Action performed"


### PR DESCRIPTION
## Summary

Polish translation updated to version 2026.08.06.

- `addon/locale/pl/LC_MESSAGES/nvda.po`: 674 active entries, 674 translated, 0 fuzzy, 0 untranslated. Merged against `VisionAssistant.pot` from the ZIP attached to #271 (POT-Creation-Date 2026-08-06 21:29+0330).
- `addon/doc/pl/readme.md`: synchronized with the English readme from the same ZIP, including the 2026.08.06 changelog.

New in this version: Voice Translation (`Control+T`), Direct Chat (`Shift+C`), Visual CAPTCHA solving, tab-based settings, dedicated file logging, Audio Transcriber overhaul, eSpeak-NG and update download progress.

All 48 entries that `msgmerge` filled in as fuzzy were reviewed one by one; 47 required a corrected translation because the fuzzy match referred to a different feature.

Terminology fixes beyond the new strings:
- Prompt Manager labels no longer start with a lowercase letter (3 entries).
- Two pairs of AI voice styles shared a single Polish word and were indistinguishable in the selection list: `Upbeat`/`Energetic` and `Breezy`/`Casual`. Now distinct.

## Test plan

- `msgfmt --statistics` reports 674 translated messages, no fuzzy, no untranslated.
- File uses LF line endings, consistent with the other locales in this repository.
- Entry count matches `uk`, the other locale already updated to this POT.