### PR TITLE
Update Polish translation for Vision Assistant Pro 2026.09.01

### DIFF
--- a/addon/doc/pl/readme.md
+++ b/addon/doc/pl/readme.md
@@ -8,7 +8,7 @@ _Dodatek trafił do społeczności z okazji Międzynarodowego Dnia Osób z Niepe
 
 ## 1. Konfiguracja
 
-Przejdź do **menu NVDA > Preferencje > Ustawienia > Vision Assistant Pro**. Okno ustawień jest podzielone na 8 zakładek: **Połączenie**, **Zachowanie AI**, **Języki tłumaczenia**, **Czytnik dokumentów**, **Wideo**, **CAPTCHA**, **Polecenia** i **Zaawansowane**.
+Przejdź do **menu NVDA > Preferencje > Ustawienia > Vision Assistant Pro**. Okno ustawień jest podzielone na 9 zakładek: **Połączenie**, **Asystent na żywo**, **Zachowanie AI**, **Języki tłumaczenia**, **Czytnik dokumentów**, **Wideo**, **CAPTCHA**, **Polecenia** i **Zaawansowane**.
 
 ### 1.1 Zakładka Połączenie
 - **Dostawca:** wybór usługi AI. Obsługiwani dostawcy to **Google Gemini**, **OpenAI**, **Mistral**, **Groq**, **MiniMax** oraz **Niestandardowy** (serwery zgodne z OpenAI, na przykład Ollama, LM Studio, Jan.ai albo KoboldCPP).
@@ -19,28 +19,35 @@ Przejdź do **menu NVDA > Preferencje > Ustawienia > Vision Assistant Pro**. Okn
 - **Osobny model dla każdego zadania:** można wskazać osobne modele dla OCR, STT, TTS, Operatora AI, wideo i asystenta głosowego.
 - **Opcje połączenia i wyjścia:** adres proxy, sprawdzanie aktualizacji przy starcie, czyszczenie Markdownu w czacie, kopiowanie odpowiedzi AI do schowka, tryb bezpośredni (nie pokazuje okna czatu) oraz tryb bezpośredni asystenta głosowego.
 
-### 1.2 Zakładka Zachowanie AI
+### 1.2 Zakładka Asystent na żywo
+- **Asystent na żywo: wyjście bezpośrednie (bez okna):** uruchamia asystenta bez okna rozmowy; można je otworzyć później klawiszem przywołania ostatniego wyniku (`Spacja`).
+- **Naciśnij i mów:** włącza tryb naciśnij i mów. Gdy jest aktywny, mikrofon wysyła dźwięk tylko wtedy, gdy trzymasz przypisany klawisz.
+- **Klawisz funkcji Naciśnij i mów:** naciśnij klawisze, aby zapisać skrót (na przykład `F12` lub `Ctrl+F12`) — możesz przypisać nawet sam modyfikator, taki jak `lewy Ctrl`. Przytrzymaj klawisz, aby mówić, i zwolnij go po zakończeniu; każde naciśnięcie i zwolnienie potwierdza krótki sygnał.
+
+Uwaga: ta zakładka pojawia się tylko wtedy, gdy aktywnym dostawcą jest **Google Gemini** (lub zgodny z Gemini dostawca niestandardowy).
+
+### 1.3 Zakładka Zachowanie AI
 - **Kreatywność (temperatura):** steruje losowością odpowiedzi (od 0,0 do 2,0). Niższe wartości dają bardziej przewidywalne odpowiedzi. Nie wpływa na OCR ani na tłumaczenie.
 
-### 1.3 Zakładka Języki tłumaczenia
+### 1.4 Zakładka Języki tłumaczenia
 - **Język źródłowy:** domyślny język wejściowy.
 - **Język docelowy:** główny język tłumaczenia.
 - **Język odpowiedzi AI:** język ogólnych odpowiedzi AI.
 - **Zamiana:** automatycznie zamienia język źródłowy z docelowym na podstawie wykrytego wejścia.
 
-### 1.4 Zakładka Czytnik dokumentów
+### 1.5 Zakładka Czytnik dokumentów
 - **Silnik OCR:** do wyboru **Chrome (szybki)** dla szybkich wyników albo **AI (zaawansowany)** dla lepszego zachowania układu strony.
 - **Porcja OCR:** liczba stron na jedno żądanie (0 wyłącza dzielenie i wysyła wszystko w jednym żądaniu).
 - **Wplataj opisy obrazów w tekst:** przy wyodrębnianiu treści dokumentu opis obrazu ląduje dokładnie tam, gdzie w dokumencie znajduje się obraz, a nie osobno na końcu.
 - **Numery stron przy eksporcie:** włącza numery stron i separatory w dokumentach wielostronicowych.
 - **Głos TTS:** domyślny styl głosu przy generowaniu mowy.
 
-### 1.5 Zakładka Wideo
+### 1.6 Zakładka Wideo
 - **Rozmiar fragmentu wideo:** długość odcinka w minutach przy generowaniu audiodeskrypcji (0 wyłącza dzielenie i przetwarza cały plik).
 - **Dodaj listę postaci:** wstawia listę postaci jako pierwszy napis.
 - **Dodaj informację o AI:** wstawia informację o udziale AI na początku napisów SRT do wideo.
 
-### 1.6 Zakładka CAPTCHA
+### 1.7 Zakładka CAPTCHA
 
 Dodatek radzi sobie z **dwoma rodzajami CAPTCHA**, a wybiera między nimi sam. Obsługuje je jeden skrót — **C** w warstwie poleceń — i nie trzeba z góry wiedzieć, na którą się trafiło.
 
@@ -53,15 +60,20 @@ Ustawienia:
 - **Włącz rozwiązywanie CAPTCHA obrazkowej:** włącza i wyłącza obsługę zagadek obrazkowych (hCaptcha, reCAPTCHA). Wyłączenie nie rusza CAPTCHA tekstowej — ta działa dalej.
 - **Metoda dla CAPTCHA tekstowej:** przechwytywanie **obiektu nawigatora** albo **całego ekranu**. Dotyczy wyłącznie kodów do przepisania.
 
-### 1.7 Zakładka Polecenia
+### 1.8 Zakładka Polecenia
 - **Zarządzaj poleceniami:** otwiera osobne okno, w którym można zmienić domyślne polecenia systemowe albo tworzyć, edytować, porządkować i podglądać własne polecenia ze zmiennymi (na przykład `[selection]`, `[screen_fg_obj]`).
 
-### 1.8 Zakładka Zaawansowane i globalny dziennik
+### 1.9 Zakładka Zaawansowane i globalny dziennik
 W zakładce **Zaawansowane** konfiguruje się globalny dziennik dodatku:
 - **Włącz osobny plik dziennika:** zapisuje zdarzenia, ruch do API i błędy ze wszystkich modułów dodatku do osobnego pliku (`vision_assistant.log`).
 - **Poziom szczegółowości dziennika:** **Diagnostyka (wszystkie szczegóły)**, **Informacje (ogólne)**, **Ostrzeżenia (tylko ostrzeżenia)** albo **Błędy (tylko błędy)**.
 - **Przechowuj dziennik przez:** automatyczne czyszczenie starszych wpisów, od godziny do 90 dni.
 - **Zarządzanie dziennikiem:** **Otwórz plik dziennika**, **Otwórz folder dziennika** i **Wyczyść plik dziennika** pozwalają zajrzeć do danych albo je usunąć bez restartu NVDA i bez mieszania się do standardowego dziennika NVDA.
+
+### 1.10 Kopia zapasowa i przywracanie ustawień
+Zakładka **Zaawansowane** zawiera także sekcję **Kopia zapasowa i przywracanie**:
+- **Kopia zapasowa:** zapisuje konfigurację do pojedynczego pliku JSON. Po kliknięciu wybierasz zakres: **Wszystko** (ustawienia, własne etykiety, postęp OCR i historia) albo **Tylko ustawienia**.
+- **Przywróć:** wczytuje wcześniej zapisaną kopię, aby odtworzyć konfigurację i dane w dowolnej chwili, na dowolnym komputerze albo po ponownej instalacji NVDA. Najpierw pojawi się prośba o potwierdzenie, ponieważ przywracanie zastępuje wszystkie bieżące ustawienia i dane.
 
 ## 2. Warstwa poleceń i skróty
 
@@ -100,7 +112,18 @@ Aby uniknąć konfliktów skrótów klawiszowych, dodatek używa **warstwy polec
 | **Góra / Dół** | Nawigacja po szybkich ustawieniach | Przechodzi między kategoriami szybkich ustawień (dostawca, model i inne) w warstwie. |
 | **Lewo / Prawo** | Zmiana szybkiego ustawienia | Zmienia wartość wybranego szybkiego ustawienia. |
 
-## 3. Operator AI — autonomiczne sterowanie komputerem
+## 3. Czat i historia
+
+### 3.1 Skróty okna czatu
+Gdy okno czatu jest otwarte (czat bezpośredni, czat z dokumentem, dopracowywanie i podobne), możesz przeglądać rozmowę klawiszami:
+- **Alt + strzałka w dół:** odczytuje następną wiadomość.
+- **Alt + strzałka w górę:** odczytuje poprzednią wiadomość.
+- **Alt + C:** kopiuje bieżącą wiadomość.
+
+### 3.2 Historia (Control + H)
+Naciśnij **Control + H** w warstwie poleceń, aby otworzyć okno **Historii** z wcześniejszymi czatami i dokumentami, z możliwością filtrowania według typu (Wszystko / Czaty / Dokumenty). Otwórz czat, aby kontynuować rozmowę — wraz z załączonymi plikami, które dołączą się automatycznie — albo otwórz dokument i czytaj dalej. Naciśnij **Delete** na wybranej pozycji, aby ją usunąć, albo **Wyczyść wszystko**, aby opróżnić listę.
+
+## 4. Operator AI — autonomiczne sterowanie komputerem
 
 **Operator AI** zamienia Vision Assistant Pro z czytnika w asystenta, który działa na komputerze w Twoim imieniu. Można poprosić go o opis ekranu, o odpowiedź na pytanie o to, co widzi, albo oddać mu sterowanie: klikanie przycisków, przeciąganie elementów, wpisywanie tekstu i poruszanie się po aplikacjach zwykłym językiem.
 
@@ -129,88 +152,112 @@ Operator rozumie szeroki zakres poleceń:
 - **Aplikacje administracyjne**: jeśli NVDA nie działa z uprawnieniami administratora, operator może nie obsłużyć okien wymagających podwyższonych uprawnień. To ograniczenie bezpieczeństwa Windows, nie błąd dodatku.
 - **Dobre praktyki**: najlepiej działają polecenia konkretne. „Kliknij niebieski przycisk Wyślij na dole formularza” zadziała prawie zawsze lepiej niż samo „Kliknij przycisk”.
 
-## 4. Analiza wideo i audiodeskrypcja
+## 5. Analiza wideo i audiodeskrypcja
 
 > **Uwaga:** analiza wideo i audiodeskrypcja działają wyłącznie na dostawcy **Google Gemini**. Upewnij się, że w ustawieniach dodatku aktywnym dostawcą jest Google Gemini.
 
 Vision Assistant Pro przetwarza wideo z myślą o osobach niewidomych. Analizuje zarówno filmy online, jak i lokalne nagrania ekranu, dając szczegółowe opisy wizualne oraz gotowe skrypty audiodeskrypcji w formacie SRT.
 
-### 4.1 Nagrywanie ekranu (Control + V)
+### 5.1 Nagrywanie ekranu (Control + V)
 Jeśli trafisz na bezgłośne wideo, animację albo poradnik na ekranie, możesz nagrać go bezpośrednio:
 1. Naciśnij **NVDA + Shift + V**, żeby wejść w warstwę poleceń, potem **Control + V**.
 2. Dodatek zacznie po cichu nagrywać ekran w tle.
 3. Ponowne **Control + V** kończy nagrywanie.
 4. AI przeanalizuje nagrany fragment i szczegółowo opisze scenę, postacie i przebieg zdarzeń.
 
-### 4.2 Analiza wideo (Shift + V)
+### 5.2 Analiza wideo (Shift + V)
 Analizować można zarówno lokalne pliki, jak i filmy online. Wystarczy zaznaczyć plik wideo w Eksploratorze Windows albo skopiować link do schowka. Można też nacisnąć **Shift + V** w dowolnym miejscu (na przykład w odtwarzaczu), żeby otworzyć okno, w którym wskazuje się plik albo wkleja adres ręcznie.
 - **Obsługiwane serwisy:** YouTube, Instagram, TikTok i Twitter (X).
 - Dodatek sam rozpozna plik lokalny albo adres, przetworzy wideo i poda pełny opis wizualny oraz podsumowanie dźwięku.
 
-### 4.3 Generowanie audiodeskrypcji (SRT)
+### 5.3 Generowanie audiodeskrypcji (SRT)
 Dodatek tworzy skrypty audiodeskrypcji w standardowym formacie SubRip (SRT).
 - **Dopasowanie do pauz:** AI słucha ścieżki dźwiękowej i zaczepia opisy o naturalne pauzy i ciszę, żeby jak najmniej nachodziły na dialog.
 - **Śledzenie postaci:** silnik najpierw wyodrębnia poszczególne postacie po niezmiennych cechach twarzy. Buduje globalny słownik, dzięki czemu rozpoznaje i nazywa te same osoby w różnych scenach bez pomyłek.
 - **Dosłowny OCR tekstu:** każdy tekst pojawiający się na ekranie, taki jak np. napisy końcowe jest cytowany dosłownie.
 - **Jak z tego skorzystać:** żeby odsłuchać wygenerowane napisy, umieść plik `.srt` w tym samym folderze co wideo i nadaj mu dokładnie tę samą nazwę. Potem ustaw w odtwarzaczu (na przykład VLC albo PotPlayer) przekazywanie tekstu napisów wprost do czytnika ekranu albo silnika TTS podczas odtwarzania.
 
-### 4.4 Zsynchronizowana narracja dźwiękowa (eksport MP3)
+### 5.4 Zsynchronizowana narracja dźwiękowa (eksport MP3)
 Dodatek nie kończy na plikach SRT — jest pełnym narzędziem produkcyjnym audiodeskrypcji: syntezuje opisy na mowę i miksuje je z wideo. Jako silnik głosu można teraz wybrać **Gemini Live TTS**, który przez Gemini Live API tworzy bardzo naturalną narrację bez ograniczeń długości. Przy generowaniu MP3 dla plików lokalnych dostępnych jest kilka trybów miksowania:
 - **Standardowa audiodeskrypcja (miks głosu):** narracja nakłada się bezpośrednio na dźwięk wideo. Pojawi się pytanie, czy zastosować **przyciszanie tła** podczas opisów, żeby narracja była wyraźna.
 - **Rozszerzona audiodeskrypcja (pauza dźwięku):** silnik zatrzymuje oryginalny dźwięk na czas opisu, dzięki czemu nie umknie ani słowo dialogu, ani narracji.
 - **Filmy z YouTube:** dla źródeł z YouTube (które nie są pobierane lokalnie) eksport MP3 zawiera wyłącznie zsynchronizowaną ścieżkę głosu AI, bez dźwięku tła.
 
-## 5. Transkrypcja i dubbing mediów (M)
+## 6. Transkrypcja i dubbing mediów (M)
 Moduł transkrypcji został napisany od nowa i obsługuje zarówno pliki dźwiękowe, jak i wideo (MP3, WAV, MP4, MKV i inne). Naciśnij **M** w warstwie poleceń, żeby wybrać plik i jeden z trzech trybów pracy:
 1. **Transkrybuj (język oryginału)**: dokładnie transkrybuje wypowiedź w języku oryginału.
 2. **Transkrybuj i przetłumacz (język docelowy)**: transkrybuje wypowiedź i tłumaczy ją na ustawiony język docelowy.
 3. **Zdubbinguj i przetłumacz (język docelowy)** *(tylko Gemini)*: transkrybuje wypowiedź, tłumaczy ją na język docelowy i tworzy mówioną ścieżkę dźwiękową silnikiem TTS dodatku.
 
-## 6. Zaawansowany czytnik dokumentów i obrazów
+## 7. Zaawansowany czytnik dokumentów i obrazów
 
-Vision Assistant Pro ma zoptymalizowany czytnik dokumentów przygotowany pod wielostronicowe pliki PDF, złożone obrazy, a nawet format HEIC z iPhone'a.
+**Czytnik dokumentów** zamienia dokumenty w czysty, czytelny tekst — dzięki czemu możesz czytać, tłumaczyć i słuchać wszystkiego, od zeskanowanej książki po stos zdjęć. Obsługuje wielostronicowe pliki PDF, złożone obrazy, format HEIC z iPhone'a, a nawet zwykłe pliki tekstowe (`.txt`) oraz HTML (`.html`, `.htm`), które otwierają się natychmiast, bez OCR i bez przetwarzania przez AI. Możesz wybrać kilka plików naraz — zostaną scalone w jeden ciągły dokument w kolejności stron. Dostępne są trzy silniki OCR: **Chrome (szybki)**, **AI (zaawansowany)** dla lepszego zachowania układu oraz **Wyodrębnij tekst (offline)** dla plików PDF z warstwą tekstową; wybiera się je w Ustawieniach → Czytnik dokumentów.
 
-### 6.1 Przetwarzanie wsadowe i wznawianie
+### Jak to działa
+1. Naciśnij **NVDA + Shift + V**, a następnie **D**, aby otworzyć czytnik dokumentów — albo zaznacz najpierw plik w Eksploratorze plików i naciśnij **D** lub **F**, aby całkiem pominąć okno wyboru pliku.
+2. Wybierz jeden lub więcej plików PDF albo obrazów. Dodatek przeskanuje je i poda łączną liczbę stron.
+3. W oknie **Opcje** wybierz zakres stron (Od/Do). Możesz też zaznaczyć **Tłumacz wynik** i wskazać język docelowy albo włączyć **Opisuj obrazy w trakcie OCR**.
+4. Wyodrębnianie tekstu rusza w tle, partiami. Okno możesz zamknąć w dowolnej chwili i wrócić później — nic nie ginie.
+5. Gdy strony są gotowe, czytaj je w podglądzie: przechodź między stronami, skocz do dowolnej strony, zadawaj pytania AI, zapisz tekst albo wygeneruj narrację dźwiękową.
+
+### 7.1 Przetwarzanie wsadowe i wznawianie
 Nie trzeba czytać wielkiego dokumentu za jednym razem. Podaj zakres stron (na przykład `1-20`), a AI przetworzy je w tle. Jeśli NVDA ulegnie awarii albo przerwiesz skanowanie, dodatek zapamięta postęp i zaproponuje **wznowienie** dokładnie w miejscu przerwania.
 
-### 6.2 Akcja na pliku
+### 7.2 Akcja na pliku
 Nie zawsze trzeba najpierw otwierać dokument. W Eksploratorze plików Windows wystarczy zaznaczyć plik PDF albo obraz i w warstwie poleceń nacisnąć **D** (czytnik dokumentów) albo **F** (akcja na pliku). Dodatek pominie okno wyboru pliku i od razu zacznie przetwarzanie zaznaczonego dokumentu.
 
-### 6.3 Skróty czytnika dokumentów
+### 7.3 Skróty czytnika dokumentów
 Gdy okno czytnika jest otwarte, działają następujące skróty:
-- **Ctrl + PageDown:** następna strona.
-- **Ctrl + PageUp:** poprzednia strona.
+#### Skróty klawiszowe
+- **Ctrl + PageDown / Ctrl + PageUp:** przejście do następnej / poprzedniej strony.
+- **Strzałka w dół / w górę:** gdy kursor dojdzie do ostatniego wiersza strony, naciśnij **strzałkę w dół**, aby przeskoczyć na następną stronę; naciśnięcie **strzałki w górę** na początku strony wraca do poprzedniej.
 - **Alt + A:** okno rozmowy z pytaniami o dokument.
 - **Alt + R:** wymuszenie **ponownego skanowania przez AI** aktywnym dostawcą.
 - **Alt + G:** wygenerowanie i zapisanie pliku dźwiękowego wysokiej jakości (WAV/MP3). *(Ukryte, jeśli dostawca nie obsługuje TTS).*
 - **Alt + S / Ctrl + S:** zapis wyodrębnionego tekstu jako plik TXT albo HTML.
 
-## 7. Etykietowanie semantyczne i Eksplorator interfejsu
+#### Przyciski i elementy sterujące
+- **Przejdź do:** wybór dowolnej strony z listy stron.
+- **Pokaż sformatowany:** wyświetla cały dokument scalony jako sformatowany tekst.
+- **Ponów nieudane strony:** ponawia wyłącznie te partie, które nie powiodły się z powodu tymczasowego błędu serwera (na przykład przy dużym obciążeniu). Przycisk pojawia się automatycznie wtedy, gdy jest potrzebny.
+- **Głos syntezy / Silnik syntezy mowy:** wybór głosu, a przy dostawcy Gemini także wybór między **standardową syntezą mowy** a strumieniowym **Gemini Live**.
+- **Poprzednia / Następna:** przechodzenie między stronami (to samo co skróty Ctrl+PageUp i Ctrl+PageDown).
+
+### 7.4 Ostatnie dokumenty (D)
+Naciśnięcie **D** w warstwie poleceń pokazuje najpierw ostatnio czytane dokumenty. Wybierz jeden, aby kontynuować od strony, na której skończyłeś — nawet jeśli OCR już się zakończył — albo naciśnij **Otwórz plik...** (`Ctrl + O`), aby wybrać plik jak zwykle.
+
+## 8. Etykietowanie semantyczne i Eksplorator interfejsu
 
 Aplikacja, w której wszędzie słychać „nieoznaczony przycisk”? Silnik etykietowania semantycznego rozwiązuje to na stałe.
 
-### 7.1 Trwałe etykietowanie obiektu (L)
+### 8.1 Trwałe etykietowanie obiektu (L)
 Ustaw czytnik na nieoznaczonej grafice albo przycisku i naciśnij **L** w warstwie poleceń. AI obejrzy przycisk, rozpozna jego funkcję i nada mu trwałą etykietę.
 *W odróżnieniu od starszych narzędzi do etykietowania, ten dodatek korzysta z hybrydowego systemu „sygnatury obiektu” (AutomationId/ControlID). Własne etykiety przetrwają zmianę rozmiaru okna, przełączenie monitora i aktualizację aplikacji.*
 
-### 7.2 Skanowanie całej aplikacji (Shift + L)
+### 8.2 Skanowanie całej aplikacji (Shift + L)
 Naciśnij **Shift + L**, żeby przeskanować całe aktywne okno naraz. AI znajdzie wszystkie nieoznaczone elementy i nazwie je za jednym razem. Etykiety można potem przeglądać, zmieniać i usuwać zbiorczo we wbudowanym menedżerze etykiet.
 
-### 7.3 Eksplorator interfejsu (E)
+### 8.3 Eksplorator interfejsu (E)
 Chcesz obsłużyć element bez ręcznego docierania do niego? Naciśnij **E**, żeby uruchomić Eksplorator interfejsu. AI przeskanuje ekran i utworzy dostępną listę wszystkich klikalnych elementów (pomijając szum systemowy w rodzaju paska zadań). Wybierz pozycję z listy, a dodatek od razu ją kliknie.
 
-## 8. Asystent głosowy
+## 9. Asystent głosowy
 
 Asystent głosowy zamienia Vision Assistant Pro w interaktywnego pomocnika działającego w czasie rzeczywistym.
 *(Uwaga: funkcja dostępna wyłącznie w Google Gemini i w niestandardowych dostawcach zgodnych z Gemini).*
 
 - **Uruchomienie:** naciśnij **Control + L** w warstwie poleceń, żeby otworzyć okno asystenta głosowego.
 - **Rozmowa w czasie rzeczywistym:** mów swobodnie do mikrofonu. AI jednocześnie słucha i patrzy na aktywny ekran. Można pytać na przykład „Na co teraz patrzę?” albo „Przeczytaj mi trzeci akapit”.
+- **Naciśnij i mów:** włącz opcję **Naciśnij i mów** w zakładce ustawień asystenta na żywo (albo przełącz ją bezpośrednio w oknie asystenta), a potem przytrzymuj przypisany klawisz, żeby mówić, i zwalniaj go po zakończeniu. Mikrofon pozostaje wyciszony, dopóki nie naciśniesz klawisza — idealne w głośnym otoczeniu.
 - **Dostosowanie:** w oknie można zmienić styl głosu AI (na przykład profesjonalny, przyjazny, energiczny) oraz **głębię myślenia**, czyli to, jak dokładnie AI rozważa odpowiedź.
 
-## 9. Polecenia niestandardowe i zmienne
+## 10. Polecenia niestandardowe i zmienne
 
 Poleceniami zarządza się w **Ustawienia > Polecenia > Zarządzaj poleceniami...**.
+
+### Skróty poleceń niestandardowych
+Nadaj dowolnemu poleceniu niestandardowemu własny skrót klawiszowy bezpośrednio w menedżerze poleceń i uruchamiaj je natychmiast z bieżącym zaznaczeniem lub kontekstem:
+- **Pojedynczy klawisz** (na przykład `1`, `p` albo `F3`): działa w warstwie poleceń, a także globalnie jako `NVDA + Shift + klawisz`.
+- **Kombinacja klawiszy** (na przykład `Control + Shift + 1`, `Alt + P` albo `Insert + 1`): działa globalnie samodzielnie.
 
 ### Obsługiwane zmienne
 - `[selection]`: zaznaczony tekst.
@@ -228,7 +275,7 @@ Poleceniami zarządza się w **Ustawienia > Polecenia > Zarządzaj poleceniami..
 - `{swap_target}`: język zapasowy przy tłumaczeniu z zamianą.
 - `{swap_instruction}`: blok instrukcji tłumaczenia z zamianą.
 
-## 10. Zastosowania w praktyce (której funkcji użyć?)
+## 11. Zastosowania w praktyce (której funkcji użyć?)
 
 Vision Assistant Pro ma dużo narzędzi. Poniżej typowe sytuacje, które pomogą wybrać właściwe:
 
@@ -259,7 +306,7 @@ Vision Assistant Pro ma dużo narzędzi. Poniżej typowe sytuacje, które pomog�
 ***
 **Uwaga:** wszystkie funkcje AI wymagają aktywnego połączenia z internetem. Dokumenty wielostronicowe są przetwarzane automatycznie.
 
-## 11. Wsparcie i społeczność
+## 12. Wsparcie i społeczność
 
 Bądź na bieżąco z nowościami, funkcjami i wydaniami:
 - **Kanał na Telegramie:** [t.me/VisionAssistantPro](https://t.me/VisionAssistantPro)
@@ -268,7 +315,7 @@ Bądź na bieżąco z nowościami, funkcjami i wydaniami:
 ### Zgłaszanie błędów i dzienniki
 Otwierając zgłoszenie na GitHubie albo prosząc o pomoc, podaj aktywnego dostawcę AI, model i wersję NVDA. Jeśli masz problemy z połączeniem albo nieoczekiwane awarie, włącz osobny plik dziennika w **Ustawienia > Zaawansowane**, powtórz sytuację i dołącz plik `vision_assistant.log` — to znacznie przyspieszy rozwiązanie problemu.
 
-## 12. Patroni projektu
+## 13. Patroni projektu
 
 Serdecznie dziękujemy osobom ze społeczności, które wspierają rozwój i utrzymanie tego projektu swoim wkładem finansowym:
 
@@ -283,6 +330,23 @@ Serdecznie dziękujemy osobom ze społeczności, które wspierają rozwój i utr
 *Jeśli chcesz wesprzeć projekt finansowo i zobaczyć tutaj swoje imię, opcję **Wsparcie** znajdziesz w menu Narzędzia NVDA (podmenu Vision Assistant) albo podczas konfiguracji po instalacji.*
 
 ---
+## Zmiany w wersji 2026.09.01
+
+*   **Historia (Control + H)**: warstwa poleceń zawiera teraz okno **Historii** (`Control + H`), które wypisuje wcześniejsze czaty i dokumenty, z filtrami Wszystko, Czaty i Dokumenty. Możesz otworzyć ponownie dowolny czat wraz z całą rozmową — załączone pliki dołączają się automatycznie — albo wrócić do dokumentu i czytać dalej. Naciśnij **Delete** na wybranej pozycji, aby ją usunąć, lub wyczyść wszystko naraz.
+*   **Ostatnie dokumenty w czytniku**: naciśnięcie **D** w warstwie poleceń pokazuje teraz najpierw ostatnio czytane dokumenty. Wybierz jeden, aby kontynuować od strony, na której skończyłeś — nawet gdy OCR już się zakończył — albo naciśnij **Otwórz plik...** (`Ctrl + O`), aby przeglądać jak dotąd.
+*   **Naciśnij i mów w asystencie na żywo**: przejmij pełną kontrolę nad rozmowami na żywo. Włącz opcję **Naciśnij i mów** w nowej karcie ustawień asystenta na żywo i przypisz dowolny klawisz — nawet sam modyfikator, taki jak `lewy Ctrl`. Przytrzymaj klawisz, aby mówić, i zwolnij go po zakończeniu; każdemu naciśnięciu i zwolnieniu towarzyszy krótki sygnał. Odpowiedni przełącznik pojawia się też w samym oknie asystenta, więc możesz przechodzić między trybem naciśnij i mów a otwartym mikrofonem bez opuszczania rozmowy.
+*   **Gemini 2.5 Flash z natywnym dźwiękiem**: asystent na żywo obsługuje teraz model natywnego dźwięku Gemini 2.5 Flash (`gemini-2.5-flash-native-audio-preview-12-2025`), zapewniający naturalne rozmowy głosowe o małym opóźnieniu. Możesz go wybrać w **Ustawieniach → Zaawansowane kierowanie modeli → Model asystenta na żywo (tylko Gemini)** albo zostawić \"Auto\", aby korzystać z modelu zalecanego.
+*   **Kopia zapasowa i przywracanie ustawień**: w karcie **Zaawansowane** pojawił się rozbudowany system kopii zapasowych. Możesz zapisać wszystkie ustawienia dodatku — w tym klucze API, modele, polecenia niestandardowe i preferencje — do jednego pliku JSON, a potem odtworzyć je w dowolnej chwili, na dowolnym komputerze albo po ponownej instalacji NVDA. Przy tworzeniu kopii wybierasz jej zakres: **Wszystko** (ustawienia, własne etykiety, postęp OCR i historia) albo **Tylko ustawienia**.
+*   **Bezpośrednie czytanie plików tekstowych i HTML**: czytnik dokumentów otwiera teraz wprost pliki tekstowe (`.txt`) oraz HTML (`.html`, `.htm`). Automatycznie rozpoznaje kodowanie pliku, usuwa skrypty i zbędne formatowanie oraz dzieli treść na czytelne strony — potrafi też ponownie wczytać własne wyeksportowane pliki z zachowaniem podziału na strony — więc przeczytasz je od razu, bez OCR i bez przetwarzania przez AI.
+*   **Gemini Live jako synteza mowy w czytniku**: przycisk \"Generuj dźwięk\" obsługuje teraz Gemini Live, czyli strumieniową syntezę mowy o wysokiej jakości i naturalnym tempie. Gdy aktywnym dostawcą jest Gemini, możesz wybrać w czytniku między standardową syntezą a Gemini Live, a wybór zostanie zapamiętany.
+*   **Skróty klawiszowe poleceń niestandardowych**: każdemu własnemu poleceniu możesz teraz przypisać skrót klawiszowy bezpośrednio w menedżerze poleceń. Nadaj poleceniu własny klawisz lub kombinację, aby uruchamiać je natychmiast, automatycznie przechwytując bieżące zaznaczenie lub kontekst, bez żadnych dodatkowych kroków.
+*   **Nawigacja po wiadomościach czatu**: przejrzyj każdą rozmowę bez użycia rąk. W dowolnym oknie czatu (czat bezpośredni, czat z dokumentem, dopracowywanie i inne) naciśnij `Alt + strzałka w dół`, aby usłyszeć następną wiadomość, a `Alt + strzałka w górę`, aby usłyszeć poprzednią — z wyraźnymi przedrostkami \"Ty\" i \"AI\" oraz zapowiedzią granic \"Pierwsza wiadomość\" i \"Ostatnia wiadomość\".
+*   **Kopiowanie wiadomości czatu (Alt + C)**: przeglądając rozmowę klawiszami `Alt + strzałki`, naciśnij `Alt + C`, aby skopiować bieżącą wiadomość do schowka — z uwzględnieniem ustawienia czyszczenia znaczników Markdown — wraz z potwierdzeniem głosowym.
+*   **Instrukcja czatu bezpośredniego**: czat bezpośredni (`Shift+C`) ma teraz własną, edytowalną instrukcję systemową — \"Instrukcja czatu bezpośredniego\" — która ustala osobowość asystenta i język odpowiedzi dla każdej rozmowy. Możesz ją zmienić w karcie poleceń domyślnych w menedżerze poleceń.
+*   **Przechodzenie między stronami kursorem w czytniku**: czytanie dokumentów wielostronicowych jest płynniejsze. Gdy w podglądzie dokumentu kursor dojdzie do ostatniego wiersza strony i naciśniesz `strzałkę w dół`, czytnik automatycznie przejdzie do następnej strony. Naciśnięcie `strzałki w górę` na początku strony wraca do poprzedniej — koniec z ręcznym przełączaniem stron podczas czytania.
+*   **Nowe przełączniki w szybkich ustawieniach**: kopiowanie odpowiedzi AI do schowka, wyjście bezpośrednie (bez okna czatu), czyszczenie znaczników Markdown w czacie oraz inteligentna zamiana dają się teraz włączać i wyłączać natychmiast z szybkich ustawień w warstwie poleceń.
+*   **Karta ustawień asystenta na żywo**: asystent na żywo ma teraz własną kartę ustawień. Opcja \"Asystent na żywo: wyjście bezpośrednie (bez okna)\" przeniosła się tu z karty połączenia, a sama karta pojawia się tylko wtedy, gdy aktywnym dostawcą jest Google Gemini lub zgodny z Gemini dostawca niestandardowy.
+
 ## Zmiany w wersji 2026.08.06
 
 *   **Etykietowanie w Eksploratorze interfejsu**: teraz można dodawać etykiety wprost do znalezionych elementów w Eksploratorze interfejsu. Doszedł przycisk „Dodaj etykietę”, a okno zostaje otwarte i utrzymuje fokus, więc kilka obiektów da się opisać jeden po drugim bez przerywania pracy.

--- a/addon/locale/pl/LC_MESSAGES/nvda.po
+++ b/addon/locale/pl/LC_MESSAGES/nvda.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 'VisionAssistant' '2026.08.06'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
-"POT-Creation-Date: 2026-08-06 21:29+0330\n"
+"POT-Creation-Date: 2026-08-21 00:36+0330\n"
 "PO-Revision-Date: 2026-08-09 12:44+0200\n"
 "Last-Translator: Oliwia Sobczak <oliwia.sobczak@proton.me>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -13,894 +13,975 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#. Translators: Prefix for custom prompts in the Refine menu
-#: addon\globalPlugins\visionAssistant\prompt_utils.py:217 addon\globalPlugins\visionAssistant\vision_config.py:1024
-msgid "Custom: "
-msgstr "Niestandardowe: "
-
 #. --- 1. Recommended (Auto-Updating) ---
-#. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest
-#. version.
-#: addon\globalPlugins\visionAssistant\vision_config.py:36 addon\globalPlugins\visionAssistant\vision_config.py:37
+#. Translators: AI Model info. [Auto] = Automatic updates. (Latest) = Newest version.
+#: addon\globalPlugins\visionAssistant\vision_config.py:45
+#: addon\globalPlugins\visionAssistant\vision_config.py:46
 msgid "[Auto]"
 msgstr "[Auto]"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:36 addon\globalPlugins\visionAssistant\vision_config.py:37
+#: addon\globalPlugins\visionAssistant\vision_config.py:45
+#: addon\globalPlugins\visionAssistant\vision_config.py:46
 msgid "(Latest)"
 msgstr "(Najnowszy)"
 
 #. --- 2. Current Standard (Free & Fast) ---
-#. Translators: AI Model info. [Free] = Generous usage limits. (Preview) =
-#. Experimental or early-access version.
-#: addon\globalPlugins\visionAssistant\vision_config.py:41 addon\globalPlugins\visionAssistant\vision_config.py:42 addon\globalPlugins\visionAssistant\vision_config.py:43 addon\globalPlugins\visionAssistant\vision_config.py:44 addon\globalPlugins\visionAssistant\vision_config.py:45
-#: addon\globalPlugins\visionAssistant\vision_config.py:46
+#. Translators: AI Model info. [Free] = Generous usage limits. (Preview) = Experimental or early-access version.
+#: addon\globalPlugins\visionAssistant\vision_config.py:50
+#: addon\globalPlugins\visionAssistant\vision_config.py:51
+#: addon\globalPlugins\visionAssistant\vision_config.py:52
+#: addon\globalPlugins\visionAssistant\vision_config.py:53
+#: addon\globalPlugins\visionAssistant\vision_config.py:54
+#: addon\globalPlugins\visionAssistant\vision_config.py:55
 msgid "[Free]"
 msgstr "[Darmowy]"
 
 #. --- 3. High Intelligence (Paid/Pro/Preview) ---
-#. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview)
-#. = Experimental version.
-#: addon\globalPlugins\visionAssistant\vision_config.py:50 addon\globalPlugins\visionAssistant\vision_config.py:51
+#. Translators: AI Model info. [Pro] = High intelligence/Paid tier. (Preview) = Experimental version.
+#: addon\globalPlugins\visionAssistant\vision_config.py:59
+#: addon\globalPlugins\visionAssistant\vision_config.py:60
 msgid "[Pro]"
 msgstr "[Pro]"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:50
+#: addon\globalPlugins\visionAssistant\vision_config.py:59
 msgid "(Preview)"
 msgstr "(Podgląd)"
 
 #. Translators: Adjective describing a bright AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:56 addon\globalPlugins\visionAssistant\vision_config.py:72
+#: addon\globalPlugins\visionAssistant\vision_config.py:65
+#: addon\globalPlugins\visionAssistant\vision_config.py:81
 msgid "Bright"
 msgstr "Jasny"
 
 #. Translators: Adjective describing an upbeat AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:58 addon\globalPlugins\visionAssistant\vision_config.py:85
+#: addon\globalPlugins\visionAssistant\vision_config.py:67
+#: addon\globalPlugins\visionAssistant\vision_config.py:94
 msgid "Upbeat"
 msgstr "Pogodny"
 
 #. Translators: Adjective describing an informative AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:60 addon\globalPlugins\visionAssistant\vision_config.py:84
+#: addon\globalPlugins\visionAssistant\vision_config.py:69
+#: addon\globalPlugins\visionAssistant\vision_config.py:93
 msgid "Informative"
 msgstr "Informacyjny"
 
 #. Translators: Adjective describing a firm AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:62 addon\globalPlugins\visionAssistant\vision_config.py:67 addon\globalPlugins\visionAssistant\vision_config.py:88
+#: addon\globalPlugins\visionAssistant\vision_config.py:71
+#: addon\globalPlugins\visionAssistant\vision_config.py:76
+#: addon\globalPlugins\visionAssistant\vision_config.py:97
 msgid "Firm"
 msgstr "Stanowczy"
 
 #. Translators: Adjective describing an excitable AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:64
+#: addon\globalPlugins\visionAssistant\vision_config.py:73
 msgid "Excitable"
 msgstr "Entuzjastyczny"
 
 #. Translators: Adjective describing a youthful AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:66
+#: addon\globalPlugins\visionAssistant\vision_config.py:75
 msgid "Youthful"
 msgstr "Młodzieńczy"
 
 #. Translators: Adjective describing a breezy AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:69
+#: addon\globalPlugins\visionAssistant\vision_config.py:78
 msgid "Breezy"
 msgstr "Lekki"
 
 #. Translators: Adjective describing an easy-going AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:71 addon\globalPlugins\visionAssistant\vision_config.py:77
+#: addon\globalPlugins\visionAssistant\vision_config.py:80
+#: addon\globalPlugins\visionAssistant\vision_config.py:86
 msgid "Easy-going"
 msgstr "Wyluzowany"
 
 #. Translators: Adjective describing a breathy AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:74
+#: addon\globalPlugins\visionAssistant\vision_config.py:83
 msgid "Breathy"
 msgstr "Szeptany"
 
 #. Translators: Adjective describing a clear AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:76 addon\globalPlugins\visionAssistant\vision_config.py:81 addon\globalPlugins\visionAssistant\vision_config.py:127
+#: addon\globalPlugins\visionAssistant\vision_config.py:85
+#: addon\globalPlugins\visionAssistant\vision_config.py:90
+#: addon\globalPlugins\visionAssistant\vision_config.py:136
 msgid "Clear"
 msgstr "Wyraźny"
 
 #. Translators: Adjective describing a smooth AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:79 addon\globalPlugins\visionAssistant\vision_config.py:80
+#: addon\globalPlugins\visionAssistant\vision_config.py:88
+#: addon\globalPlugins\visionAssistant\vision_config.py:89
 msgid "Smooth"
 msgstr "Łagodny"
 
 #. Translators: Adjective describing a gravelly AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:83
+#: addon\globalPlugins\visionAssistant\vision_config.py:92
 msgid "Gravelly"
 msgstr "Chropowaty"
 
 #. Translators: Adjective describing a soft AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:87
+#: addon\globalPlugins\visionAssistant\vision_config.py:96
 msgid "Soft"
 msgstr "Miękki"
 
 #. Translators: Adjective describing an even AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:90
+#: addon\globalPlugins\visionAssistant\vision_config.py:99
 msgid "Even"
 msgstr "Równomierny"
 
 #. Translators: Adjective describing a mature AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:92
+#: addon\globalPlugins\visionAssistant\vision_config.py:101
 msgid "Mature"
 msgstr "Dojrzały"
 
 #. Translators: Adjective describing a forward AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:94
+#: addon\globalPlugins\visionAssistant\vision_config.py:103
 msgid "Forward"
 msgstr "Bezpośredni"
 
 #. Translators: Adjective describing a friendly AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:96
+#: addon\globalPlugins\visionAssistant\vision_config.py:105
 msgid "Friendly"
 msgstr "Przyjazny"
 
 #. Translators: Adjective describing a casual AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:98
+#: addon\globalPlugins\visionAssistant\vision_config.py:107
 msgid "Casual"
 msgstr "Swobodny"
 
 #. Translators: Adjective describing a gentle AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:100 addon\globalPlugins\visionAssistant\vision_config.py:126
+#: addon\globalPlugins\visionAssistant\vision_config.py:109
+#: addon\globalPlugins\visionAssistant\vision_config.py:135
 msgid "Gentle"
 msgstr "Delikatny"
 
 #. Translators: Adjective describing a lively AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:102
+#: addon\globalPlugins\visionAssistant\vision_config.py:111
 msgid "Lively"
 msgstr "Żywiołowy"
 
 #. Translators: Adjective describing a knowledgeable AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:104
+#: addon\globalPlugins\visionAssistant\vision_config.py:113
 msgid "Knowledgeable"
 msgstr "Kompetentny"
 
 #. Translators: Adjective describing a warm AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:106
+#: addon\globalPlugins\visionAssistant\vision_config.py:115
 msgid "Warm"
 msgstr "Ciepły"
 
 #. Translators: Adjective describing a neutral AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:111
+#: addon\globalPlugins\visionAssistant\vision_config.py:120
 msgid "Neutral"
 msgstr "Neutralny"
 
 #. Translators: Adjective describing a quirky AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:113
+#: addon\globalPlugins\visionAssistant\vision_config.py:122
 msgid "Quirky"
 msgstr "Ekscentryczny"
 
 #. Translators: Adjective describing a professional AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:115
+#: addon\globalPlugins\visionAssistant\vision_config.py:124
 msgid "Professional"
 msgstr "Profesjonalny"
 
 #. Translators: Adjective describing a cheerful AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:117
+#: addon\globalPlugins\visionAssistant\vision_config.py:126
 msgid "Cheerful"
 msgstr "Radosny"
 
 #. Translators: Adjective describing a confident AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:119
+#: addon\globalPlugins\visionAssistant\vision_config.py:128
 msgid "Confident"
 msgstr "Pewny siebie"
 
 #. Translators: Adjective describing a British AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:121
+#: addon\globalPlugins\visionAssistant\vision_config.py:130
 msgid "British"
 msgstr "Brytyjski"
 
 #. Translators: Adjective describing a pleasant AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:123
+#: addon\globalPlugins\visionAssistant\vision_config.py:132
 msgid "Pleasant"
 msgstr "Przyjemny"
 
 #. Translators: Adjective describing a deep AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:125
+#: addon\globalPlugins\visionAssistant\vision_config.py:134
 msgid "Deep"
 msgstr "Głęboki"
 
 #. Translators: Adjective describing an expressive AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:129
+#: addon\globalPlugins\visionAssistant\vision_config.py:138
 msgid "Expressive"
 msgstr "Ekspresyjny"
 
 #. Translators: Adjective describing a reliable AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:131
+#: addon\globalPlugins\visionAssistant\vision_config.py:140
 msgid "Reliable"
 msgstr "Niezawodny"
 
 #. Translators: Adjective describing an energetic AI voice style.
-#: addon\globalPlugins\visionAssistant\vision_config.py:133
+#: addon\globalPlugins\visionAssistant\vision_config.py:142
 msgid "Energetic"
 msgstr "Energiczny"
 
-#. Translators: Option in the language list to automatically detect the source
-#. language.
-#: addon\globalPlugins\visionAssistant\vision_config.py:164
+#. Translators: Option in the language list to automatically detect the source language.
+#: addon\globalPlugins\visionAssistant\vision_config.py:179
 msgid "Auto-detect"
 msgstr "Wykryj automatycznie"
 
 #. Translators: OCR Engine option (Fast but less formatted)
-#: addon\globalPlugins\visionAssistant\vision_config.py:178
+#: addon\globalPlugins\visionAssistant\vision_config.py:193
 msgid "Chrome (Fast)"
 msgstr "Chrome (szybki)"
 
 #. Translators: OCR Engine option (Slower but better formatting/AI-driven)
-#: addon\globalPlugins\visionAssistant\vision_config.py:180
+#: addon\globalPlugins\visionAssistant\vision_config.py:195
 msgid "AI (Advanced)"
 msgstr "AI (zaawansowany)"
 
-#. Translators: OCR Engine option for searchable PDFs (extracts text without
-#. OCR)
-#: addon\globalPlugins\visionAssistant\vision_config.py:182
+#. Translators: OCR Engine option for searchable PDFs (extracts text without OCR)
+#: addon\globalPlugins\visionAssistant\vision_config.py:197
 msgid "None (Extract Text Layer)"
 msgstr "Wyodrębnij tekst (offline)"
 
 #. Translators: Log retention option: 1 hour
-#: addon\globalPlugins\visionAssistant\vision_config.py:283
+#: addon\globalPlugins\visionAssistant\vision_config.py:301
 msgid "1 Hour"
 msgstr "1 godzina"
 
 #. Translators: Log retention option: 3 hours
-#: addon\globalPlugins\visionAssistant\vision_config.py:285
+#: addon\globalPlugins\visionAssistant\vision_config.py:303
 msgid "3 Hours"
 msgstr "3 godziny"
 
 #. Translators: Log retention option: 6 hours
-#: addon\globalPlugins\visionAssistant\vision_config.py:287
+#: addon\globalPlugins\visionAssistant\vision_config.py:305
 msgid "6 Hours"
 msgstr "6 godzin"
 
 #. Translators: Log retention option: 12 hours
-#: addon\globalPlugins\visionAssistant\vision_config.py:289
+#: addon\globalPlugins\visionAssistant\vision_config.py:307
 msgid "12 Hours"
 msgstr "12 godzin"
 
 #. Translators: Log retention option: 24 hours (1 day)
-#: addon\globalPlugins\visionAssistant\vision_config.py:291
+#: addon\globalPlugins\visionAssistant\vision_config.py:309
 msgid "24 Hours (1 Day)"
 msgstr "24 godziny (1 dzień)"
 
 #. Translators: Log retention option: 3 days
-#: addon\globalPlugins\visionAssistant\vision_config.py:293
+#: addon\globalPlugins\visionAssistant\vision_config.py:311
 msgid "3 Days"
 msgstr "3 dni"
 
 #. Translators: Log retention option: 7 days
-#: addon\globalPlugins\visionAssistant\vision_config.py:295
+#: addon\globalPlugins\visionAssistant\vision_config.py:313
 msgid "7 Days"
 msgstr "7 dni"
 
 #. Translators: Log retention option: 14 days
-#: addon\globalPlugins\visionAssistant\vision_config.py:297
+#: addon\globalPlugins\visionAssistant\vision_config.py:315
 msgid "14 Days"
 msgstr "14 dni"
 
 #. Translators: Log retention option: 30 days
-#: addon\globalPlugins\visionAssistant\vision_config.py:299
+#: addon\globalPlugins\visionAssistant\vision_config.py:317
 msgid "30 Days"
 msgstr "30 dni"
 
 #. Translators: Log retention option: 90 days
-#: addon\globalPlugins\visionAssistant\vision_config.py:301
+#: addon\globalPlugins\visionAssistant\vision_config.py:319
 msgid "90 Days"
 msgstr "90 dni"
 
 #. Translators: Section header for text refinement prompts in Prompt Manager.
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\vision_config.py:310 addon\globalPlugins\visionAssistant\vision_config.py:318 addon\globalPlugins\visionAssistant\vision_config.py:325 addon\globalPlugins\visionAssistant\vision_config.py:332 addon\globalPlugins\visionAssistant\features\vision.py:394
+#: addon\globalPlugins\visionAssistant\vision_config.py:328
+#: addon\globalPlugins\visionAssistant\vision_config.py:336
+#: addon\globalPlugins\visionAssistant\vision_config.py:343
+#: addon\globalPlugins\visionAssistant\vision_config.py:350
+#: addon\globalPlugins\visionAssistant\features\vision.py:432
 msgid "Refine"
 msgstr "Poprawianie"
 
 #. Translators: Label for the text summarization prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:312
+#: addon\globalPlugins\visionAssistant\vision_config.py:330
 msgid "Summarize"
 msgstr "Podsumuj"
 
 #. Translators: Label for the grammar correction prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:320
+#: addon\globalPlugins\visionAssistant\vision_config.py:338
 msgid "Fix Grammar"
 msgstr "Popraw gramatykę"
 
 #. Translators: Label for the grammar correction and translation prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:327
+#: addon\globalPlugins\visionAssistant\vision_config.py:345
 msgid "Fix Grammar & Translate"
 msgstr "Popraw gramatykę i przetłumacz"
 
 #. Translators: Label for the text explanation prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:334
+#: addon\globalPlugins\visionAssistant\vision_config.py:352
 msgid "Explain"
 msgstr "Wyjaśnij"
 
-#. Translators: Section header for translation-related prompts in Prompt
-#. Manager.
+#. Translators: Section header for translation-related prompts in Prompt Manager.
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\vision_config.py:340 addon\globalPlugins\visionAssistant\vision_config.py:351 addon\globalPlugins\visionAssistant\dialogs\document.py:265
+#: addon\globalPlugins\visionAssistant\vision_config.py:358
+#: addon\globalPlugins\visionAssistant\vision_config.py:369
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:267
 msgid "Translation"
 msgstr "Tłumaczenie"
 
 #. Translators: Label for the smart translation prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:342 addon\globalPlugins\visionAssistant\vision_config.py:344
+#: addon\globalPlugins\visionAssistant\vision_config.py:360
+#: addon\globalPlugins\visionAssistant\vision_config.py:362
 msgid "Smart Translation"
 msgstr "Inteligentne tłumaczenie"
 
 #. Translators: Label for the quick translation prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:353
+#: addon\globalPlugins\visionAssistant\vision_config.py:371
 msgid "Quick Translation"
 msgstr "Szybkie tłumaczenie"
 
 #. Translators: Section header for document-related prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:359 addon\globalPlugins\visionAssistant\vision_config.py:617
+#: addon\globalPlugins\visionAssistant\vision_config.py:377
+#: addon\globalPlugins\visionAssistant\vision_config.py:647
 msgid "Document"
 msgstr "Dokument"
 
 #. Translators: Label for the initial context prompt in document chat.
-#: addon\globalPlugins\visionAssistant\vision_config.py:361
+#: addon\globalPlugins\visionAssistant\vision_config.py:379
 msgid "Document Chat Context"
 msgstr "Kontekst czatu z dokumentem"
 
+#. Translators: Section header for direct chat prompts in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:385
+msgid "Chat"
+msgstr "Czat"
+
+
+#. Translators: Label for the Direct Chat system instruction prompt in the Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:387
+msgid "Direct Chat Instruction"
+msgstr "Instrukcja czatu bezpośredniego"
+
+
 #. Translators: Section header for image analysis prompts in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:374 addon\globalPlugins\visionAssistant\vision_config.py:387 addon\globalPlugins\visionAssistant\vision_config.py:672 addon\globalPlugins\visionAssistant\vision_config.py:700 addon\globalPlugins\visionAssistant\vision_config.py:721
-#: addon\globalPlugins\visionAssistant\vision_config.py:736
+#: addon\globalPlugins\visionAssistant\vision_config.py:404
+#: addon\globalPlugins\visionAssistant\vision_config.py:417
+#: addon\globalPlugins\visionAssistant\vision_config.py:702
+#: addon\globalPlugins\visionAssistant\vision_config.py:730
+#: addon\globalPlugins\visionAssistant\vision_config.py:751
+#: addon\globalPlugins\visionAssistant\vision_config.py:766
 msgid "Vision"
 msgstr "Rozpoznawanie"
 
-#. Translators: Label for the prompt used to analyze the current navigator
-#. object.
-#: addon\globalPlugins\visionAssistant\vision_config.py:376
+#. Translators: Label for the prompt used to analyze the current navigator object.
+#: addon\globalPlugins\visionAssistant\vision_config.py:406
 msgid "Navigator Object Analysis"
 msgstr "Analiza obiektu nawigatora"
 
 #. Translators: Label for the prompt used to analyze the entire screen.
-#: addon\globalPlugins\visionAssistant\vision_config.py:389
+#: addon\globalPlugins\visionAssistant\vision_config.py:419
 msgid "Full Screen Analysis"
 msgstr "Analiza pełnego ekranu"
 
 #. Translators: Section header for video analysis prompts in Prompt Manager.
 #. Translators: Labels for the AI and User in chat history
-#: addon\globalPlugins\visionAssistant\vision_config.py:415 addon\globalPlugins\visionAssistant\vision_config.py:483 addon\globalPlugins\visionAssistant\vision_config.py:527 addon\globalPlugins\visionAssistant\__init__.py:518 addon\globalPlugins\visionAssistant\dialogs\settings.py:360
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:667 addon\globalPlugins\visionAssistant\features\quick_settings.py:248
+#: addon\globalPlugins\visionAssistant\vision_config.py:445
+#: addon\globalPlugins\visionAssistant\vision_config.py:513
+#: addon\globalPlugins\visionAssistant\vision_config.py:557
+#: addon\globalPlugins\visionAssistant\__init__.py:466
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:393
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:725
 msgid "Video"
 msgstr "Wideo"
 
 #. Translators: Label for the general video content analysis prompt.
 #. Translators: Option to generate an Audio Description SRT file.
 #. Translators: Option for general video analysis without timestamps.
-#: addon\globalPlugins\visionAssistant\vision_config.py:417 addon\globalPlugins\visionAssistant\dialogs\media.py:258 addon\globalPlugins\visionAssistant\features\video.py:84
+#: addon\globalPlugins\visionAssistant\vision_config.py:447
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:287
+#: addon\globalPlugins\visionAssistant\features\video.py:84
 msgid "General Video Analysis"
 msgstr "Ogólna analiza wideo"
 
 #. Translators: Label for the Audio Description (SRT) generation prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:485
+#: addon\globalPlugins\visionAssistant\vision_config.py:515
 msgid "Audio Description Generation (SRT)"
 msgstr "Generowanie audiodeskrypcji (SRT)"
 
 #. Translators: Label for the local video recording analysis prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:529
+#: addon\globalPlugins\visionAssistant\vision_config.py:559
 msgid "Local Video Recording Analysis"
 msgstr "Analiza nagrania ekranu"
 
 #. Translators: Section header for audio-related prompts in Prompt Manager.
 #. Translators: Label for audio translation prompt in Prompt Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:540 addon\globalPlugins\visionAssistant\vision_config.py:548 addon\globalPlugins\visionAssistant\vision_config.py:557 addon\globalPlugins\visionAssistant\vision_config.py:570
+#: addon\globalPlugins\visionAssistant\vision_config.py:570
+#: addon\globalPlugins\visionAssistant\vision_config.py:578
+#: addon\globalPlugins\visionAssistant\vision_config.py:587
+#: addon\globalPlugins\visionAssistant\vision_config.py:600
 msgid "Audio"
 msgstr "Audio"
 
 #. Translators: Label for the audio file transcription prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:542
+#: addon\globalPlugins\visionAssistant\vision_config.py:572
 msgid "Audio Transcription"
 msgstr "Transkrypcja audio"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:549 addon\globalPlugins\visionAssistant\vision_config.py:551
+#: addon\globalPlugins\visionAssistant\vision_config.py:579
+#: addon\globalPlugins\visionAssistant\vision_config.py:581
 msgid "Audio Translation"
 msgstr "Tłumaczenie audio"
 
 #. Translators: Label for the smart voice dictation prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:559 addon\globalPlugins\visionAssistant\vision_config.py:561
+#: addon\globalPlugins\visionAssistant\vision_config.py:589
+#: addon\globalPlugins\visionAssistant\vision_config.py:591
 msgid "Smart Dictation"
 msgstr "Dyktowanie"
 
 #. Translators: Prompt Manager label for voice translation feature
-#: addon\globalPlugins\visionAssistant\vision_config.py:572 addon\globalPlugins\visionAssistant\vision_config.py:574
+#: addon\globalPlugins\visionAssistant\vision_config.py:602
+#: addon\globalPlugins\visionAssistant\vision_config.py:604
 msgid "Voice Translation"
 msgstr "Tłumaczenie mowy"
 
 #. Translators: Section header for OCR-related prompts in Prompt Manager.
 #. Translators: Prefix for main model status
-#: addon\globalPlugins\visionAssistant\vision_config.py:587 addon\globalPlugins\visionAssistant\vision_config.py:599 addon\globalPlugins\visionAssistant\vision_config.py:635 addon\globalPlugins\visionAssistant\__init__.py:511 addon\globalPlugins\visionAssistant\features\quick_settings.py:241
+#: addon\globalPlugins\visionAssistant\vision_config.py:617
+#: addon\globalPlugins\visionAssistant\vision_config.py:629
+#: addon\globalPlugins\visionAssistant\vision_config.py:665
+#: addon\globalPlugins\visionAssistant\__init__.py:459
 msgid "OCR"
 msgstr "OCR"
 
 #. Translators: Label for the OCR prompt used for image text extraction.
-#: addon\globalPlugins\visionAssistant\vision_config.py:589
+#: addon\globalPlugins\visionAssistant\vision_config.py:619
 msgid "OCR Image Extraction"
 msgstr "Wyodrębnianie tekstu z obrazu (OCR)"
 
 #. Translators: Label for the OCR prompt used for document text extraction.
-#: addon\globalPlugins\visionAssistant\vision_config.py:601 addon\globalPlugins\visionAssistant\vision_config.py:603
+#: addon\globalPlugins\visionAssistant\vision_config.py:631
+#: addon\globalPlugins\visionAssistant\vision_config.py:633
 msgid "OCR Document Extraction"
 msgstr "Wyodrębnianie tekstu z dokumentu (OCR)"
 
-#. Translators: Label for the combined OCR and translation prompt for
-#. documents.
-#: addon\globalPlugins\visionAssistant\vision_config.py:619 addon\globalPlugins\visionAssistant\vision_config.py:621
+#. Translators: Label for the combined OCR and translation prompt for documents.
+#: addon\globalPlugins\visionAssistant\vision_config.py:649
+#: addon\globalPlugins\visionAssistant\vision_config.py:651
 msgid "Document OCR + Translate"
 msgstr "OCR dokumentu + tłumaczenie"
 
-#. Translators: Title for the sub-prompt that instructs the AI to describe
-#. images inline.
-#: addon\globalPlugins\visionAssistant\vision_config.py:637
+#. Translators: Title for the sub-prompt that instructs the AI to describe images inline.
+#: addon\globalPlugins\visionAssistant\vision_config.py:667
 msgid "Image Description Instruction (Sub-prompt)"
 msgstr "Wytyczne do opisu obrazu (polecenie dodatkowe)"
 
-#. Translators: Checkbox label to add an AI warning disclaimer at the
-#. beginning of the video SRT output.
+#. Translators: Checkbox label to add an AI warning disclaimer at the beginning of the video SRT output.
 #. --- CAPTCHA Group ---
-#: addon\globalPlugins\visionAssistant\vision_config.py:651 addon\globalPlugins\visionAssistant\dialogs\settings.py:383
+#: addon\globalPlugins\visionAssistant\vision_config.py:681
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:416
 msgid "CAPTCHA"
 msgstr "CAPTCHA"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:652 addon\globalPlugins\visionAssistant\vision_config.py:654
+#: addon\globalPlugins\visionAssistant\vision_config.py:682
+#: addon\globalPlugins\visionAssistant\vision_config.py:684
 msgid "CAPTCHA Solver"
 msgstr "Rozwiązywanie CAPTCHA"
 
-#. Translators: Label for the UI Explorer system instruction prompt in the
-#. Prompt Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:674
+#. Translators: Label for the UI Explorer system instruction prompt in the Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:704
 msgid "UI Explorer Instruction"
 msgstr "Instrukcja Eksploratora interfejsu"
 
-#. Translators: Feature name shown in the warning dialog when a user tries to
-#. eid the UI Explorer prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:677
+#. Translators: Feature name shown in the warning dialog when a user tries to eid the UI Explorer prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:707
 msgid "UI Explorer"
 msgstr "Eksplorator interfejsu"
 
-#. Translators: Label for the AI Operator system instruction prompt in the
-#. Prompt Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:702
+#. Translators: Label for the AI Operator system instruction prompt in the Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:732
 msgid "AI Operator Instruction"
 msgstr "Instrukcja Operatora AI"
 
-#. Translators: Feature name shown in the warning dialog when a user tries to
-#. edit the AI Operator prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:705 addon\globalPlugins\visionAssistant\features\operator_captcha.py:152
+#. Translators: Feature name shown in the warning dialog when a user tries to edit the AI Operator prompt.
+#: addon\globalPlugins\visionAssistant\vision_config.py:735
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:152
 msgid "AI Operator"
 msgstr "Operator AI"
 
 #. Translators: Label for the prompt used to identify a single UI icon.
-#: addon\globalPlugins\visionAssistant\vision_config.py:723
+#: addon\globalPlugins\visionAssistant\vision_config.py:753
 msgid "Single Labeling Instruction"
 msgstr "Instrukcja pojedynczego etykietowania"
 
-#. Translators: Label for the prompt used to identify multiple unnamed
-#. elements at once.
-#: addon\globalPlugins\visionAssistant\vision_config.py:738
+#. Translators: Label for the prompt used to identify multiple unnamed elements at once.
+#: addon\globalPlugins\visionAssistant\vision_config.py:768
 msgid "Batch Labeling Instruction"
 msgstr "Instrukcja zbiorczego etykietowania"
 
-#. Translators: Feature name used in guarded prompt warnings for Batch
-#. Labeling.
-#: addon\globalPlugins\visionAssistant\vision_config.py:741
+#. Translators: Feature name used in guarded prompt warnings for Batch Labeling.
+#: addon\globalPlugins\visionAssistant\vision_config.py:771
 msgid "Batch Labeling"
 msgstr "Zbiorcze etykietowanie"
 
 #. Translators: Section header for advanced prompts in Prompt Manager.
 #. --- Advanced Group ---
 #. Translators: Title of the advanced settings tab
-#: addon\globalPlugins\visionAssistant\vision_config.py:757 addon\globalPlugins\visionAssistant\dialogs\settings.py:427
+#: addon\globalPlugins\visionAssistant\vision_config.py:787
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:460
 msgid "Advanced"
 msgstr "Zaawansowane"
 
 #. Translators: Label for the advanced visual CAPTCHA solver prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:759
+#: addon\globalPlugins\visionAssistant\vision_config.py:789
 msgid "Visual CAPTCHA Solver"
 msgstr "Rozwiązywanie CAPTCHA obrazkowej"
 
-#. Translators: Section header for the Live Assistant prompt in Prompt
-#. Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:779 addon\globalPlugins\visionAssistant\__init__.py:519 addon\globalPlugins\visionAssistant\features\quick_settings.py:249
+#. Translators: Section header for the Live Assistant prompt in Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:809
+#: addon\globalPlugins\visionAssistant\__init__.py:467
 msgid "Live"
 msgstr "Asystent głosowy"
 
-#. Translators: Label for the Live Assistant system instruction prompt in the
-#. Prompt Manager.
-#: addon\globalPlugins\visionAssistant\vision_config.py:781
+#. Translators: Label for the Live Assistant system instruction prompt in the Prompt Manager.
+#: addon\globalPlugins\visionAssistant\vision_config.py:811
 msgid "Live Assistant Instruction"
 msgstr "Instrukcja asystenta głosowego"
 
-#. Translators: Feature name shown in the warning dialog when a user tries to
-#. edit the Live Assistant prompt.
-#: addon\globalPlugins\visionAssistant\vision_config.py:784
+#. Translators: Feature name shown in the warning dialog when a user tries to edit the Live Assistant prompt.
+#. --- Live Assistant Group ---
+#. Translators: Title of the settings group for Live Assistant features.
+#: addon\globalPlugins\visionAssistant\vision_config.py:814
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:284
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:750
 msgid "Live Assistant"
 msgstr "Asystent głosowy"
 
-#. Translators: Description and input type for the [selection] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\vision_config.py:804
+#. Translators: Description and input type for the [selection] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:834
 msgid "Currently selected text"
 msgstr "Aktualnie zaznaczony tekst"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:804 addon\globalPlugins\visionAssistant\vision_config.py:805 addon\globalPlugins\visionAssistant\vision_config.py:817 addon\globalPlugins\visionAssistant\vision_config.py:818 addon\globalPlugins\visionAssistant\vision_config.py:819
-#: addon\globalPlugins\visionAssistant\vision_config.py:820 addon\globalPlugins\visionAssistant\vision_config.py:822
+#: addon\globalPlugins\visionAssistant\vision_config.py:834
+#: addon\globalPlugins\visionAssistant\vision_config.py:835
+#: addon\globalPlugins\visionAssistant\vision_config.py:847
+#: addon\globalPlugins\visionAssistant\vision_config.py:848
+#: addon\globalPlugins\visionAssistant\vision_config.py:849
+#: addon\globalPlugins\visionAssistant\vision_config.py:850
+#: addon\globalPlugins\visionAssistant\vision_config.py:852
 msgid "Text"
 msgstr "Tekst"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:805
+#: addon\globalPlugins\visionAssistant\vision_config.py:835
 msgid "Clipboard content"
 msgstr "Zawartość schowka"
 
-#. Translators: Description for the [clipboard_image] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\vision_config.py:807
+#. Translators: Description for the [clipboard_image] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:837
 msgid "Image currently in clipboard"
 msgstr "Obraz obecnie w schowku"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:807 addon\globalPlugins\visionAssistant\vision_config.py:808 addon\globalPlugins\visionAssistant\vision_config.py:809 addon\globalPlugins\visionAssistant\vision_config.py:810
+#: addon\globalPlugins\visionAssistant\vision_config.py:837
+#: addon\globalPlugins\visionAssistant\vision_config.py:838
+#: addon\globalPlugins\visionAssistant\vision_config.py:839
+#: addon\globalPlugins\visionAssistant\vision_config.py:840
 msgid "Image"
 msgstr "Obraz"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:808
+#: addon\globalPlugins\visionAssistant\vision_config.py:838
 msgid "Screenshot of the navigator object"
 msgstr "Zrzut ekranu obiektu nawigatora"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:809
+#: addon\globalPlugins\visionAssistant\vision_config.py:839
 msgid "Screenshot of the entire screen"
 msgstr "Zrzut całego ekranu"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:810
+#: addon\globalPlugins\visionAssistant\vision_config.py:840
 msgid "Screenshot of the active foreground window"
 msgstr "Zrzut ekranu aktywnego okna pierwszoplanowego"
 
-#. Translators: Description and input type for the [file_ocr] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\vision_config.py:812
+#. Translators: Description and input type for the [file_ocr] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:842
 msgid "Select image/PDF/TIFF for text extraction"
 msgstr "Wybierz obraz/PDF/TIFF do wyodrębnienia tekstu"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:812
+#: addon\globalPlugins\visionAssistant\vision_config.py:842
 msgid "Image, PDF, TIFF"
 msgstr "Obraz, PDF, TIFF"
 
-#. Translators: Description and input type for the [file_read] variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\vision_config.py:814
+#. Translators: Description and input type for the [file_read] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:844
 msgid "Select document for reading"
 msgstr "Wybierz dokument do odczytu"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:814
+#: addon\globalPlugins\visionAssistant\vision_config.py:844
 msgid "TXT, Code, PDF"
 msgstr "TXT, kod, PDF"
 
-#. Translators: Description and input type for the [file_audio] variable in
-#. the Variables Guide.
-#: addon\globalPlugins\visionAssistant\vision_config.py:816
+#. Translators: Description and input type for the [file_audio] variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:846
 msgid "Select audio file for analysis"
 msgstr "Wybierz plik audio do analizy"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:816
+#: addon\globalPlugins\visionAssistant\vision_config.py:846
 msgid "MP3, WAV, OGG"
 msgstr "MP3, WAV, OGG"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:817
+#: addon\globalPlugins\visionAssistant\vision_config.py:847
 msgid "Current target language"
 msgstr "Bieżący język docelowy"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:818
+#: addon\globalPlugins\visionAssistant\vision_config.py:848
 msgid "Current source language"
 msgstr "Bieżący język źródłowy"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:819
+#: addon\globalPlugins\visionAssistant\vision_config.py:849
 msgid "Current AI response language"
 msgstr "Bieżący język odpowiedzi AI"
 
-#: addon\globalPlugins\visionAssistant\vision_config.py:820
+#: addon\globalPlugins\visionAssistant\vision_config.py:850
 msgid "Fallback language for translation"
 msgstr "Język zapasowy tłumaczenia"
 
-#. Translators: Description for the {swap_instruction} variable in the
-#. Variables Guide.
-#: addon\globalPlugins\visionAssistant\vision_config.py:822
+#. Translators: Description for the {swap_instruction} variable in the Variables Guide.
+#: addon\globalPlugins\visionAssistant\vision_config.py:852
 msgid "Smart swap translation instruction"
 msgstr "Instrukcja tłumaczenia dla zamiany"
 
 #. Translators: Error message shown when uploading a video file fails.
-#: addon\globalPlugins\visionAssistant\__init__.py:105 addon\globalPlugins\visionAssistant\__init__.py:224 addon\globalPlugins\visionAssistant\__init__.py:396 addon\globalPlugins\visionAssistant\__init__.py:967 addon\globalPlugins\visionAssistant\__init__.py:980 addon\globalPlugins\visionAssistant\__init__.py:1073
-#: addon\globalPlugins\visionAssistant\__init__.py:1089 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:185 addon\globalPlugins\visionAssistant\dialogs\document.py:147 addon\globalPlugins\visionAssistant\dialogs\document.py:203 addon\globalPlugins\visionAssistant\dialogs\document.py:241
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:358 addon\globalPlugins\visionAssistant\dialogs\document.py:465 addon\globalPlugins\visionAssistant\dialogs\document.py:775 addon\globalPlugins\visionAssistant\dialogs\document.py:854 addon\globalPlugins\visionAssistant\dialogs\document.py:932
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:949 addon\globalPlugins\visionAssistant\dialogs\document.py:963 addon\globalPlugins\visionAssistant\dialogs\document.py:969 addon\globalPlugins\visionAssistant\dialogs\media.py:1599 addon\globalPlugins\visionAssistant\features\audio.py:139
-#: addon\globalPlugins\visionAssistant\features\audio.py:251 addon\globalPlugins\visionAssistant\features\audio.py:367 addon\globalPlugins\visionAssistant\features\audio.py:659 addon\globalPlugins\visionAssistant\features\operator_captcha.py:274 addon\globalPlugins\visionAssistant\features\operator_captcha.py:488
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:512 addon\globalPlugins\visionAssistant\features\operator_captcha.py:584 addon\globalPlugins\visionAssistant\features\operator_captcha.py:646 addon\globalPlugins\visionAssistant\features\operator_captcha.py:719
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:839 addon\globalPlugins\visionAssistant\features\video.py:395 addon\globalPlugins\visionAssistant\features\video.py:411 addon\globalPlugins\visionAssistant\features\video.py:419 addon\globalPlugins\visionAssistant\features\video.py:637
-#: addon\globalPlugins\visionAssistant\features\video.py:642 addon\globalPlugins\visionAssistant\features\video.py:650 addon\globalPlugins\visionAssistant\features\video.py:657 addon\globalPlugins\visionAssistant\features\video.py:778 addon\globalPlugins\visionAssistant\features\video.py:802
-#: addon\globalPlugins\visionAssistant\features\vision.py:819 addon\globalPlugins\visionAssistant\features\vision.py:926 addon\globalPlugins\visionAssistant\features\vision.py:1048 addon\globalPlugins\visionAssistant\features\vision.py:1073 addon\globalPlugins\visionAssistant\features\vision.py:1076
-#: addon\globalPlugins\visionAssistant\features\vision.py:1094 addon\globalPlugins\visionAssistant\features\vision.py:1233 addon\globalPlugins\visionAssistant\features\vision.py:1236 addon\globalPlugins\visionAssistant\features\vision.py:1263 addon\globalPlugins\visionAssistant\features\vision.py:1274
-#: addon\globalPlugins\visionAssistant\features\vision.py:1278 addon\globalPlugins\visionAssistant\features\vision.py:1295 addon\globalPlugins\visionAssistant\features\vision.py:1298 addon\globalPlugins\visionAssistant\features\vision.py:1302 addon\globalPlugins\visionAssistant\utils\media_capture.py:205
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:213
+#: addon\globalPlugins\visionAssistant\__init__.py:132
+#: addon\globalPlugins\visionAssistant\__init__.py:314
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:151
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:310
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:321
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:149
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:205
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:243
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:364
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:507
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:568
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:840
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:877
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:968
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1053
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1152
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1162
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1173
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1190
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1204
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1211
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1478
+#: addon\globalPlugins\visionAssistant\features\audio.py:175
+#: addon\globalPlugins\visionAssistant\features\audio.py:293
+#: addon\globalPlugins\visionAssistant\features\audio.py:589
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:274
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:492
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:516
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:590
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:654
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:727
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:848
+#: addon\globalPlugins\visionAssistant\features\video.py:395
+#: addon\globalPlugins\visionAssistant\features\video.py:411
+#: addon\globalPlugins\visionAssistant\features\video.py:419
+#: addon\globalPlugins\visionAssistant\features\video.py:639
+#: addon\globalPlugins\visionAssistant\features\video.py:644
+#: addon\globalPlugins\visionAssistant\features\video.py:652
+#: addon\globalPlugins\visionAssistant\features\video.py:659
+#: addon\globalPlugins\visionAssistant\features\video.py:780
+#: addon\globalPlugins\visionAssistant\features\video.py:804
+#: addon\globalPlugins\visionAssistant\features\vision.py:860
+#: addon\globalPlugins\visionAssistant\features\vision.py:966
+#: addon\globalPlugins\visionAssistant\features\vision.py:1107
+#: addon\globalPlugins\visionAssistant\features\vision.py:1132
+#: addon\globalPlugins\visionAssistant\features\vision.py:1135
+#: addon\globalPlugins\visionAssistant\features\vision.py:1155
+#: addon\globalPlugins\visionAssistant\features\vision.py:1295
+#: addon\globalPlugins\visionAssistant\features\vision.py:1298
+#: addon\globalPlugins\visionAssistant\features\vision.py:1325
+#: addon\globalPlugins\visionAssistant\features\vision.py:1337
+#: addon\globalPlugins\visionAssistant\features\vision.py:1341
+#: addon\globalPlugins\visionAssistant\features\vision.py:1358
+#: addon\globalPlugins\visionAssistant\features\vision.py:1361
+#: addon\globalPlugins\visionAssistant\features\vision.py:1365
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:206
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:214
 msgid "Idle"
 msgstr "Bezczynny"
 
 #. Translators: Menu item for Document Reader
-#: addon\globalPlugins\visionAssistant\__init__.py:128
+#: addon\globalPlugins\visionAssistant\__init__.py:162
 msgid "&Document Reader..."
 msgstr "&Czytnik dokumentów..."
 
 #. Translators: Menu item for media transcription and dubbing
-#: addon\globalPlugins\visionAssistant\__init__.py:132
+#: addon\globalPlugins\visionAssistant\__init__.py:166
 msgid "Media Transcription and &Dubbing..."
 msgstr "Transkrypcja i &dubbing mediów..."
 
 #. Translators: Menu item for Video Analysis
-#: addon\globalPlugins\visionAssistant\__init__.py:136
+#: addon\globalPlugins\visionAssistant\__init__.py:170
 msgid "Analyze &Video..."
 msgstr "Analizuj &wideo..."
 
 #. Translators: Menu item to open settings
-#: addon\globalPlugins\visionAssistant\__init__.py:142
+#: addon\globalPlugins\visionAssistant\__init__.py:176
 msgid "&Settings..."
 msgstr "&Ustawienia..."
 
 #. Translators: Menu item to check for updates
-#: addon\globalPlugins\visionAssistant\__init__.py:146
+#: addon\globalPlugins\visionAssistant\__init__.py:180
 msgid "Check for &Update"
 msgstr "Sprawdź &aktualizację"
 
 #. Translators: Menu item to open documentation
-#: addon\globalPlugins\visionAssistant\__init__.py:150
+#: addon\globalPlugins\visionAssistant\__init__.py:184
 msgid "Docu&mentation"
 msgstr "Doku&mentacja"
 
 #. Translators: Menu item for donations
-#: addon\globalPlugins\visionAssistant\__init__.py:154
+#: addon\globalPlugins\visionAssistant\__init__.py:188
 msgid "D&onate"
 msgstr "W&esprzyj"
 
 #. Translators: Menu item to open the Telegram channel
-#: addon\globalPlugins\visionAssistant\__init__.py:158
+#: addon\globalPlugins\visionAssistant\__init__.py:192
 msgid "Telegram &Channel"
 msgstr "Kanał w &Telegramie"
 
 #. Translators: The name of the addon's sub-menu in the NVDA Tools menu.
-#: addon\globalPlugins\visionAssistant\__init__.py:163
+#: addon\globalPlugins\visionAssistant\__init__.py:197
 msgid "Vision Assistant"
 msgstr "Vision Assistant"
 
-#. Translators: Announcement when an in-progress OCR extraction is stopped by
-#. the user.
-#: addon\globalPlugins\visionAssistant\__init__.py:226 addon\globalPlugins\visionAssistant\features\vision.py:1050
-msgid "OCR operation stopped."
-msgstr "Zatrzymano operację OCR."
-
-#. Translators: Title of the dialog asking whether to resume an OCR operation
-#. Translators: Title of the dialog asking whether to resume an OCR operation
-#. that did not finish (for example after NVDA closed unexpectedly).
-#: addon\globalPlugins\visionAssistant\__init__.py:240 addon\globalPlugins\visionAssistant\features\vision.py:157
-msgid "Unfinished Operation"
-msgstr "Niedokończona operacja"
-
-#. Translators: Message asking whether to continue an interrupted OCR
-#. extraction.
-#. Translators: Message asking whether to continue an interrupted OCR
-#. extraction. {done} is the number of pages already processed, {total} is the
-#. total number of pages, and {files} is the number of files involved.
-#: addon\globalPlugins\visionAssistant\__init__.py:242 addon\globalPlugins\visionAssistant\features\vision.py:159
-#, python-brace-format
-msgid "You have an unfinished operation: {done} of {total} pages processed across {files} file(s). Would you like to continue from where it stopped?"
-msgstr "Masz niedokończoną operację: przetworzono stron {done} z {total} w plikach: {files}. Kontynuować od miejsca zatrzymania?"
-
-#. Translators: File dialog filter for supported files
-#: addon\globalPlugins\visionAssistant\__init__.py:267 addon\globalPlugins\visionAssistant\features\vision.py:367
-msgid "Supported Files"
-msgstr "Obsługiwane pliki"
-
-#. Translators: Error when PyMuPDF is missing
-#: addon\globalPlugins\visionAssistant\__init__.py:275 addon\globalPlugins\visionAssistant\features\vision.py:663 addon\globalPlugins\visionAssistant\features\vision.py:939
-msgid "PyMuPDF library is missing."
-msgstr "Brak biblioteki PyMuPDF."
-
-#. Translators: Message shown when a PDF has no text layer.
-#: addon\globalPlugins\visionAssistant\__init__.py:284 addon\globalPlugins\visionAssistant\dialogs\document.py:554 addon\globalPlugins\visionAssistant\features\vision.py:651 addon\globalPlugins\visionAssistant\features\vision.py:741 addon\globalPlugins\visionAssistant\features\vision.py:947
-msgid "The 'None (Extract Text Layer)' engine cannot process image-based content. Please change the OCR Engine to 'Chrome' or 'AI (Advanced)' in settings."
-msgstr "Silnik „Wyodrębnij tekst (offline)” nie obsługuje treści graficznych. Zmień silnik OCR na „Chrome” albo „AI (Advanced)” w ustawieniach."
-
-#. Translators: Title of the error dialog shown when the selected OCR engine
-#. cannot process the chosen image-based files.
-#: addon\globalPlugins\visionAssistant\__init__.py:286 addon\globalPlugins\visionAssistant\features\vision.py:653 addon\globalPlugins\visionAssistant\features\vision.py:948
-msgid "OCR Engine Error"
-msgstr "Błąd silnika OCR"
-
-#. Translators: Error when no pages found
-#: addon\globalPlugins\visionAssistant\__init__.py:293 addon\globalPlugins\visionAssistant\features\vision.py:669 addon\globalPlugins\visionAssistant\features\vision.py:954
-msgid "No readable pages found."
-msgstr "Nie znaleziono stron do odczytu."
-
-#. Translators: Script description for 'Shows a list of available commands in
-#. the layer.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:344 addon\globalPlugins\visionAssistant\__init__.py:380
+#. Translators: Script description for 'Shows a list of available commands in the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:254
+#: addon\globalPlugins\visionAssistant\__init__.py:290
 msgid "Shows a list of available commands in the layer."
 msgstr "Wyświetla listę dostępnych poleceń w warstwie."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:348 addon\globalPlugins\visionAssistant\features\operator_captcha.py:135
+#: addon\globalPlugins\visionAssistant\__init__.py:258
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:135
 msgid "Asks the AI Operator to perform an action or describe the screen."
 msgstr "Aktywuje okno operatora ai."
 
-#. Translators: Script description for 'Shows a list of available commands in
-#. the layer.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:349 addon\globalPlugins\visionAssistant\features\operator_captcha.py:40
+#. Translators: Script description for 'Shows a list of available commands in the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:259
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:40
 msgid "Toggles the interactive UI elements explorer."
 msgstr "Przełącza interaktywny eksplorator elementów interfejsu."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:350 addon\globalPlugins\visionAssistant\features\vision.py:1428
+#: addon\globalPlugins\visionAssistant\__init__.py:260
+#: addon\globalPlugins\visionAssistant\features\vision.py:1491
 msgid "Translates the selected text or navigator object."
 msgstr "Tłumaczy zaznaczony tekst lub obiekt nawigatora."
 
-#. Translators: Script description for 'Shows a list of available commands in
-#. the layer.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:351 addon\globalPlugins\visionAssistant\features\vision.py:1411
+#. Translators: Script description for 'Shows a list of available commands in the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:261
+#: addon\globalPlugins\visionAssistant\features\vision.py:1474
 msgid "Translates the text currently in the clipboard."
 msgstr "Tłumaczy tekst znajdujący się w schowku."
 
-#. Translators: Script description for 'Shows a list of available commands in
-#. the layer.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:352 addon\globalPlugins\visionAssistant\features\audio.py:143
-msgid "Records voice, transcribes and translates it using AI, and types the result."
-msgstr "Nagrywa mowę, transkrybuje ją i tłumaczy przy użyciu AI, a wynik wpisuje jako tekst."
+#. Translators: Script description for 'Shows a list of available commands in the layer.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:262
+#: addon\globalPlugins\visionAssistant\features\audio.py:45
+msgid ""
+"Records voice, transcribes and translates it using AI, and types the result."
+msgstr ""
+"Nagrywa mowę, transkrybuje ją i tłumaczy przy użyciu AI, a wynik wpisuje "
+"jako tekst."
 
-#. Translators: Script description for 'Opens a menu to Explain, Summarize, or
-#. Fix the selected text.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:354 addon\globalPlugins\visionAssistant\features\vision.py:1356
+#. Translators: Script description for 'Opens a menu to Explain, Summarize, or Fix the selected text.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:264
+#: addon\globalPlugins\visionAssistant\features\vision.py:1419
 msgid "Opens a menu to Explain, Summarize, or Fix the selected text."
-msgstr "Otwiera menu do wyjaśniania, podsumowywania lub poprawiania zaznaczonego tekstu."
+msgstr ""
+"Otwiera menu do wyjaśniania, podsumowywania lub poprawiania zaznaczonego "
+"tekstu."
 
-#. Translators: Script description for 'Performs OCR and description on the
-#. entire screen.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:356 addon\globalPlugins\visionAssistant\features\vision.py:1342
+#. Translators: Script description for 'Performs OCR and description on the entire screen.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:266
+#: addon\globalPlugins\visionAssistant\features\vision.py:1405
 msgid "Performs OCR and description on the entire screen."
 msgstr "Wykonuje OCR i opis całego ekranu."
 
-#. Translators: Script description for 'Describes the current object
-#. (Navigator Object).' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:358 addon\globalPlugins\visionAssistant\features\vision.py:1334
+#. Translators: Script description for 'Describes the current object (Navigator Object).' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:268
+#: addon\globalPlugins\visionAssistant\features\vision.py:1397
 msgid "Describes the current object (Navigator Object)."
 msgstr "Opisuje bieżący obiekt nawigatora."
 
-#. Translators: Script description for 'Opens the Document Reader for detailed
-#. page-by-page analysis (PDF/Images).' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:360 addon\globalPlugins\visionAssistant\features\vision.py:1305
-msgid "Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
-msgstr "Otwiera czytnik dokumentów do szczegółowej analizy strona po stronie (PDF/obrazy)."
+#. Translators: Script description for 'Opens the Document Reader for detailed page-by-page analysis (PDF/Images).' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:270
+#: addon\globalPlugins\visionAssistant\features\vision.py:1368
+msgid ""
+"Opens the Document Reader for detailed page-by-page analysis (PDF/Images)."
+msgstr ""
+"Otwiera czytnik dokumentów do szczegółowej analizy strona po stronie (PDF/"
+"obrazy)."
 
-#. Translators: Script description for 'Performs smart actions (OCR or
-#. Description) on a selected image or PDF file.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:362 addon\globalPlugins\visionAssistant\features\vision.py:1385
-msgid "Performs smart actions (OCR or Description) on a selected image or PDF file."
-msgstr "Wykonuje inteligentne akcje (OCR lub opis) na wybranym pliku obrazu lub PDF."
+#. Translators: Script description for 'Performs smart actions (OCR or Description) on a selected image or PDF file.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:272
+#: addon\globalPlugins\visionAssistant\features\vision.py:1448
+msgid ""
+"Performs smart actions (OCR or Description) on a selected image or PDF file."
+msgstr ""
+"Wykonuje inteligentne akcje (OCR lub opis) na wybranym pliku obrazu lub PDF."
 
-#. Translators: Script description for 'Transcribes or dubs a selected media
-#. file.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:364 addon\globalPlugins\visionAssistant\features\audio.py:266
+#. Translators: Script description for 'Transcribes or dubs a selected media file.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:274
+#: addon\globalPlugins\visionAssistant\features\audio.py:191
 msgid "Transcribes or dubs a selected media file."
 msgstr "Transkrybuje lub dubbinguje wybrany plik multimedialny."
 
-#. Translators: Script description for 'Analyzes a local video file or an
-#. online video URL.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:366 addon\globalPlugins\visionAssistant\features\video.py:45
+#. Translators: Script description for 'Analyzes a local video file or an online video URL.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:276
+#: addon\globalPlugins\visionAssistant\features\video.py:45
 msgid "Analyzes a local video file or an online video URL."
 msgstr "Analizuje lokalny plik wideo lub adres URL wideo online."
 
-#. Translators: Script description for 'Starts or stops local video recording
-#. of the screen.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:368 addon\globalPlugins\visionAssistant\features\video.py:659
+#. Translators: Script description for 'Starts or stops local video recording of the screen.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:278
+#: addon\globalPlugins\visionAssistant\features\video.py:661
 msgid "Starts or stops local video recording of the screen."
 msgstr "Rozpoczyna lub zatrzymuje lokalne nagrywanie ekranu."
 
-#. Translators: Script description for 'Attempts to solve a CAPTCHA on the
-#. screen or navigator object.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:370 addon\globalPlugins\visionAssistant\features\operator_captcha.py:651
+#. Translators: Script description for 'Attempts to solve a CAPTCHA on the screen or navigator object.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:280
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:659
 msgid "Attempts to solve a CAPTCHA on the screen or navigator object."
 msgstr "Próbuje rozwiązać CAPTCHA na ekranie lub w obiekcie nawigatora."
 
-#. Translators: Script description for 'Opens a chat dialog to directly prompt
-#. the AI with text or files.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:371 addon\globalPlugins\visionAssistant\__init__.py:844 addon\globalPlugins\visionAssistant\features\vision.py:1350
+#. Translators: Script description for 'Opens a chat dialog to directly prompt the AI with text or files.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:281
+#: addon\globalPlugins\visionAssistant\features\vision.py:1413
 msgid "Opens a chat dialog to directly prompt the AI with text or files."
-msgstr "Otwiera okno rozmowy, w którym można zadać AI pytanie tekstem lub przekazać pliki."
+msgstr ""
+"Otwiera okno rozmowy, w którym można zadać AI pytanie tekstem lub przekazać "
+"pliki."
 
-#. Translators: Script description for 'Records voice, transcribes it using
-#. AI, and types the result.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:373 addon\globalPlugins\visionAssistant\features\audio.py:40
+#. Translators: Script description for 'Records voice, transcribes it using AI, and types the result.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:283
+#: addon\globalPlugins\visionAssistant\features\audio.py:40
 msgid "Records voice, transcribes it using AI, and types the result."
 msgstr "Nagrywa głos, transkrybuje go przy użyciu AI i wpisuje wynik."
 
-#: addon\globalPlugins\visionAssistant\__init__.py:374 addon\globalPlugins\visionAssistant\__init__.py:393
+#: addon\globalPlugins\visionAssistant\__init__.py:284
+#: addon\globalPlugins\visionAssistant\__init__.py:311
 msgid "Announces the current status of the add-on."
 msgstr "Odczytuje bieżący stan dodatku."
 
-#. Translators: Script description for 'Labels the current navigator object
-#. using AI.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:375 addon\globalPlugins\visionAssistant\__init__.py:929 addon\globalPlugins\visionAssistant\features\operator_captcha.py:447
+#. Translators: Script description for 'Labels the current navigator object using AI.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:285
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:451
 msgid "Labels the current navigator object using AI."
 msgstr "Nadaje etykietę bieżącemu obiektowi nawigatora za pomocą AI."
 
-#. Translators: Script description for 'Manages existing labels or scans the
-#. entire app to label unnamed elements.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:376 addon\globalPlugins\visionAssistant\__init__.py:1002 addon\globalPlugins\visionAssistant\features\operator_captcha.py:517
-msgid "Manages existing labels or scans the entire app to label unnamed elements."
-msgstr "Zarządza istniejącymi etykietami lub skanuje całą aplikację w poszukiwaniu elementów bez nich."
+#. Translators: Script description for 'Manages existing labels or scans the entire app to label unnamed elements.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:286
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:521
+msgid ""
+"Manages existing labels or scans the entire app to label unnamed elements."
+msgstr ""
+"Zarządza istniejącymi etykietami lub skanuje całą aplikację w poszukiwaniu "
+"elementów bez nich."
 
-#. Translators: Script description for 'Checks for updates manually.' in Input
-#. Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:377 addon\globalPlugins\visionAssistant\__init__.py:418
+#. Translators: Script description for 'Checks for updates manually.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:287
+#: addon\globalPlugins\visionAssistant\__init__.py:378
 msgid "Checks for updates manually."
 msgstr "Ręcznie sprawdza dostępność aktualizacji."
 
-#. Translators: Script description for 'Shows the last AI response in a chat
-#. dialog for review or follow-up questions.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:379 addon\globalPlugins\visionAssistant\__init__.py:849 addon\globalPlugins\visionAssistant\features\vision.py:1370
-msgid "Shows the last AI response in a chat dialog for review or follow-up questions."
-msgstr "Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub zadawania dodatkowych pytań."
+#. Translators: Script description for 'Shows the last AI response in a chat dialog for review or follow-up questions.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:289
+#: addon\globalPlugins\visionAssistant\features\vision.py:1433
+msgid ""
+"Shows the last AI response in a chat dialog for review or follow-up "
+"questions."
+msgstr ""
+"Wyświetla ostatnią odpowiedź AI w oknie czatu do przeglądu lub zadawania "
+"dodatkowych pytań."
 
-#. Translators: Script description for 'Starts or ends a live voice
-#. conversation with the AI assistant.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:382 addon\globalPlugins\visionAssistant\__init__.py:400
+#. Translators: Script description for 'Opens the History dialog to review past chats and documents.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:292
+#: addon\globalPlugins\visionAssistant\__init__.py:336
+msgid "Opens the History dialog to review past chats and documents."
+msgstr ""
+"Otwiera okno historii, w którym można przejrzeć wcześniejsze czaty i dokumenty."
+
+
+#. Translators: Script description for 'Starts or ends a live voice conversation with the AI assistant.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:294
+#: addon\globalPlugins\visionAssistant\__init__.py:318
 msgid "Starts or ends a live voice conversation with the AI assistant."
 msgstr "Rozpoczyna lub kończy rozmowę głosową z asystentem AI."
 
-#. Translators: Script description for 'Opens the Vision Assistant settings
-#. dialog.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:384 addon\globalPlugins\visionAssistant\__init__.py:412
+#. Translators: Script description for 'Opens the Vision Assistant settings dialog.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:296
+#: addon\globalPlugins\visionAssistant\__init__.py:330
 msgid "Opens the Vision Assistant settings dialog."
 msgstr "Otwiera okno ustawień Vision Assistant."
 
-#. Translators: Script description for 'Reports the number of Gemini API keys
-#. that have exceeded their daily quota and their reset time.' in Input
-#. Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:386 addon\globalPlugins\visionAssistant\__init__.py:426 addon\globalPlugins\visionAssistant\features\quick_settings.py:159
-msgid "Reports the number of Gemini API keys that have exceeded their daily quota and their reset time."
-msgstr "Podaje liczbę kluczy API Gemini, które przekroczyły dzienny limit i czas ich zresetowania."
+#. Translators: Script description for 'Reports the number of Gemini API keys that have exceeded their daily quota and their reset time.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:298
+#: addon\globalPlugins\visionAssistant\__init__.py:388
+msgid ""
+"Reports the number of Gemini API keys that have exceeded their daily quota "
+"and their reset time."
+msgstr ""
+"Podaje liczbę kluczy API Gemini, które przekroczyły dzienny limit i czas ich "
+"zresetowania."
 
-#. Translators: Script description for 'Reports the AI models selected in
-#. advanced routing.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:388 addon\globalPlugins\visionAssistant\__init__.py:493 addon\globalPlugins\visionAssistant\features\quick_settings.py:225
+#. Translators: Script description for 'Reports the AI models selected in advanced routing.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:300
+#: addon\globalPlugins\visionAssistant\__init__.py:446
 msgid "Reports the AI models selected in advanced routing."
 msgstr "Podaje modele AI wybrane w osobnym modelu dla każdego zadania."
 
+#. Translators: Section header in the command layer help listing custom prompt shortcuts.
+#: addon\globalPlugins\visionAssistant\__init__.py:305
+msgid "Custom Prompts:"
+msgstr "Polecenia niestandardowe:"
+
+
 #. Translators: Title of the help dialog
-#: addon\globalPlugins\visionAssistant\__init__.py:391
+#: addon\globalPlugins\visionAssistant\__init__.py:309
 #, python-brace-format
 msgid "{name} Help"
 msgstr "Pomoc {name}"
 
-#. Translators: Error shown when the Live Assistant is used with a non-Gemini
-#. provider.
-#: addon\globalPlugins\visionAssistant\__init__.py:408
-msgid "The Live Assistant is only supported with the Gemini provider (or a Custom provider with API type set to Gemini)."
-msgstr "Asystent głosowy działa tylko z dostawcą Gemini (lub niestandardowym dostawcą z typem API ustawionym na Gemini)."
+#. Translators: Error shown when the Live Assistant is used with a non-Gemini provider.
+#: addon\globalPlugins\visionAssistant\__init__.py:326
+msgid ""
+"The Live Assistant is only supported with the Gemini provider (or a Custom "
+"provider with API type set to Gemini)."
+msgstr ""
+"Asystent głosowy działa tylko z dostawcą Gemini (lub niestandardowym "
+"dostawcą z typem API ustawionym na Gemini)."
 
 #. Translators: Message reported when calling the update command
-#: addon\globalPlugins\visionAssistant\__init__.py:422
+#: addon\globalPlugins\visionAssistant\__init__.py:382
 msgid "Checking for updates..."
 msgstr "Sprawdzanie aktualizacji..."
 
-#. Translators: Message shown when a user tries to check Gemini API quotas but
-#. another provider is active.
-#: addon\globalPlugins\visionAssistant\__init__.py:431 addon\globalPlugins\visionAssistant\features\quick_settings.py:164
+#. Translators: Message shown when a user tries to check Gemini API quotas but another provider is active.
+#: addon\globalPlugins\visionAssistant\__init__.py:393
 msgid "This feature is only available for Google Gemini."
 msgstr "Ta funkcja jest dostępna tylko dla Google Gemini."
 
 #. Translators: Message when no API keys are out of quota
-#: addon\globalPlugins\visionAssistant\__init__.py:459 addon\globalPlugins\visionAssistant\features\quick_settings.py:192
+#: addon\globalPlugins\visionAssistant\__init__.py:417
 msgid "No API keys have exceeded their daily quota."
 msgstr "Żaden klucz API nie przekroczył dziennego limitu."
 
 #. Translators: Prefix for time when the daily quota resets on the next day
-#: addon\globalPlugins\visionAssistant\__init__.py:472 addon\globalPlugins\visionAssistant\features\quick_settings.py:204
+#: addon\globalPlugins\visionAssistant\__init__.py:428
 #, python-brace-format
 msgid "tomorrow at {time}"
 msgstr "jutro o {time}"
 
-#. Translators: Shows detailed information for a banned API key. {key} is the
-#. API key, {model} is the model name, {time_str} is the reset time.
-#: addon\globalPlugins\visionAssistant\__init__.py:474 addon\globalPlugins\visionAssistant\features\quick_settings.py:206
+#. Translators: Shows detailed information for a banned API key. {key} is the API key, {model} is the model name, {time_str} is the reset time.
+#: addon\globalPlugins\visionAssistant\__init__.py:430
 #, python-brace-format
 msgid ""
 "Key: {key}\n"
@@ -911,324 +992,246 @@ msgstr ""
 "Model: {model}\n"
 "Odnowienie około: {time_str}\n"
 
-#. Translators: Shows how many API keys have exceeded their quota for a
-#. specific model. {count} is the number of keys, {model} is the model name.
-#: addon\globalPlugins\visionAssistant\__init__.py:485 addon\globalPlugins\visionAssistant\features\quick_settings.py:216
+#. Translators: Shows how many API keys have exceeded their quota for a specific model. {count} is the number of keys, {model} is the model name.
+#: addon\globalPlugins\visionAssistant\__init__.py:438
 #, python-brace-format
 msgid "{count} keys for model {model}"
 msgstr "Kluczy dla modelu {model}: {count}"
 
 #. Translators: Message shown when API keys run out of quota.
-#: addon\globalPlugins\visionAssistant\__init__.py:488 addon\globalPlugins\visionAssistant\features\quick_settings.py:219
+#: addon\globalPlugins\visionAssistant\__init__.py:440
 msgid "have exceeded their daily quota."
 msgstr "przekroczyło dzienny limit."
 
-#. Translators: Title of the browseable message dialog showing exhausted API
-#. keys
-#: addon\globalPlugins\visionAssistant\__init__.py:491 addon\globalPlugins\visionAssistant\features\quick_settings.py:222
+#. Translators: Title of the browseable message dialog showing exhausted API keys
+#: addon\globalPlugins\visionAssistant\__init__.py:443
 msgid "Exhausted API Keys"
 msgstr "Wyczerpane klucze API"
 
 #. Translators: Prefix for main model status
-#: addon\globalPlugins\visionAssistant\__init__.py:504 addon\globalPlugins\visionAssistant\features\quick_settings.py:235
+#: addon\globalPlugins\visionAssistant\__init__.py:455
 #, python-brace-format
 msgid "Main: {model}"
 msgstr "Główny: {model}"
 
 #. Translators: Abbreviation for Speech-to-Text.
-#: addon\globalPlugins\visionAssistant\__init__.py:513 addon\globalPlugins\visionAssistant\features\quick_settings.py:243
+#: addon\globalPlugins\visionAssistant\__init__.py:461
 msgid "STT"
 msgstr "STT"
 
 #. Translators: Abbreviation for Text-to-Speech.
-#: addon\globalPlugins\visionAssistant\__init__.py:515 addon\globalPlugins\visionAssistant\features\quick_settings.py:245
+#: addon\globalPlugins\visionAssistant\__init__.py:463
 msgid "TTS"
 msgstr "TTS"
 
 #. Translators: Labels for the AI and User in chat history
-#: addon\globalPlugins\visionAssistant\__init__.py:517 addon\globalPlugins\visionAssistant\features\operator_captcha.py:312 addon\globalPlugins\visionAssistant\features\quick_settings.py:247
+#: addon\globalPlugins\visionAssistant\__init__.py:465
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:314
 msgid "Operator"
 msgstr "Operator"
 
-#. Translators: Message when no specific AI models are selected in advanced
-#. routing
-#: addon\globalPlugins\visionAssistant\__init__.py:523 addon\globalPlugins\visionAssistant\features\quick_settings.py:252
+#. Translators: Message when no specific AI models are selected in advanced routing
+#: addon\globalPlugins\visionAssistant\__init__.py:469
 msgid "No specific models selected."
 msgstr "Nie wybrano konkretnych modeli."
 
-#. Translators: Line appended to the conversation when the live session has
-#. ended.
-#: addon\globalPlugins\visionAssistant\__init__.py:602 addon\globalPlugins\visionAssistant\features\vision.py:123
-msgid "--- Session ended ---"
-msgstr "--- Sesja zakończona ---"
-
-#. Translators: Message announced by NVDA when the live voice conversation
-#. ends.
-#: addon\globalPlugins\visionAssistant\__init__.py:608 addon\globalPlugins\visionAssistant\features\vision.py:128
-msgid "Live conversation ended."
-msgstr "Rozmowa głosowa zakończona."
-
-#. Translators: Message announced by NVDA when the live voice conversation
-#. ends.
-#: addon\globalPlugins\visionAssistant\__init__.py:611 addon\globalPlugins\visionAssistant\features\screen_capture.py:203 addon\globalPlugins\visionAssistant\features\vision.py:96 addon\globalPlugins\visionAssistant\features\vision.py:426
-msgid "Open"
-msgstr "Otwórz"
-
-#. Translators: Message of a dialog which may pop up while performing an AI
-#. call
-#: addon\globalPlugins\visionAssistant\__init__.py:658 addon\globalPlugins\visionAssistant\features\upload.py:68
-#, python-brace-format
-msgid "File Upload Error: {error}"
-msgstr "Błąd przesyłania pliku: {error}"
-
-#. Translators: Script description for 'Activates the Command Layer for quick
-#. access to all features.' in Input Gestures dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:733
+#. Translators: Script description for 'Activates the Command Layer for quick access to all features.' in Input Gestures dialog.
+#: addon\globalPlugins\visionAssistant\__init__.py:524
 msgid "Activates the Command Layer for quick access to all features."
-msgstr "Aktywuje warstwę poleceń umożliwiającą szybki dostęp do wszystkich funkcji."
+msgstr ""
+"Aktywuje warstwę poleceń umożliwiającą szybki dostęp do wszystkich funkcji."
 
-#. Translators: Error when all available API keys fail
-#: addon\globalPlugins\visionAssistant\__init__.py:823 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:550 addon\globalPlugins\visionAssistant\features\vision.py:272
-msgid "All API Keys failed (Quota/Server)."
-msgstr "Wszystkie klucze API zawiodły (limit/serwer)."
-
-#. Translators: Initial greeting message for the Direct Chat dialog.
-#: addon\globalPlugins\visionAssistant\__init__.py:826 addon\globalPlugins\visionAssistant\features\vision.py:276
-msgid "Hello! I am Vision Assistant Pro. How can I help you today?"
-msgstr "Witaj! Tu Vision Assistant Pro. W czym mogę pomóc?"
-
-#. Translators: Dialog title for Direct Chat
-#: addon\globalPlugins\visionAssistant\__init__.py:831 addon\globalPlugins\visionAssistant\features\vision.py:281
+#. Translators: Script description in Input Gestures for a shortcut that runs a custom prompt. {name} is the prompt name.
+#: addon\globalPlugins\visionAssistant\__init__.py:548
 #, python-brace-format
-msgid "{name} - Direct Chat"
-msgstr "{name} — czat"
+msgid "Runs the custom prompt \"{name}\"."
+msgstr "Uruchamia polecenie niestandardowe \"{name}\"."
 
-#. Translators: Message shown when a user tries to use AI labeling in a web
-#. browser.
-#: addon\globalPlugins\visionAssistant\__init__.py:941 addon\globalPlugins\visionAssistant\__init__.py:1008 addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:268 addon\globalPlugins\visionAssistant\features\operator_captcha.py:457 addon\globalPlugins\visionAssistant\features\operator_captcha.py:524
-msgid "AI Labeling is currently not supported in web browsers."
-msgstr "Etykietowanie AI nie jest obecnie obsługiwane w przeglądarkach internetowych."
-
-#. Translators: Message spoken by NVDA when the current object already has a
-#. custom or AI-generated label. {name} is replaced with the existing label
-#. text.
-#: addon\globalPlugins\visionAssistant\__init__.py:956 addon\globalPlugins\visionAssistant\features\operator_captcha.py:476
-#, python-brace-format
-msgid "Already labeled as: {name}"
-msgstr "Już oznaczono jako: {name}"
-
-#. Translators: Progress message spoken when the add-on starts taking a
-#. screenshot of the current focused object.
-#: addon\globalPlugins\visionAssistant\__init__.py:961 addon\globalPlugins\visionAssistant\features\operator_captcha.py:481
-msgid "Identifying object..."
-msgstr "Rozpoznawanie obiektu..."
-
-#. Translators: Progress message spoken when the add-on starts taking a
-#. screenshot of the current focused object.
-#: addon\globalPlugins\visionAssistant\__init__.py:969 addon\globalPlugins\visionAssistant\features\audio.py:355 addon\globalPlugins\visionAssistant\features\operator_captcha.py:490 addon\globalPlugins\visionAssistant\features\vision.py:1226
-msgid "Analyzing..."
-msgstr "Analizowanie..."
-
-#. Translators: Success message spoken when the AI successfully assigns a new
-#. label to the object. {name} is replaced with the AI-generated label.
-#: addon\globalPlugins\visionAssistant\__init__.py:993 addon\globalPlugins\visionAssistant\features\operator_captcha.py:508
-#, python-brace-format
-msgid "Labeled as: {name}"
-msgstr "Etykieta jako: {name}"
-
-#. Translators: Confirmation message shown after labels are deleted or
-#. renamed.
-#: addon\globalPlugins\visionAssistant\__init__.py:1027 addon\globalPlugins\visionAssistant\features\operator_captcha.py:544
-msgid "Labels updated."
-msgstr "Etykiety zaktualizowane."
-
-#. Translators: Progress message spoken when the add-on begins scanning the
-#. current application window to find UI elements (like buttons or icons) that
-#. do not have accessibility names.
-#: addon\globalPlugins\visionAssistant\__init__.py:1046 addon\globalPlugins\visionAssistant\features\operator_captcha.py:561
-msgid "Scanning application UI..."
-msgstr "Skanowanie interfejsu aplikacji..."
-
-#. Translators: Message spoken when the add-on finishes the UI scan but finds
-#. no unnamed elements to label (everything already has a name).
-#: addon\globalPlugins\visionAssistant\__init__.py:1075 addon\globalPlugins\visionAssistant\features\operator_captcha.py:586
-msgid "No unnamed elements found."
-msgstr "Nie ma niezaetykietowanych elementów."
-
-#. Translators: Progress message spoken when the add-on has found unnamed
-#. elements and is now sending the full application screenshot to AI for batch
-#. labeling.
-#: addon\globalPlugins\visionAssistant\__init__.py:1079 addon\globalPlugins\visionAssistant\features\operator_captcha.py:590
-msgid "Analyzing application..."
-msgstr "Analizowanie aplikacji..."
-
-#. Translators: Success message spoken when the AI finishes analyzing the app
-#. and successfully names multiple elements in the background.
-#: addon\globalPlugins\visionAssistant\__init__.py:1143 addon\globalPlugins\visionAssistant\features\operator_captcha.py:638
-msgid "Application labeling complete."
-msgstr "Etykietowanie aplikacji zakończone."
-
-#. Translators: Error message spoken when the add-on fails to parse or map the
-#. labels returned by the AI (e.g., due to invalid AI response format).
-#: addon\globalPlugins\visionAssistant\__init__.py:1148 addon\globalPlugins\visionAssistant\features\operator_captcha.py:643
-msgid "Batch labeling failed."
-msgstr "Zbiorcze etykietowanie nie powiodło się."
 
 #. Translators: Error message when TTS is not supported by the provider
-#: addon\globalPlugins\visionAssistant\ai\core.py:315
+#: addon\globalPlugins\visionAssistant\ai\core.py:321
 msgid "TTS is not supported by this provider."
 msgstr "Ten dostawca nie obsługuje syntezy mowy."
 
 #. Translators: Status message showing the file upload progress percentage.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:150
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:168
 #, python-brace-format
 msgid "Uploading: {percent}%"
 msgstr "Wysyłanie: {percent}%"
 
-#. Translators: Note appended to the API error message when the daily
-#. RequestsPerDay quota limit is reached.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:286
+#. Translators: Note appended to the API error message when the daily RequestsPerDay quota limit is reached.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:302
 msgid " (RequestsPerDay quota exceeded)"
 msgstr " (przekroczono limit RequestsPerDay)"
 
 #. Translators: Error message for Bad Request (400)
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:295
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:311
 msgid "Error 400: Bad Request (Check API Key)"
 msgstr "Błąd 400: nieprawidłowe żądanie (sprawdź klucz API)"
 
 #. Translators: Error message for Forbidden (403)
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:297
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:313
 msgid "Error 403: Forbidden (Check Region)"
 msgstr "Błąd 403: dostęp zabroniony (sprawdź region)"
 
-#. Translators: Message of a dialog which may pop up while performing an AI
-#. call
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:391
+#. Translators: Message of a dialog which may pop up while performing an AI call
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:408
 msgid "Error 429: Quota Exceeded (Try later)"
 msgstr "Błąd 429: przekroczono limit (spróbuj później)"
 
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:393 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:546
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:410
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:564
 #, python-brace-format
 msgid "Server Error {code}: {reason}"
 msgstr "Błąd serwera {code}: {reason}"
 
-#. Translators: Error prefix shown when the AI response is blocked by safety
-#. filters.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:485 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:499 addon\globalPlugins\visionAssistant\ai\providers\openai.py:144
+#. Translators: Error prefix shown when the AI response is blocked by safety filters.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:502
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:516
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:145
 msgid "Blocked by AI Safety Filters: "
 msgstr "Zablokowane przez filtry bezpieczeństwa AI: "
 
 #. Translators: Error shown when the AI response is blocked during generation.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:488 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:507
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:505
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:524
 msgid "The response was blocked mid-generation by safety filters."
 msgstr "Filtry bezpieczeństwa zablokowały odpowiedź w trakcie generowania."
 
 #. Translators: Generic error message when Gemini returns an empty response.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:490 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:500
-msgid "AI failed to provide a response. This might be due to safety filters or a temporary server issue."
-msgstr "AI nie zwróciła odpowiedzi. Powodem mogą być filtry bezpieczeństwa lub chwilowy problem serwera."
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:507
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:517
+msgid ""
+"AI failed to provide a response. This might be due to safety filters or a "
+"temporary server issue."
+msgstr ""
+"AI nie zwróciła odpowiedzi. Powodem mogą być filtry bezpieczeństwa lub "
+"chwilowy problem serwera."
 
-#. Translators: Error shown when the response structure is unexpected or
-#. empty.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:509
+#. Translators: Error shown when the response structure is unexpected or empty.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:526
 msgid "AI returned an empty response structure."
 msgstr "AI zwróciła pustą strukturę odpowiedzi."
 
 #. Translators: Error when no API keys are found in settings
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:518 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:781
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:535
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:806
 msgid "No valid API key available or daily quota exhausted for all keys."
-msgstr "Brak ważnego klucza API lub wyczerpany dzienny limit dla wszystkich kluczy."
+msgstr ""
+"Brak ważnego klucza API lub wyczerpany dzienny limit dla wszystkich kluczy."
 
-#. Translators: Generic error message when an operation fails for an unknown
-#. reason.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:558
+#. Translators: Error when all available API keys fail
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:568
+#: addon\globalPlugins\visionAssistant\features\vision.py:287
+msgid "All API Keys failed (Quota/Server)."
+msgstr "Wszystkie klucze API zawiodły (limit/serwer)."
+
+#. Translators: Generic error message when an operation fails for an unknown reason.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:576
 msgid "Unknown error occurred."
 msgstr "Wystąpił nieznany błąd."
 
 #. Translators: Error message for missing API Keys
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:614
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:632
 msgid "No API Keys."
 msgstr "Brak kluczy API."
 
-#. Translators: Message reported when an upload fails and the system
-#. automatically switches to the next available API key.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:664
+#. Translators: Message reported when an upload fails and the system automatically switches to the next available API key.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:683
 msgid "Upload failed. Rotating key..."
 msgstr "Wysyłanie nie powiodło się. Zmiana klucza..."
 
 #. Translators: Error message for upload failure
 #. Translators: Error message shown when uploading a video file fails.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:669 addon\globalPlugins\visionAssistant\ai\providers\mistral.py:172 addon\globalPlugins\visionAssistant\dialogs\document.py:99 addon\globalPlugins\visionAssistant\dialogs\document.py:109 addon\globalPlugins\visionAssistant\features\video.py:418
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:687
+#: addon\globalPlugins\visionAssistant\ai\providers\mistral.py:172
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:101
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:111
+#: addon\globalPlugins\visionAssistant\features\video.py:418
 msgid "Upload failed."
 msgstr "Przesyłanie nie powiodło się."
 
-#. Translators: Message shown when an API rate limit is reached. {sec} is the
-#. number of seconds to wait.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:705 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:963
+#. Translators: Status message showing the progress of document scanning. {start} and {end} are page numbers.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:696
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:894
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:999
+#: addon\globalPlugins\visionAssistant\features\vision.py:888
+#, python-brace-format
+msgid "Processing pages {start} to {end}..."
+msgstr "Przetwarzanie stron {start} do {end}..."
+
+#. Translators: Message shown when an API rate limit is reached. {sec} is the number of seconds to wait.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:729
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:991
 #, python-brace-format
 msgid "Rate limit reached. Waiting {sec}s before retry..."
 msgstr "Osiągnięto limit zapytań. Czekam {sec}s przed ponowną próbą..."
 
-#. Translators: Status message indicating an API request retry due to a
-#. temporary error for specific pages. {error} is replaced with details,
-#. {range} is the page range, {current} and {total} are attempts.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:717
+#. Translators: Status message indicating an API request retry due to a temporary error for specific pages. {error} is replaced with details, {range} is the page range, {current} and {total} are attempts.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:740
 #, python-brace-format
-msgid "Temporary error ({error}). Retrying API request for pages {range} (Attempt {current}/{total})..."
-msgstr "Błąd tymczasowy ({error}). Ponawianie zapytania API dla stron {range} (próba {current}/{total})..."
+msgid ""
+"Temporary error ({error}). Retrying API request for pages {range} (Attempt "
+"{current}/{total})..."
+msgstr ""
+"Błąd tymczasowy ({error}). Ponawianie zapytania API dla stron {range} (próba "
+"{current}/{total})..."
 
-#. Translators: Status message indicating an API request retry due to a
-#. temporary error. {error} is replaced with details, {current} and {total}
-#. are attempts.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:719 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:971
+#. Translators: Status message indicating an API request retry due to a temporary error. {error} is replaced with details, {current} and {total} are attempts.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:742
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:999
 #, python-brace-format
-msgid "Temporary error ({error}). Retrying on current key (Attempt {current}/{total})..."
-msgstr "Błąd tymczasowy ({error}). Ponawianie na bieżącym kluczu (próba {current}/{total})..."
+msgid ""
+"Temporary error ({error}). Retrying on current key (Attempt {current}/"
+"{total})..."
+msgstr ""
+"Błąd tymczasowy ({error}). Ponawianie na bieżącym kluczu (próba {current}/"
+"{total})..."
 
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:728 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:742
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:750
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:752
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:767
 msgid "All keys failed."
 msgstr "Wszystkie klucze zawiodły."
 
-#. Translators: Message reported when API quota is exhausted and the system
-#. rotates key.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:738 addon\globalPlugins\visionAssistant\ai\providers\gemini.py:985
-msgid "Daily quota exhausted or retries failed. Rotating key and re-uploading..."
-msgstr "Wyczerpany dzienny limit lub nieudane ponowne próby. Zmiana klucza i ponowne wysyłanie..."
+#. Translators: Message reported when API quota is exhausted and the system rotates key.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:764
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:1013
+msgid ""
+"Daily quota exhausted or retries failed. Rotating key and re-uploading..."
+msgstr ""
+"Wyczerpany dzienny limit lub nieudane ponowne próby. Zmiana klucza i ponowne "
+"wysyłanie..."
 
-#. Translators: Status message indicating video upload progress with file size
-#. in MB.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:870
+#. Translators: Status message indicating video upload progress with file size in MB.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:898
 #, python-brace-format
 msgid "Uploading to AI ({size:.1f} MB)..."
 msgstr "Wysyłanie do AI ({size:.1f} MB)..."
 
-#. Translators: Status message indicating video upload progress with file size
-#. in MB and retry attempt numbers.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:903
+#. Translators: Status message indicating video upload progress with file size in MB and retry attempt numbers.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:931
 #, python-brace-format
 msgid "Uploading to AI ({size:.1f} MB) (Key {current}/{total})..."
 msgstr "Wysyłanie do AI ({size:.1f} MB) (klucz {current}/{total})..."
 
-#. Translators: Message reported when a file upload fails and the system is
-#. retrying.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:909
+#. Translators: Message reported when a file upload fails and the system is retrying.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:937
 msgid "Upload failed. Retrying..."
 msgstr "Wysyłanie nie powiodło się. Ponawianie..."
 
 #. Translators: Error shown internally when AI stops early
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:940
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:968
 msgid "Incomplete description. AI stopped early."
 msgstr "Niepełny opis. AI zatrzymała się przedwcześnie."
 
-#. Translators: Message reported when all available API keys have reached
-#. their usage limits.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:989
+#. Translators: Message reported when all available API keys have reached their usage limits.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:1017
 msgid "All API keys exhausted or server unavailable."
 msgstr "Wszystkie klucze API wyczerpane lub serwer niedostępny."
 
-#. Translators: Error message shown when all API keys run out of quota or
-#. fail.
-#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:999
+#. Translators: Error message shown when all API keys run out of quota or fail.
+#: addon\globalPlugins\visionAssistant\ai\providers\gemini.py:1027
 msgid "All API keys failed or daily quota exhausted."
 msgstr "Wszystkie klucze API zawiodły lub wyczerpano dzienny limit."
 
@@ -1236,29 +1239,41 @@ msgstr "Wszystkie klucze API zawiodły lub wyczerpano dzienny limit."
 #. Translators: Error message when TTS is not supported by the provider
 #. Translators: Message box content for successful save
 #. Translators: Error message when TTS is not supported by the provider
-#: addon\globalPlugins\visionAssistant\ai\providers\mistral.py:23 addon\globalPlugins\visionAssistant\ai\providers\mistral.py:118 addon\globalPlugins\visionAssistant\ai\providers\openai.py:26 addon\globalPlugins\visionAssistant\ai\providers\openai.py:199 addon\globalPlugins\visionAssistant\dialogs\document.py:653
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:869 addon\globalPlugins\visionAssistant\dialogs\document.py:977 addon\globalPlugins\visionAssistant\features\audio.py:393 addon\globalPlugins\visionAssistant\utils\media_capture.py:1019
+#: addon\globalPlugins\visionAssistant\ai\providers\mistral.py:23
+#: addon\globalPlugins\visionAssistant\ai\providers\mistral.py:118
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:27
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:200
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:787
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1072
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1221
+#: addon\globalPlugins\visionAssistant\features\audio.py:321
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1063
 msgid "No API Keys configured."
 msgstr "Nie skonfigurowano kluczy API."
 
 #. Translators: Error message shown when the AI returns an unknown error
-#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:146 addon\globalPlugins\visionAssistant\features\operator_captcha.py:229
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:147
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:229
 msgid "AI Error"
 msgstr "Błąd AI"
 
 #. Translators: Error message when speech-to-text fails.
-#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:191
+#: addon\globalPlugins\visionAssistant\ai\providers\openai.py:192
 msgid "Transcription Failed"
 msgstr "Transkrypcja nie powiodła się"
 
 #. Translators: Label for the AI response text area in a chat dialog
 #. Translators: Label for Target Language selection
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:36 addon\globalPlugins\visionAssistant\dialogs\settings.py:309
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:41
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:342
 msgid "AI Response:"
 msgstr "Odpowiedź AI:"
 
 #. Translators: Format for displaying User message in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:53 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:144 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:228
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:58
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:236
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:266
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:356
 #, python-brace-format
 msgid ""
 "\n"
@@ -1268,54 +1283,93 @@ msgstr ""
 "Ty: {text}\n"
 
 #. Translators: Format for displaying AI message in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:57 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:63 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:214 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:229
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:63
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:70
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:238
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:341
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:357
 #, python-brace-format
 msgid "AI: {text}\n"
 msgstr "AI: {text}\n"
 
 #. Translators: Label for user input field in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:77
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:90
 msgid "Ask:"
 msgstr "Zapytaj:"
 
 #. Translators: Button to attach files in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:89 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:202
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:102
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:329
 msgid "&Attach File"
 msgstr "Dołącz &plik"
 
+#. Translators: Label for attach button when files are attached
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:105
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:296
+#, python-brace-format
+msgid "Attach File ({count})"
+msgstr "Dołącz plik ({count})"
+
 #. Translators: Button to send message in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:92 addon\globalPlugins\visionAssistant\dialogs\document.py:74
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:107
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:76
 msgid "Send"
 msgstr "Wyślij"
 
 #. Translators: Button to view the content in a formatted HTML window
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:94 addon\globalPlugins\visionAssistant\dialogs\document.py:404
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:109
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:461
 msgid "View Formatted"
 msgstr "Podgląd sformatowany"
 
 #. Translators: Button to save only the result content without chat history
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:97
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:112
 msgid "Save Content"
 msgstr "Zapisz treść odpowiedzi"
 
 #. Translators: Button to save chat in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:100
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:115
 msgid "Save Chat"
 msgstr "Zapisz cały czat"
 
 #. Translators: Button to close chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:102 addon\globalPlugins\visionAssistant\dialogs\document.py:436 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:110
+#. Translators: Button to close the History dialog.
+#. Translators: Button to close the recent documents dialog.
+#. Translators: Button to close chat dialog
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:117
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:473
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:80
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:214
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:216
 msgid "Close"
 msgstr "Zamknij"
 
+#. Translators: Announced before the first message when reviewing a chat conversation with Alt+Up/Down.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:243
+msgid "First message"
+msgstr "Pierwsza wiadomość"
+
+
+#. Translators: Announced before the last message when reviewing a chat conversation with Alt+Up/Down.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:247
+msgid "Last message"
+msgstr "Ostatnia wiadomość"
+
+
+#. Translators: Announced when the currently selected chat message is copied to the clipboard.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:259
+msgid "Copied."
+msgstr "Skopiowano."
+
+
 #. Translators: Message shown while processing in a chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:148 addon\globalPlugins\visionAssistant\dialogs\document.py:136
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:271
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:138
 msgid "Thinking..."
 msgstr "Przetwarzanie..."
 
-#. Translators: Text appended to the chat window while waiting for the AI to
-#. respond.
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:152
+#. Translators: Text appended to the chat window while waiting for the AI to respond.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:275
 msgid ""
 "\n"
 "Processing...\n"
@@ -1324,1027 +1378,1328 @@ msgstr ""
 "Przetwarzanie...\n"
 
 #. Translators: Status when the AI is thinking in chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:160
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:283
 msgid "Processing response..."
 msgstr "Przetwarzanie odpowiedzi..."
 
-#. Translators: Title of the file selection dialog when attaching a file to a
-#. chat.
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:166
+#. Translators: Title of the file selection dialog when attaching a file to a chat.
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:289
 msgid "Select a file to attach"
 msgstr "Wybierz plik do dołączenia"
 
-#. Translators: Label for attach button when files are attached
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:171
-#, python-brace-format
-msgid "Attach File ({count})"
-msgstr "Dołącz plik ({count})"
-
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:172
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:297
 #, python-brace-format
 msgid "File attached: {name}"
 msgstr "Dołączono plik: {name}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:249
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:377
 msgid "Formatted Conversation"
 msgstr "Sformatowana rozmowa"
 
 #. Translators: Error message if viewing fails
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:252
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:380
 #, python-brace-format
 msgid "Error displaying content: {error}"
 msgstr "Błąd wyświetlania treści: {error}"
 
 #. Translators: Save dialog title
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:257
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:385
 msgid "Save Chat Log"
 msgstr "Zapisz dziennik czatu"
 
 #. Translators: Message shown on successful save of a file.
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:262 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:274
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:390
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:402
 msgid "Saved."
 msgstr "Zapisano."
 
 #. Translators: Message in the error dialog when saving fails.
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:265 addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:276
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:393
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:404
 #, python-brace-format
 msgid "Save failed: {error}"
 msgstr "Zapisywanie nie powiodło się: {error}"
 
-#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:269
+#: addon\globalPlugins\visionAssistant\dialogs\chat_dialog.py:397
 msgid "Save Result"
 msgstr "Zapisywanie wyniku"
 
 #. Translators: Title of the chat dialog
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:50
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:52
 msgid "Ask about Document"
 msgstr "Zapytaj o dokument"
 
 #. Translators: Label showing the analyzed file name
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:59
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:61
 #, python-brace-format
 msgid "File: {name}"
 msgstr "Plik: {name}"
 
 #. Translators: Status message while uploading
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:64
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:66
 msgid "Uploading to AI...\n"
 msgstr "Przesyłanie do AI...\n"
 
 #. Translators: Label for the chat input field
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:68
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:70
 msgid "Your Question:"
 msgstr "Twoje pytanie:"
 
-#. Translators: Message shown in the chat area when the file is uploaded and
-#. the AI is ready to answer questions.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:126
+#. Translators: Message shown in the chat area when the file is uploaded and the AI is ready to answer questions.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:128
 msgid "Ready! Ask your questions.\n"
 msgstr "Gotowe! Zadawaj pytania.\n"
 
-#. Translators: Placeholder text used in document chat when the text is still
-#. being extracted or is empty.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:180
+#. Translators: Placeholder text used in document chat when the text is still being extracted or is empty.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:182
 msgid "[Text extraction in progress or empty]"
 msgstr "[Wyodrębnianie tekstu w toku lub puste]"
 
 #. Translators: Prefix for an AI message line in the Live Assistant history.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:237 addon\globalPlugins\visionAssistant\utils\media_capture.py:1290 addon\globalPlugins\visionAssistant\utils\media_capture.py:1306
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:239
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1375
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1391
 msgid "AI: "
 msgstr "AI: "
 
-#. Translators: Title of the PDF and document options dialog (range,
-#. translation, etc.)
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:246
+#. Translators: Title of the PDF and document options dialog (range, translation, etc.)
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:248
 msgid "Options"
 msgstr "Opcje"
 
 #. Translators: Label showing total pages found
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:249
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:251
 #, python-brace-format
 msgid "Total Pages (All Files): {count}"
 msgstr "Łączna liczba stron (wszystkie pliki): {count}"
 
 #. Translators: Box title for page range selection
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:252
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:254
 msgid "Range"
 msgstr "Zakres"
 
 #. Translators: Label for start page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:255
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:257
 msgid "From:"
 msgstr "Od:"
 
 #. Translators: Label for end page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:259
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:261
 msgid "To:"
 msgstr "Do:"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:267
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:269
 msgid "Translate Output"
 msgstr "Przetłumacz wynik"
 
 #. Translators: Checkbox to enable translation
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:270 addon\globalPlugins\visionAssistant\dialogs\media.py:204 addon\globalPlugins\visionAssistant\dialogs\settings.py:304
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:272
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:233
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:337
 msgid "Target:"
 msgstr "Docelowy:"
 
-#. Translators: Label for the checkbox that enables image descriptions during
-#. OCR in the extraction dialog
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:280
+#. Translators: Label for the checkbox that enables image descriptions during OCR in the extraction dialog
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:282
 msgid "Describe images inline during OCR"
 msgstr "Wplataj opisy obrazów w tekst podczas OCR"
 
 #. Translators: Button to start processing
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:286 addon\globalPlugins\visionAssistant\dialogs\media.py:214
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:288
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:243
 msgid "Start"
 msgstr "Rozpocznij"
 
 #. Translators: Button to add a label for the selected element
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:288 addon\globalPlugins\visionAssistant\dialogs\media.py:217 addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:231
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:290
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:246
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:231
 msgid "Cancel"
 msgstr "Anuluj"
 
 #. Translators: Title of settings group for Document Reader features
 #. --- Document Reader Settings ---
 #. Translators: Title of settings group for Document Reader features
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:316 addon\globalPlugins\visionAssistant\dialogs\settings.py:321
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:318
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:177
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:354
 msgid "Document Reader"
 msgstr "Czytnik dokumentów"
 
 #. Translators: Initial status message
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:364 addon\globalPlugins\visionAssistant\dialogs\media.py:415
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:370
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:444
 msgid "Initializing..."
 msgstr "Inicjowanie..."
 
 #. Translators: Button to go to previous page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:370
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:377
 msgid "Previous (Ctrl+PageUp)"
 msgstr "Poprzednia (Ctrl+PageUp)"
 
 #. Translators: Button to go to next page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:374
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:381
 msgid "Next (Ctrl+PageDown)"
 msgstr "Następna (Ctrl+PageDown)"
 
 #. Translators: Label for Go To Page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:378
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:385
 msgid "Go to:"
 msgstr "Przejdź do:"
 
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:396
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:382
+msgid "TTS Voice:"
+msgstr "Głos TTS:"
+
+#. Translators: Label for the TTS engine selector in the document reader.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:418
+msgid "TTS Engine:"
+msgstr "Silnik syntezy mowy:"
+
+
+#. Translators: Option for the standard TTS engine.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:422
+msgid "Standard TTS"
+msgstr "Standardowa synteza mowy"
+
+
+#. Translators: Option for the Gemini Live streaming TTS engine.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:424
+msgid "Gemini Live"
+msgstr "Gemini Live"
+
+
 #. Translators: Button to Ask questions about the document
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:389
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:437
 msgid "Ask AI (Alt+A)"
 msgstr "Zapytaj AI (Alt+A)"
 
 #. Translators: Button to force re-scan
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:394
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:442
 msgid "Re-scan with AI (Alt+R)"
 msgstr "Ponowne skanowanie AI (Alt+R)"
 
+#. Translators: Button to retry pages that failed due to a temporary server error
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:447
+msgid "Retry Failed Pages"
+msgstr "Ponów nieudane strony"
+
+
 #. Translators: Button to generate audio
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:399
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:456
 msgid "Generate Audio (Alt+G)"
 msgstr "Generuj audio (Alt+G)"
 
 #. Translators: Button to save text
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:409
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:466
 msgid "Save (Alt+S)"
 msgstr "Zapisz (Alt+S)"
 
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:417 addon\globalPlugins\visionAssistant\dialogs\settings.py:349
-msgid "TTS Voice:"
-msgstr "Głos TTS:"
+#. Translators: Subtitle for a document history entry showing the current page. {page} is the current page and {total} is the total number of pages.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:526
+#, python-brace-format
+msgid "Page {page} of {total}"
+msgstr "Strona {page} z {total}"
+
 
 #. Translators: Message reported when extracting text from a file
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:474 addon\globalPlugins\visionAssistant\features\vision.py:750
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:574
+#: addon\globalPlugins\visionAssistant\features\vision.py:794
 msgid "Extracting Text..."
 msgstr "Wyodrębnianie tekstu..."
 
 #. Translators: Status message showing page-by-page progress during file OCR.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:529 addon\globalPlugins\visionAssistant\features\vision.py:721 addon\globalPlugins\visionAssistant\features\vision.py:733 addon\globalPlugins\visionAssistant\features\vision.py:795 addon\globalPlugins\visionAssistant\features\vision.py:811
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:631
+#: addon\globalPlugins\visionAssistant\features\vision.py:766
+#: addon\globalPlugins\visionAssistant\features\vision.py:777
+#: addon\globalPlugins\visionAssistant\features\vision.py:838
+#: addon\globalPlugins\visionAssistant\features\vision.py:853
 #, python-brace-format
 msgid "Processing page {current} of {total}..."
 msgstr "Przetwarzanie strony {current} z {total}..."
 
 #. Translators: Spoken message when the current page is ready
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:537
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:639
 #, python-brace-format
 msgid "Page {num} ready"
 msgstr "Strona {num} gotowa"
 
+#. Translators: Message shown when a PDF has no text layer.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:665
+#: addon\globalPlugins\visionAssistant\features\vision.py:696
+#: addon\globalPlugins\visionAssistant\features\vision.py:785
+#: addon\globalPlugins\visionAssistant\features\vision.py:990
+msgid ""
+"The 'None (Extract Text Layer)' engine cannot process image-based content. "
+"Please change the OCR Engine to 'Chrome' or 'AI (Advanced)' in settings."
+msgstr ""
+"Silnik „Wyodrębnij tekst (offline)” nie obsługuje treści graficznych. Zmień "
+"silnik OCR na „Chrome” albo „AI (Advanced)” w ustawieniach."
+
 #. Translators: Placeholder text when OCR fails
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:567
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:678
 msgid "[OCR failed. Try a different AI model or provider.]"
 msgstr "[OCR nie powiodło się. Spróbuj innego modelu AI lub dostawcy.]"
 
 #. Translators: Error message for page processing failure
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:585
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:696
 msgid "Error processing page."
 msgstr "Błąd przetwarzania strony."
 
 #. Translators: Status label format
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:590
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:701
 #, python-brace-format
 msgid "Page {current} of {total}"
 msgstr "Strona {current} z {total}"
 
 #. Translators: Status when page is loading
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:597
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:708
 msgid "Processing in background..."
 msgstr "Przetwarzanie w tle..."
 
 #. Translators: Spoken message when switching pages
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:608 addon\globalPlugins\visionAssistant\dialogs\document.py:628 addon\globalPlugins\visionAssistant\dialogs\document.py:1023
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:719
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:760
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1268
 #, python-brace-format
 msgid "Page {num}"
 msgstr "Strona {num}"
 
 #. Translators: Title of the formatted result window
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:644
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:776
 msgid "Formatted Content"
 msgstr "Sformatowana treść"
 
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:653 addon\globalPlugins\visionAssistant\dialogs\document.py:863 addon\globalPlugins\visionAssistant\dialogs\document.py:869 addon\globalPlugins\visionAssistant\dialogs\document.py:930 addon\globalPlugins\visionAssistant\dialogs\document.py:971
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:977 addon\globalPlugins\visionAssistant\dialogs\document.py:1041 addon\globalPlugins\visionAssistant\dialogs\settings.py:808 addon\globalPlugins\visionAssistant\dialogs\settings.py:1142
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:787
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1066
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1072
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1150
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1160
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1171
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1213
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1221
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1287
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:878
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1349
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1440
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1462
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1466
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1491
 msgid "Error"
 msgstr "Błąd"
 
 #. Translators: Menu option for current page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:657
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:791
 msgid "Current Page"
 msgstr "Bieżąca strona"
 
 #. Translators: Menu option for all pages
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:659
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:793
 msgid "All Pages (In Range)"
 msgstr "Wszystkie strony (w zakresie)"
 
 #. Translators: Message during manual scan
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:669
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:803
 msgid "Scanning with AI..."
 msgstr "Skanowanie AI..."
 
 #. Translators: Error shown when a specific page scan fails.
-#. Translators: Error shown in the document reader when a page is dropped
-#. because the AI output exceeded its limit during batch processing.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:685 addon\globalPlugins\visionAssistant\dialogs\document.py:767 addon\globalPlugins\visionAssistant\dialogs\document.py:838 addon\globalPlugins\visionAssistant\dialogs\document.py:845
+#. Translators: Error shown in the document reader when a page is dropped because the AI output exceeded its limit during batch processing.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:823
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:940
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1037
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1044
 #, python-brace-format
 msgid "[Scan failed: {err}]"
 msgstr "[Skanowanie nie powiodło się: {err}]"
 
 #. Translators: Message shown when OCR returns no text for a page.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:690
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:828
 msgid "[No text detected]"
 msgstr "[Nie wykryto tekstu]"
 
 #. Translators: Message when scan is complete
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:695
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:833
 msgid "Scan complete"
 msgstr "Skanowanie zakończone"
 
 #. Translators: Generic system error message inside the document viewer.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:698
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:836
 #, python-brace-format
 msgid "[Error: {msg}]"
 msgstr "[Błąd: {msg}]"
 
 #. Translators: Status message for local text extraction
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:711
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:853
 msgid "Extracting text layer..."
 msgstr "Wyodrębnianie tekstu..."
 
 #. Translators: Message when batch scan starts
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:718 addon\globalPlugins\visionAssistant\dialogs\document.py:783
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:860
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:982
 msgid "Batch Processing Started"
 msgstr "Rozpoczęto przetwarzanie wsadowe"
 
-#. Translators: Status message showing the progress of document scanning.
-#. {start} and {end} are page numbers.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:737 addon\globalPlugins\visionAssistant\dialogs\document.py:800 addon\globalPlugins\visionAssistant\features\vision.py:847
-#, python-brace-format
-msgid "Processing pages {start} to {end}..."
-msgstr "Przetwarzanie stron {start} do {end}..."
-
-#. Translators: Success message shown when all batches of the document have
-#. been processed.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:780 addon\globalPlugins\visionAssistant\dialogs\document.py:858
+#. Translators: Success message shown when all batches of the document have been processed.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:884
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1057
 msgid "All document pages have been processed."
 msgstr "Wszystkie strony dokumentu zostały przetworzone."
 
-#. Translators: Error shown in the document reader when the AI returns an
-#. empty response for a batch of pages.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:823
-msgid "[Error: Empty response received from AI. Try reducing the batch size in settings or scanning page-by-page.]"
-msgstr "[Błąd: otrzymano pustą odpowiedź od AI. Zmniejsz rozmiar wsadu w ustawieniach lub skanuj strona po stronie.]"
+#. Translators: Status message when a temporary server error interrupts a batch of pages. {range} is the page range that can be retried.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:933
+#, python-brace-format
+msgid "Server busy for pages {range}. Retry available."
+msgstr "Serwer zajęty dla stron {range}. Można ponowić próbę."
 
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:830
-msgid "[Error: Page skipped during batch processing due to model output limits. Try a smaller batch size in settings.]"
-msgstr "[Błąd: pominięto stronę podczas przetwarzania wsadowego z powodu limitów wyjścia modelu. Zmniejsz rozmiar wsadu w ustawieniach.]"
 
-#. Translators: Error message when trying to use TTS with an unsupported
-#. provider
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:863
+#. Translators: Status message when the user retries pages that previously failed.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:954
+msgid "Retrying failed pages..."
+msgstr "Ponawianie nieudanych stron..."
+
+
+#. Translators: Error shown in the document reader when the AI returns an empty response for a batch of pages.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1022
+msgid ""
+"[Error: Empty response received from AI. Try reducing the batch size in "
+"settings or scanning page-by-page.]"
+msgstr ""
+"[Błąd: otrzymano pustą odpowiedź od AI. Zmniejsz rozmiar wsadu w "
+"ustawieniach lub skanuj strona po stronie.]"
+
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1029
+msgid ""
+"[Error: Page skipped during batch processing due to model output limits. Try "
+"a smaller batch size in settings.]"
+msgstr ""
+"[Błąd: pominięto stronę podczas przetwarzania wsadowego z powodu limitów "
+"wyjścia modelu. Zmniejsz rozmiar wsadu w ustawieniach.]"
+
+#. Translators: Error message when trying to use TTS with an unsupported provider
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1066
 msgid "TTS is not supported by the current provider or configuration."
 msgstr "Bieżący dostawca lub konfiguracja nie obsługuje syntezy mowy."
 
 #. Translators: Menu option for TTS current page
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:874
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1077
 msgid "Generate for Current Page"
 msgstr "Generuj dla bieżącej strony"
 
 #. Translators: Menu option for TTS all pages
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:876
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1079
 msgid "Generate for All Pages (In Range)"
 msgstr "Generuj dla wszystkich stron (w zakresie)"
 
 #. Translators: Error message when text field is empty
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:886
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1089
 msgid "No text to read."
 msgstr "Brak tekstu do odczytu."
 
 #. Translators: Message while gathering text
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:896
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1099
 msgid "Gathering text for audio..."
 msgstr "Zbieranie tekstu do audio..."
 
-#. Translators: Placeholder text shown in the document reader when processing
-#. takes too long
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:903 addon\globalPlugins\visionAssistant\dialogs\document.py:1014
+#. Translators: Placeholder text shown in the document reader when processing takes too long
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1106
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1259
 msgid "[Processing timeout]"
 msgstr "[Przekroczono czas przetwarzania]"
 
 #. Translators: File dialog title for saving audio
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:910
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1112
 msgid "Save Audio"
 msgstr "Zapisz audio"
 
 #. Translators: Message while generating audio
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:921
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1129
 msgid "Generating Audio..."
 msgstr "Generowanie audio..."
 
+#. Translators: Status message showing per-page audio generation progress. {current} and {total} are page numbers.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1143
+#, python-brace-format
+msgid "Generating audio for page {current} of {total}..."
+msgstr "Generowanie dźwięku dla strony {current} z {total}..."
+
+
+#. Translators: Error message when the Gemini Live TTS engine returns no audio.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1150
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1160
+msgid "TTS Error: Gemini Live returned no audio."
+msgstr "Błąd syntezy mowy: Gemini Live nie zwrócił dźwięku."
+
+
 #. Translators: Fallback error message during text-to-speech generation.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:929
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1170
 msgid "Unknown Error"
 msgstr "Nieznany błąd"
 
 #. Translators: Success message after generating TTS audio.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:930 addon\globalPlugins\visionAssistant\dialogs\document.py:971
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1171
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1213
 #, python-brace-format
 msgid "TTS Error: {error}"
 msgstr "Błąd TTS: {error}"
 
 #. Translators: Error message when the MP3 encoder (LAME) is missing.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:947
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1188
 msgid "lame.exe not found in lib folder."
 msgstr "Nie znaleziono lame.exe w folderze lib."
 
 #. Translators: Spoken message when audio is saved
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:961
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1202
 msgid "Audio Saved"
 msgstr "Audio zapisane"
 
-#. Translators: Success message shown when narration generation is
-#. successfully completed with silence detection.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:966
+#. Translators: Success message shown when narration generation is successfully completed with silence detection.
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1207
 msgid "Audio file generated and saved successfully."
 msgstr "Plik audio został wygenerowany i zapisany."
 
 #. Translators: Title for the success message box.
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:966 addon\globalPlugins\visionAssistant\dialogs\document.py:1039 addon\globalPlugins\visionAssistant\dialogs\donate.py:55 addon\globalPlugins\visionAssistant\dialogs\media.py:1568
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1207
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1284
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:64
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1448
 msgid "Success"
 msgstr "Sukces"
 
 #. Translators: File dialog title for saving
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:996
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1240
 msgid "Save"
 msgstr "Zapisz"
 
 #. Translators: Message showing save progress
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:1008
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1253
 #, python-brace-format
 msgid "Saving Page {num}..."
 msgstr "Zapisywanie strony {num}..."
 
 #. Translators: Status label when save is complete
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:1038
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1283
 msgid "Saved"
 msgstr "Zapisano"
 
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:1039
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1284
 msgid "File saved successfully."
 msgstr "Plik zapisany."
 
 #. Translators: Message box content for successful save
-#: addon\globalPlugins\visionAssistant\dialogs\document.py:1041 addon\globalPlugins\visionAssistant\dialogs\settings.py:1142
+#: addon\globalPlugins\visionAssistant\dialogs\document.py:1287
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1349
 #, python-brace-format
 msgid "Save Error: {error}"
 msgstr "Błąd zapisu: {error}"
 
-#. Translators: Label for the button to open a website to purchase an Apple
-#. Gift Card.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:21
+#. Translators: Label for the button to get instructions for donating with a Visa gift card purchased in any country.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:22
+msgid "Visa Gift Card (Any Country)"
+msgstr "Karta podarunkowa Visa (dowolny kraj)"
+
+
+#. Translators: Label for the button to open a website to purchase an Apple Gift Card.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:24
 msgid "Buy Apple Gift Card (US Region)"
 msgstr "Kup Apple Gift Card (region USA)"
 
-#. Translators: Label for the button to copy the support email address for
-#. gift cards.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:23
+#. Translators: Label for the button to copy the support email address for gift cards.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:26
 msgid "Copy Support Email"
 msgstr "Kopiuj adres e-mail wsparcia"
 
-#. Translators: Label for the button to copy the TON cryptocurrency wallet
-#. address.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:25
+#. Translators: Label for the button to copy the TON cryptocurrency wallet address.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:28
 msgid "Copy TON Address"
 msgstr "Kopiuj adres TON"
 
-#. Translators: Label for the button to copy the TRON cryptocurrency wallet
-#. address.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:27
+#. Translators: Label for the button to copy the TRON cryptocurrency wallet address.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:30
 msgid "Copy TRON Address"
 msgstr "Skopiuj adres TRON"
 
-#. Translators: Button to dismiss the donation dialog without taking any
-#. action.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:36
+#. Translators: Button to dismiss the donation dialog without taking any action.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:40
 msgid "Maybe Later"
 msgstr "Może później"
 
-#. Translators: Message shown after the gift card website is opened.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:48
+#. Translators: Message shown after the Visa gift card option is chosen, explaining how to send the card code and its country.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:52
 #, python-brace-format
-msgid "The website has been opened. Please purchase a 'US Region' card and send the code to: {email}"
-msgstr "Otwarto stronę. Kup kartę z regionu USA i wyślij kod na adres: {email}"
+msgid ""
+"Buy a Visa gift card from a retailer in your country. Then email the card "
+"code to {email}, and please mention the country the card was purchased in."
+msgstr ""
+"Kup kartę podarunkową Visa u sprzedawcy w swoim kraju. Następnie wyślij kod karty na adres {email} i podaj kraj, w którym karta została kupiona."
 
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:49
+
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:53
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:58
 msgid "Information"
 msgstr "Informacja"
 
-#. Translators: Success message shown after an address or email is copied to
-#. the clipboard.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:53
+#. Translators: Message shown after the gift card website is opened.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:57
+#, python-brace-format
+msgid ""
+"The website has been opened. Please purchase a 'US Region' card and send the "
+"code to: {email}"
+msgstr "Otwarto stronę. Kup kartę z regionu USA i wyślij kod na adres: {email}"
+
+#. Translators: Success message shown after an address or email is copied to the clipboard.
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:62
 msgid "Copied to clipboard! Your support is greatly appreciated!"
 msgstr "Skopiowano do schowka! Twoje wsparcie jest bardzo ważne!"
 
 #. Translators: Title of the donation request dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:66
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:75
 #, python-brace-format
 msgid "Support the Future of {name}"
 msgstr "Wesprzyj przyszłość {name}"
 
 #. Translators: The main message of the donation dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\donate.py:69
+#: addon\globalPlugins\visionAssistant\dialogs\donate.py:78
 #, python-brace-format
 msgid ""
-"{name} is a project born from a personal vision to bridge the gap between AI and true accessibility. The initial concept and many of the features you enjoy were created from my own ideas to solve real challenges and provide a new level of digital independence.\n"
+"{name} is a project born from a personal vision to bridge the gap between AI "
+"and true accessibility. The initial concept and many of the features you "
+"enjoy were created from my own ideas to solve real challenges and provide a "
+"new level of digital independence.\n"
 "\n"
-"I take great pride in thinking through every detail and turning both my own innovations and your valuable requests into reality. Ensuring this tool remains fast, stable, and constantly evolving is a continuous creative journey that I am passionate about pursuing.\n"
+"I take great pride in thinking through every detail and turning both my own "
+"innovations and your valuable requests into reality. Ensuring this tool "
+"remains fast, stable, and constantly evolving is a continuous creative "
+"journey that I am passionate about pursuing.\n"
 "\n"
-"Important Note: Due to international banking restrictions in my region, I am unable to use PayPal or Stripe. If you wish to support this project, you can donate via Cryptocurrency or by sending an Apple Gift Card (US region) to: {email}\n"
+"Important Note: Due to international banking restrictions in my region, I am "
+"unable to use PayPal or Stripe. If you wish to support this project, you can "
+"donate via Cryptocurrency, a Visa Gift Card, or an Apple Gift Card (US "
+"region). For gift cards, please send the code to: {email} and mention the "
+"country the card was purchased in.\n"
 "\n"
-"If this assistant has brought value to your daily life, your support is a wonderful way to show appreciation for the original work and the dedication behind it. Thank you for being part of this mission!"
+"If this assistant has brought value to your daily life, your support is a "
+"wonderful way to show appreciation for the original work and the dedication "
+"behind it. Thank you for being part of this mission!"
 msgstr ""
 "{name} to projekt zrodzony z osobistej wizji, by zbliżyć sztuczną inteligencję do prawdziwej dostępności. Pierwotna koncepcja i wiele funkcji, z których korzystasz, powstały z moich własnych pomysłów, by rozwiązywać realne problemy i zapewnić nowy poziom cyfrowej niezależności.\n"
 "\n"
 "Z dumą dopracowuję każdy szczegół, zamieniając zarówno własne innowacje, jak i Wasze cenne sugestie w rzeczywistość. Dbanie o to, by narzędzie pozostawało szybkie, stabilne i stale się rozwijało, to nieustanna twórcza podróż, którą realizuję z pasją.\n"
 "\n"
-"Ważna uwaga: ze względu na międzynarodowe ograniczenia bankowe w moim regionie nie mogę korzystać z PayPal ani Stripe. Jeśli chcesz wesprzeć ten projekt, możesz przekazać darowiznę w kryptowalucie lub wysłać kartę podarunkową Apple (region US) na adres: {email}\n"
+"Ważna uwaga: ze względu na międzynarodowe ograniczenia bankowe w moim regionie nie mogę korzystać z PayPal ani Stripe. Jeśli chcesz wesprzeć ten projekt, możesz przekazać darowiznę w kryptowalucie, kartą podarunkową Visa albo kartą podarunkową Apple (region US). W przypadku kart podarunkowych wyślij kod na adres: {email} i podaj kraj, w którym karta została kupiona.\n"
 "\n"
 "Jeśli ten asystent wniósł wartość do Twojego codziennego życia, Twoje wsparcie jest wspaniałym sposobem na docenienie włożonej pracy i zaangażowania. Dziękuję, że jesteś częścią tej misji!"
 
+
+#. Translators: Title of the dialog that lists recent chats and documents.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:41
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:63
+msgid "History"
+msgstr "Historia"
+
+
+#. Translators: Label for the filter combo box in the History dialog.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:54
+msgid "Show:"
+msgstr "Pokaż:"
+
+
+#. Translators: Button to open the selected history item.
+#. Translators: Button to open the selected recent document.
+#. Translators: Message announced by NVDA when the live voice conversation ends.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:70
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:201
+#: addon\globalPlugins\visionAssistant\features\screen_capture.py:203
+#: addon\globalPlugins\visionAssistant\features\vision.py:96
+#: addon\globalPlugins\visionAssistant\features\vision.py:473
+msgid "Open"
+msgstr "Otwórz"
+
+#. Translators: Button to delete the selected history item.
+#. Translators: Button to delete the selected recent document.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:74
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:144
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:205
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:278
+msgid "Delete"
+msgstr "Usuń"
+
+
+#. Translators: Button to clear all history items.
+#. Translators: Button to clear all recent documents.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:77
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:167
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:208
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:292
+msgid "Clear All"
+msgstr "Wyczyść wszystko"
+
+
+#. Translators: Message announced when the history list is empty.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:127
+msgid "No history yet."
+msgstr "Historia jest pusta."
+
+
+#. Translators: Message confirming deletion of the selected history item.
+#. Translators: Message confirming deletion of the selected recent document.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:144
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:278
+msgid "Delete this item from history?"
+msgstr "Usunąć ten element z historii?"
+
+
+#. Translators: Announcement when a history item is deleted.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:149
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:283
+msgid "Deleted."
+msgstr "Usunięto."
+
+
+#. Translators: Message confirming clearing of all chats in the History dialog.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:160
+msgid "Clear all chats? This cannot be undone."
+msgstr "Wyczyścić wszystkie czaty? Tej operacji nie można cofnąć."
+
+
+#. Translators: Message confirming clearing of all documents in the History dialog.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:163
+msgid "Clear all documents? This cannot be undone."
+msgstr "Wyczyścić wszystkie dokumenty? Tej operacji nie można cofnąć."
+
+
+#. Translators: Message confirming clearing of all history.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:166
+msgid "Clear all history? This cannot be undone."
+msgstr "Wyczyścić całą historię? Tej operacji nie można cofnąć."
+
+
+#. Translators: Announcement when history is cleared.
+#. Translators: Announcement when all recent documents are cleared.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:172
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:297
+msgid "History cleared."
+msgstr "Wyczyszczono historię."
+
+
+#. Translators: Label for the recent documents list in the Document Reader.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:190
+msgid "Recent Documents:"
+msgstr "Ostatnie dokumenty:"
+
+
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:194
+msgid "Recent Documents"
+msgstr "Ostatnie dokumenty"
+
+
+#. Translators: Button to browse for a document file instead of opening a recent one. Ctrl+O is the shortcut.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:211
+msgid "Open File..."
+msgstr "Otwórz plik..."
+
+
+#. Translators: Message announced when the recent documents list is empty.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:257
+msgid "No recent documents."
+msgstr "Brak ostatnich dokumentów."
+
+
+#. Translators: Message confirming clearing of all recent documents.
+#: addon\globalPlugins\visionAssistant\dialogs\history_dialog.py:292
+msgid "Clear all recent documents?"
+msgstr "Wyczyścić listę ostatnich dokumentów?"
+
+
 #. Translators: Title of the Live Assistant conversation window.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:47
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:43
 #, python-brace-format
 msgid "{name} - Live Assistant"
 msgstr "{name} - Asystent głosowy"
 
-#. Translators: Label for the conversation history area in the Live Assistant
-#. window.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:58
+#. Translators: Label for the conversation history area in the Live Assistant window.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:54
 msgid "Conversation:"
 msgstr "Rozmowa:"
 
 #. Translators: Label for TTS Voice selection in the Live Assistant window.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:64
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:63
 msgid "&TTS Voice:"
 msgstr "Głos &TTS:"
 
-#. Translators: Label for Thinking Depth selection in the Live Assistant
-#. window.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:82
+#. Translators: Label for Thinking Depth selection in the Live Assistant window.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:81
 msgid "Thinking &Depth:"
 msgstr "Głębia &myślenia:"
 
 #. Translators: Thinking level option for no reasoning (lowest latency)
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:86
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:85
 msgid "Minimal (Fastest)"
 msgstr "Minimalna (najszybsza)"
 
 #. Translators: Thinking level option for slight reasoning
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:88
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:87
 msgid "Low (Agentic)"
 msgstr "Niska (agentowa)"
 
 #. Translators: Thinking level option for standard reasoning (balanced)
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:90
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:89
 msgid "Medium (Balanced)"
 msgstr "Średnia (zrównoważona)"
 
 #. Translators: Thinking level option for deep reasoning
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:92
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:91
 msgid "High (Deep)"
 msgstr "Wysoka (głęboka)"
 
+#. Translators: Checkbox in the Live Assistant window to enable push-to-talk mode.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:107
+msgid "Push to &Talk"
+msgstr "Naciśnij i &mów"
+
+
 #. Translators: Button that ends the live voice conversation.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:108 addon\globalPlugins\visionAssistant\dialogs\media.py:165
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:118
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:194
 msgid "&End"
 msgstr "&Zakończ"
 
 #. Translators: Message shown in conversation log when voice is changed
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:128
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:138
 msgid "--- Changing voice, reconnecting... ---"
 msgstr "--- Zmiana głosu, ponowne łączenie... ---"
 
-#. Translators: Message shown in conversation log when thinking depth is
-#. changed
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:137
+#. Translators: Message shown in conversation log when thinking depth is changed
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:147
 msgid "--- Changing thinking depth, reconnecting... ---"
 msgstr "--- Zmiana głębi myślenia, ponowne łączenie... ---"
 
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:165
+#. Translators: Label showing the assigned push-to-talk key in the Live Assistant window. {key} is replaced with the key name.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:163
+#, python-brace-format
+msgid "Push to Talk Key: {key}"
+msgstr "Klawisz funkcji Naciśnij i mów: {key}"
+
+
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:194
 msgid "&Start"
 msgstr "&Rozpocznij"
 
 #. Translators: Title of the dubbing options dialog
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:187
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:216
 msgid "Dubbing Options"
 msgstr "Opcje dubbingu"
 
 #. Translators: Title of the translation options dialog
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:190
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:219
 msgid "Translation Options"
 msgstr "Opcje tłumaczenia"
 
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:197 addon\globalPlugins\visionAssistant\dialogs\settings.py:299
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:226
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:332
 msgid "Source:"
 msgstr "Źródłowy:"
 
 #. Translators: Title of the video analysis dialog
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:237
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:266
 #, python-brace-format
 msgid "{name} - Analyze Video"
 msgstr "{name} - Analiza wideo"
 
-#. Translators: Label instructing the user to enter a URL or browse for a
-#. local video
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:243
-msgid "Enter Video URL (YouTube, Instagram, Twitter, TikTok) or Browse for a local video:"
-msgstr "Wprowadź adres URL wideo (YouTube, Instagram, Twitter, TikTok) lub wskaż lokalny plik wideo:"
+#. Translators: Label instructing the user to enter a URL or browse for a local video
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:272
+msgid ""
+"Enter Video URL (YouTube, Instagram, Twitter, TikTok) or Browse for a local "
+"video:"
+msgstr ""
+"Wprowadź adres URL wideo (YouTube, Instagram, Twitter, TikTok) lub wskaż "
+"lokalny plik wideo:"
 
 #. Translators: Button to browse for a local video file
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:251
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:280
 msgid "&Browse..."
 msgstr "&Przeglądaj..."
 
 #. Translators: Option to generate an Audio Description SRT file.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:258 addon\globalPlugins\visionAssistant\features\video.py:86
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:287
+#: addon\globalPlugins\visionAssistant\features\video.py:86
 msgid "Generate Audio Description (SRT File)"
 msgstr "Generuj audiodeskrypcję (plik SRT)"
 
 #. Translators: Label for the video action radio box
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:262
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:291
 msgid "Action"
 msgstr "Akcja"
 
-#. Translators: Checkbox label to add character list as the first subtitle in
-#. video SRT output.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:272 addon\globalPlugins\visionAssistant\dialogs\settings.py:371
+#. Translators: Checkbox label to add character list as the first subtitle in video SRT output.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:301
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:404
 msgid "Add character list as first subtitle"
 msgstr "Dodaj listę postaci jako pierwszy napis"
 
-#. Translators: Checkbox label to add an AI warning disclaimer at the
-#. beginning of the video SRT output.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:278 addon\globalPlugins\visionAssistant\dialogs\settings.py:376
+#. Translators: Checkbox label to add an AI warning disclaimer at the beginning of the video SRT output.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:307
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:409
 msgid "Add AI disclaimer at the beginning"
 msgstr "Dodaj zastrzeżenie AI na początku"
 
 #. Translators: Filter for video files in the file dialog
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:291
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:320
 msgid "Video Files"
 msgstr "Pliki wideo"
 
 #. Translators: Title of the file dialog for selecting a video
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:293
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:322
 msgid "Select Local Video"
 msgstr "Wybierz lokalne wideo"
 
 #. Translators: Title of the progress dialog when generating SRT
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:308 addon\globalPlugins\visionAssistant\dialogs\media.py:810
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:337
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:840
 #, python-brace-format
 msgid "{name} - Generating Audio Description"
 msgstr "{name} - Generowanie audiodeskrypcji"
 
 #. Translators: Label for the status log text box
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:322
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:351
 msgid "Process Status / Subtitle Content:"
 msgstr "Stan procesu / treść napisów:"
 
 #. Translators: Label for selecting the Windows TTS voice
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:329
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:358
 msgid "Narration Voice:"
 msgstr "Głos narracji:"
 
 #. Translators: Label for selecting the eSpeak voice variant
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:339
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:368
 msgid "eSpeak Voice Variant:"
 msgstr "Wariant głosu eSpeak:"
 
 #. Translators: Button to download missing eSpeak-NG
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:352
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:381
 msgid "Download eSpeak-NG"
 msgstr "Pobierz eSpeak-NG"
 
 #. Translators: Label for selecting the Gemini Live TTS voice
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:366
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:395
 msgid "Gemini Voice:"
 msgstr "Głos Gemini:"
 
 #. Translators: Button to save the generated SRT file
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:386
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:415
 msgid "&Save SRT"
 msgstr "&Zapisz SRT"
 
 #. Translators: Button to generate a synced MP3 narration using offline TTS
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:391
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:420
 msgid "&Generate Synced Narration (MP3)"
 msgstr "&Generuj zsynchronizowaną narrację (MP3)"
 
 #. Translators: Button to regenerate the audio description
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:396
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:425
 msgid "&Regenerate"
 msgstr "&Generuj ponownie"
 
 #. Translators: Button to close the dialog
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:401
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:430
 msgid "&Close / Cancel"
 msgstr "&Zamknij / Anuluj"
 
 #. Translators: Status message when downloading eSpeak-NG
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:648
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:677
 msgid "Downloading eSpeak-NG, please wait..."
 msgstr "Pobieranie eSpeak-NG, proszę czekać..."
 
 #. Translators: Progress message during eSpeak-NG download
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:668
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:697
 #, python-brace-format
 msgid "Downloading eSpeak-NG: {percent}%"
 msgstr "Pobieranie eSpeak-NG: {percent}%"
 
 #. Translators: Status message when extracting eSpeak-NG
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:674
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:703
 msgid "Extracting eSpeak-NG..."
 msgstr "Wypakowywanie eSpeak-NG..."
 
 #. Translators: Success message after eSpeak-NG download completes
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:683
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:712
 msgid "eSpeak-NG downloaded successfully!"
 msgstr "Pobrano eSpeak-NG."
 
 #. Translators: Error message when eSpeak-NG download fails
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:690
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:719
 #, python-brace-format
 msgid "Failed to download eSpeak-NG: {error}"
 msgstr "Nie udało się pobrać eSpeak-NG: {error}"
 
-#. Translators: Option for eSpeak voice matching the user's current NVDA voice
-#. settings
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:710
+#. Translators: Option for eSpeak voice matching the user's current NVDA voice settings
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:739
 msgid "eSpeak (Current NVDA Language)"
 msgstr "eSpeak (bieżący język NVDA)"
 
-#. Translators: Option to use Gemini Live API for highly realistic text-to-
-#. speech
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:734
+#. Translators: Option to use Gemini Live API for highly realistic text-to-speech
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:763
 msgid "Gemini Live TTS (Online, High Quality)"
 msgstr "Gemini Live TTS (online, wysoka jakość)"
 
 #. Translators: Option for default English eSpeak voice
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:738
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:767
 msgid "eSpeak (English Default)"
 msgstr "eSpeak (domyślny angielski)"
 
 #. Translators: Title of the dialog when generation is successfully finished
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:783
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:813
 #, python-brace-format
 msgid "{name} - Audio Description Ready"
 msgstr "{name} — audiodeskrypcja gotowa"
 
 #. Translators: Success announcement when generation is complete
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:794
-msgid "Audio description generated successfully! You can read the subtitle content in the text box."
-msgstr "Audiodeskrypcja wygenerowana! Treść napisów możesz przeczytać w polu tekstowym."
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:824
+msgid ""
+"Audio description generated successfully! You can read the subtitle content "
+"in the text box."
+msgstr ""
+"Audiodeskrypcja wygenerowana! Treść napisów możesz przeczytać w polu "
+"tekstowym."
 
 #. Translators: Status message when an error occurs during SRT generation
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:800
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:830
 #, python-brace-format
 msgid "Error: {err}"
 msgstr "Błąd: {err}"
 
 #. Translators: Status message when restarting generation
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:819
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:849
 msgid "Re-initializing..."
 msgstr "Ponowna inicjalizacja..."
 
 #. Translators: File dialog title for saving the generated SRT file
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:836
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:866
 msgid "Save Audio Description"
 msgstr "Zapisz audiodeskrypcję"
 
 #. Translators: Success message when SRT file is saved
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:848
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:878
 msgid "SRT file saved successfully."
 msgstr "Zapisano plik SRT."
 
 #. Translators: Error when SRT parsing finds no valid subtitle blocks
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:909
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:939
 msgid "No valid subtitle blocks found in the SRT content."
 msgstr "Nie znaleziono prawidłowych bloków napisów w treści SRT."
 
 #. Translators: Error when no voice is selected
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:919
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:949
 msgid "Please select an offline voice from the list."
 msgstr "Wybierz głos offline z listy."
 
-#. Translators: Warning prompt for online videos indicating that the output
-#. will only contain narration.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:964
-msgid "Because the source is an online video, the final file will ONLY contain the AI voice narration (synced to the timestamps) and will NOT include the original background audio of the video. Do you want to proceed?"
-msgstr "Ponieważ źródłem jest wideo online, plik końcowy będzie zawierał WYŁĄCZNIE narrację głosem AI (zsynchronizowaną ze znacznikami czasu) i NIE będzie zawierał oryginalnego dźwięku tła wideo. Kontynuować?"
+#. Translators: Warning prompt for online videos indicating that the output will only contain narration.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:994
+msgid ""
+"Because the source is an online video, the final file will ONLY contain the "
+"AI voice narration (synced to the timestamps) and will NOT include the "
+"original background audio of the video. Do you want to proceed?"
+msgstr ""
+"Ponieważ źródłem jest wideo online, plik końcowy będzie zawierał WYŁĄCZNIE "
+"narrację głosem AI (zsynchronizowaną ze znacznikami czasu) i NIE będzie "
+"zawierał oryginalnego dźwięku tła wideo. Kontynuować?"
 
 #. Translators: Title of the warning dialog when opening an online video link.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:966
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:996
 msgid "Online Video Mode"
 msgstr "Tryb wideo online"
 
 #. Translators: Title of the narration mode selection dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:973
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1003
 msgid "Select Narration Mode"
 msgstr "Wybierz tryb narracji"
 
 #. Translators: Instruction prompt for narration mode selection.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:975
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1005
 msgid "Choose how the narration should be mixed with the video audio:"
 msgstr "Wybierz, jak narracja ma być zmiksowana z dźwiękiem wideo:"
 
-#. Translators: Option for mixing voice directly over the video without
-#. pausing.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:978
+#. Translators: Option for mixing voice directly over the video without pausing.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1008
 msgid "Standard AD (Mix voice directly over audio - No Pausing)"
 msgstr "Standardowa AD (miksuj głos wprost na dźwięku - bez pauz)"
 
-#. Translators: Option for pausing the background video audio during
-#. descriptions.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:980
+#. Translators: Option for pausing the background video audio during descriptions.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1010
 msgid "Extended AD (Pause background audio during descriptions)"
 msgstr "Rozszerzona AD (pauzuj dźwięk tła podczas opisów)"
 
-#. Translators: Prompt asking whether to lower the background video audio
-#. during the descriptions.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:996
-msgid "Do you want to fade/duck the background video audio during the descriptions?"
+#. Translators: Prompt asking whether to lower the background video audio during the descriptions.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1026
+msgid ""
+"Do you want to fade/duck the background video audio during the descriptions?"
 msgstr "Czy przyciszyć dźwięk tła wideo podczas opisów?"
 
 #. Translators: Title for the audio ducking prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:998
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1028
 msgid "Audio Ducking"
 msgstr "Przyciszanie dźwięku tła"
 
-#. Translators: Button label or menu item to save the generated AI audio
-#. narration synced to the video.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1010
+#. Translators: Button label or menu item to save the generated AI audio narration synced to the video.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1040
 msgid "Save Synced Narration"
 msgstr "Zapisz zsynchronizowaną narrację"
 
 #. Translators: Status message when narration generation starts
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1035
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1065
 msgid "Generating offline synced narration. This may take a few moments..."
-msgstr "Generowanie zsynchronizowanej narracji offline. Może to chwilę potrwać..."
+msgstr ""
+"Generowanie zsynchronizowanej narracji offline. Może to chwilę potrwać..."
 
-#. Translators: Status message shown when extracting the original video audio
-#. tracks.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1147
+#. Translators: Status message shown when extracting the original video audio tracks.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1177
 msgid "Extracting original video audio..."
 msgstr "Wyodrębnianie oryginalnego dźwięku wideo..."
 
-#. Translators: Error message shown when extraction of the video's original
-#. audio fails.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1165
+#. Translators: Error message shown when extraction of the video's original audio fails.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1195
 msgid "Failed to extract video audio."
 msgstr "Nie udało się wyodrębnić dźwięku wideo."
 
-#. Translators: Status message shown when analyzing the video's audio to
-#. detect periods of silence.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1174
+#. Translators: Status message shown when analyzing the video's audio to detect periods of silence.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1204
 msgid "Analyzing video for natural silences..."
 msgstr "Analiza wideo pod kątem naturalnych cisz..."
 
-#. Translators: Status message shown when starting connection to Gemini Live
-#. API
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1288
+#. Translators: Status message shown when starting connection to Gemini Live API
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1213
 msgid "Connecting to Gemini Live API..."
 msgstr "Łączenie z Gemini Live API..."
 
 #. Translators: Error message shown when connection to Gemini Live API fails
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1291
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1217
 msgid "Failed to connect to Gemini Live API."
 msgstr "Nie udało się połączyć z Gemini Live API."
 
-#. Translators: Progress message during narration generation. {current} is the
-#. current block number, {total} is total blocks.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1310
+#. Translators: Progress message during narration generation. {current} is the current block number, {total} is total blocks.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1236
 #, python-brace-format
 msgid "Generating narration: part {current} of {total}..."
 msgstr "Generowanie narracji: część {current} z {total}..."
 
 #. Translators: Status message when combining audio blocks
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1435
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1311
 msgid "Arranging audio track... Please wait."
 msgstr "Układanie ścieżki dźwiękowej... Proszę czekać."
 
-#. Translators: Status message when mixing generated narration with original
-#. video audio
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1492
+#. Translators: Status message when mixing generated narration with original video audio
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1368
 msgid "Mixing narration with original video audio..."
 msgstr "Miksowanie narracji z oryginalnym dźwiękiem wideo..."
 
-#. Translators: Status message when slicing and splicing the audio file with
-#. natural pauses.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1515
+#. Translators: Status message when slicing and splicing the audio file with natural pauses.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1391
 msgid "Splicing audio based on natural pauses..."
 msgstr "Sklejanie dźwięku na podstawie naturalnych pauz..."
 
-#. Translators: Status message shown when converting the final raw WAV mix to
-#. MP3 format.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1550
+#. Translators: Status message shown when converting the final raw WAV mix to MP3 format.
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1430
 msgid "Converting final audio to MP3..."
 msgstr "Konwersja końcowego dźwięku do MP3..."
 
 #. Translators: Message spoken on successful save of the synced narration.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1567
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1447
 msgid "Synced extended narration with silence detection saved successfully."
 msgstr "Zapisano zsynchronizowaną rozszerzoną narrację z wykrywaniem ciszy."
 
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1568
-msgid "Synced extended audio narration file generated successfully with smart silence matching."
-msgstr "Wygenerowano zsynchronizowany rozszerzony plik narracji dźwiękowej z dopasowaniem do naturalnych cisz."
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1448
+msgid ""
+"Synced extended audio narration file generated successfully with smart "
+"silence matching."
+msgstr ""
+"Wygenerowano zsynchronizowany rozszerzony plik narracji dźwiękowej z "
+"dopasowaniem do naturalnych cisz."
 
 #. Translators: Error message shown when the final MP3 conversion fails.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1571
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1451
 msgid "Failed to generate the final MP3 file."
 msgstr "Nie udało się wygenerować końcowego pliku MP3."
 
 #. Translators: Error message shown when narration generation fails.
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1576
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1456
 #, python-brace-format
 msgid "Narration Error: {error}"
 msgstr "Błąd narracji: {error}"
 
 #. Translators: Message announced when user cancels the process
-#: addon\globalPlugins\visionAssistant\dialogs\media.py:1601
+#: addon\globalPlugins\visionAssistant\dialogs\media.py:1480
 msgid "Process cancelled."
 msgstr "Proces anulowany."
 
 #. Translators: Label for prompt name input field.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:22
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:31
 msgid "Name:"
 msgstr "Nazwa:"
 
+#. Translators: Label for the optional shortcut key assigned to this custom prompt, instructing the user to press the keys to record it.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:37
+msgid ""
+"Shortcut Key (optional): press the keys to record, for example Ctrl+Shift+1"
+msgstr ""
+"Skrót klawiszowy (opcjonalnie): naciśnij klawisze, aby je zapisać, na przykład Ctrl+Shift+1"
+
+
 #. Translators: Label for prompt text input field.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:28 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:186
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:46
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:296
 msgid "Prompt Text:"
 msgstr "Treść Promptu:"
 
 #. Translators: Button label to open the variables help dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:47 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:141
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:65
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:251
 msgid "Variables Guide"
 msgstr "Przewodnik po zmiennych"
 
 #. Translators: Validation error for empty prompt name.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:64
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:83
 msgid "Name cannot be empty."
 msgstr "Nazwa nie może być pusta."
 
 #. Translators: Title of validation warning dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:66 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:73 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:355 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:465
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:491
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:85
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:94
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:101
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:108
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:465
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:601
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:606
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:633
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:638
 msgid "Validation Error"
 msgstr "Błąd walidacji"
 
+#. Translators: Validation error for an invalid shortcut key.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:93
+msgid ""
+"Shortcut key must be a key or key combination, for example: 1, p, alt+1, "
+"control+shift+p, insert+1, or f3."
+msgstr ""
+"Skrót musi być klawiszem lub kombinacją klawiszy, na przykład: 1, p, alt+1, control+shift+p, insert+1 albo f3."
+
+
+#. Translators: Validation error when the chosen shortcut key is already used by another command in the command layer.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:100
+msgid ""
+"This key is already used by another command in the command layer "
+"(NVDA+Shift+V). Please choose a different key."
+msgstr ""
+"Ten klawisz jest już używany przez inne polecenie w warstwie poleceń (NVDA+Shift+V). Wybierz inny klawisz."
+
+
 #. Translators: Validation error for empty prompt text.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:72 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:354
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:107
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:464
 msgid "Prompt text cannot be empty."
 msgstr "Treść polecenia nie może być pusta."
 
 #. Translators: Title for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:94
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:200
 msgid "Prompt Variables Guide"
 msgstr "Przewodnik po zmiennych poleceń"
 
 #. Translators: Intro text for the prompt variables help dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:98
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:204
 msgid "Use these variables inside prompt text:"
 msgstr "Użyj tych zmiennych wewnątrz treści polecenia:"
 
 #. Translators: Title for the prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:120
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:226
 msgid "Prompt Manager"
 msgstr "Menedżer poleceń"
 
 #. Translators: Notebook tab for built-in refine prompts.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:132 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:164
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:242
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:274
 msgid "Default Prompts"
 msgstr "Polecenia domyślne"
 
 #. Translators: Notebook tab for user-defined prompts.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:134 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:217
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:244
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:327
 msgid "Custom Prompts"
 msgstr "Polecenia niestandardowe"
 
 #. Translators: Note explaining when prompt changes are persisted.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:145
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:255
 msgid "Changes are applied only when you press OK."
 msgstr "Zmiany zostaną zastosowane dopiero po naciśnięciu OK."
 
 #. Translators: Button label to reset currently selected default prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:176
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:286
 msgid "Reset Selected"
 msgstr "Resetuj wybrane"
 
 #. Translators: Button label to reset all default prompts.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:181
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:291
 msgid "Reset All"
 msgstr "Resetuj wszystkie"
 
-#. Translators: Button label to apply current editor text to the selected
-#. default prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:195
+#. Translators: Button label to apply current editor text to the selected default prompt.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:305
 msgid "Apply to Selected"
 msgstr "Zastosuj do wybranego"
 
 #. Translators: Button label for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:226
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:336
 msgid "Add"
 msgstr "Dodaj"
 
 #. Translators: Button label for editing a custom prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:228
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:338
 msgid "Edit"
 msgstr "Edytuj"
 
 #. Translators: Button label for removing a custom prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:230
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:340
 msgid "Remove"
 msgstr "Usuń"
 
 #. Translators: Button label for moving selected custom prompt up in the list.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:241
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:351
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
-#. Translators: Button label for moving selected custom prompt down in the
-#. list.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:243
+#. Translators: Button label for moving selected custom prompt down in the list.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:353
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
 #. Translators: Label above the custom prompt preview area.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:252
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:362
 msgid "Prompt Preview:"
 msgstr "Podgląd polecenia:"
 
-#. Translators: Validation message shown when required text is missing in a
-#. guarded prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:314
+#. Translators: Validation message shown when required text is missing in a guarded prompt.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:424
 #, python-brace-format
-msgid "This prompt is used by {feature}. To save it, add the required text below:"
-msgstr "Ten prompt jest używany przez funkcję {feature}. Aby go zapisać, dodaj wymagany tekst poniżej:"
+msgid ""
+"This prompt is used by {feature}. To save it, add the required text below:"
+msgstr ""
+"Ten prompt jest używany przez funkcję {feature}. Aby go zapisać, dodaj "
+"wymagany tekst poniżej:"
 
 #. Translators: Guidance shown after listing missing required text.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:320
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:430
 msgid "Add these items exactly as written, then try again."
-msgstr "Dodaj te elementy dokładnie tak, jak podano, a następnie spróbuj ponownie."
+msgstr ""
+"Dodaj te elementy dokładnie tak, jak podano, a następnie spróbuj ponownie."
 
 #. Translators: Title of validation warning dialog for guarded prompt checks.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:322
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:432
 msgid "Required Text Missing"
 msgstr "Brak wymaganego tekstu"
 
 #. Translators: Confirmation message shown before saving a guarded prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:333
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:443
 #, python-brace-format
 msgid ""
 "You are editing a prompt used by {feature}.\n"
@@ -2359,516 +2714,648 @@ msgstr ""
 "\n"
 "Czy rozumiesz ryzyko i mimo to chcesz zapisać?"
 
-#. Translators: Title of confirmation dialog shown before saving guarded
-#. prompts.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:336
+#. Translators: Title of confirmation dialog shown before saving guarded prompts.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:446
 msgid "Confirm"
 msgstr "Potwierdź"
 
 #. Translators: Confirm button label for guarded prompt save confirmation.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:340
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:450
 msgid "Yes, Save Anyway"
 msgstr "Tak, zapisz mimo to"
 
 #. Translators: Cancel button label for guarded prompt save confirmation.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:342
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:452
 msgid "No, Go Back"
 msgstr "Nie, wróć"
 
-#. Translators: Message shown after applying changes to the selected default
-#. prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:389
+#. Translators: Message shown after applying changes to the selected default prompt.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:499
 msgid "Selected prompt updated."
 msgstr "Wybrane polecenie zaktualizowane."
 
 #. Translators: Confirmation text before resetting all default prompts.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:402
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:512
 msgid "Reset all default prompts to built-in values?"
 msgstr "Przywrócić wszystkie domyślne polecenia do wartości domyślnych?"
 
 #. Translators: Title of confirmation dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:404
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:514
 msgid "Confirm Reset"
 msgstr "Potwierdź reset"
 
 #. Translators: Title of dialog for adding a custom prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:459
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:595
 msgid "Add Custom Prompt"
 msgstr "Dodaj polecenie niestandardowe"
 
 #. Translators: Validation error for duplicate custom prompt name.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:464 addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:490
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:600
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:632
 msgid "A custom prompt with this name already exists."
 msgstr "Polecenie niestandardowe o tej nazwie już istnieje."
 
+#. Translators: Validation error when another custom prompt already uses the chosen shortcut key.
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:605
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:637
+msgid "Another custom prompt already uses this shortcut key."
+msgstr "Inne polecenie niestandardowe używa już tego skrótu klawiszowego."
+
+
 #. Translators: Title of the dialog for editing an existing custom prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:482
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:623
 msgid "Edit Custom Prompt"
 msgstr "Edytuj polecenie niestandardowe"
 
 #. Translators: Confirmation text before deleting a custom prompt.
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:504
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:651
 #, python-brace-format
 msgid "Remove custom prompt '{name}'?"
 msgstr "Usunąć polecenie niestandardowe \"{name}\"?"
 
-#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:505
+#: addon\globalPlugins\visionAssistant\dialogs\prompt_manager_dialog.py:652
 msgid "Confirm Remove"
 msgstr "Potwierdź usunięcie"
 
 #. --- Connection Group ---
 #. Translators: Title of the settings group for connection and updates
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:43
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:52
 msgid "Connection"
 msgstr "Połączenie"
 
 #. Translators: Name of the Google Gemini AI provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:50
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:59
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
 #. Translators: Name of the OpenAI provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:52
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:61
 msgid "OpenAI"
 msgstr "OpenAI"
 
 #. Translators: Name of the Mistral AI provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:54
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:63
 msgid "Mistral AI"
 msgstr "Mistral AI"
 
 #. Translators: Name of the Groq AI provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:56
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:65
 msgid "Groq"
 msgstr "Groq"
 
 #. Translators: Name of the MiniMax AI provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:58
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:67
 msgid "MiniMax"
 msgstr "MiniMax"
 
 #. Translators: Option for a user-defined custom AI provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:60
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:69
 msgid "Custom"
 msgstr "Niestandardowy"
 
 #. Translators: Label for AI Provider selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:63
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:72
 msgid "Provider:"
 msgstr "Dostawca:"
 
 #. Translators: Label for API Key input
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:71
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:80
 msgid "API Key (Separate multiple keys with comma or newline):"
 msgstr "Klucz API (rozdziel wiele kluczy przecinkiem lub nową linią):"
 
 #. Translators: Checkbox to toggle API Key visibility
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:82
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:91
 msgid "Show API Key"
 msgstr "Pokaż klucz API"
 
 #. Custom Fields Box
 #. Translators: Static box title for custom AI provider settings
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:88
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:97
 msgid "Custom Provider Settings"
 msgstr "Ustawienia niestandardowego dostawcy"
 
-#. Translators: Button label to automatically configure local AI engines
-#. (Ollama, LM Studio, etc.)
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:91 addon\globalPlugins\visionAssistant\dialogs\settings.py:738
+#. Translators: Button label to automatically configure local AI engines (Ollama, LM Studio, etc.)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:100
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:808
 msgid "Setup Local AI"
 msgstr "Konfiguracja lokalnej AI"
 
 #. Translators: Label for Custom API URL input
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:96
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:105
 msgid "API URL:"
 msgstr "Adres URL API:"
 
 #. Translators: Label for Custom API Type selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:101
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:110
 msgid "API Type:"
 msgstr "Typ API:"
 
 #. Translators: AI API compatibility types
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:103
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:112
 msgid "OpenAI Compatible"
 msgstr "Zgodny z OpenAI"
 
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:103
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:112
 msgid "Gemini Compatible"
 msgstr "Zgodny z Gemini"
 
 #. Translators: Label for Custom Model Name input
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:109
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:118
 msgid "Model Name (Manual):"
 msgstr "Nazwa modelu (ręcznie):"
 
 #. Translators: Checkbox to indicate if custom provider supports file upload
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:115
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:124
 msgid "Supports File Upload"
 msgstr "Obsługuje przesyłanie plików"
 
 #. Advanced Endpoints Section
 #. Translators: Checkbox to toggle advanced endpoint URLs
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:122
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:131
 msgid "Advanced Endpoint Configuration"
 msgstr "Adresy usług"
 
 #. Translators: Label for Custom Models List URL
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:131
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:140
 msgid "Models List URL:"
 msgstr "URL listy modeli:"
 
 #. Translators: Label for Custom OCR URL
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:136
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:145
 msgid "OCR Endpoint URL:"
 msgstr "URL punktu końcowego OCR:"
 
 #. Translators: Label for Custom OCR Model
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:141
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:150
 msgid "Custom OCR Model (Optional):"
 msgstr "Niestandardowy model OCR (opcjonalnie):"
 
 #. Translators: Label for Custom STT URL
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:147
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:156
 msgid "Speech-to-Text (STT) URL:"
 msgstr "URL rozpoznawania mowy (STT):"
 
 #. Translators: Label for Custom STT Model
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:152
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:161
 msgid "Custom STT Model (Optional):"
 msgstr "Niestandardowy model STT (opcjonalnie):"
 
 #. Translators: Label for Custom TTS URL
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:158
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:167
 msgid "Text-to-Speech (TTS) URL:"
 msgstr "URL syntezy mowy (TTS):"
 
 #. Translators: Label for Custom TTS Model
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:163
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:172
 msgid "Custom TTS Model (Optional):"
 msgstr "Niestandardowy model TTS (opcjonalnie):"
 
-#. Translators: Label for a text field in the "Custom Provider Settings"
-#. section of settings where the user enters the AI Operator URL.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:169
+#. Translators: Label for a text field in the "Custom Provider Settings" section of settings where the user enters the AI Operator URL.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:178
 msgid "AI Operator URL:"
 msgstr "URL Operatora AI:"
 
-#. Translators: Label for a text field in the "Custom Provider Settings"
-#. section of settings where the user manually enters the model name for AI
-#. Operator.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:174
+#. Translators: Label for a text field in the "Custom Provider Settings" section of settings where the user manually enters the model name for AI Operator.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:183
 msgid "Custom Operator Model (Optional):"
 msgstr "Niestandardowy model Operatora (opcjonalne):"
 
 #. Translators: Label for Custom TTS Voice Name
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:180
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:189
 msgid "Custom TTS Voice Name (Optional):"
 msgstr "Niestandardowa nazwa głosu TTS (opcjonalnie):"
 
 #. Standard Fetch & Model Logic
 #. Translators: Button to fetch available models from the selected provider
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:191
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:200
 msgid "Fetch Models"
 msgstr "Pobierz modele"
 
 #. Translators: Label for AI Model selection choice box
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:195 addon\globalPlugins\visionAssistant\dialogs\settings.py:198
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:204
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:207
 msgid "AI Model:"
 msgstr "Model AI:"
 
 #. Advanced Model Routing Box
 #. Translators: Checkbox to toggle advanced model routing
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:204
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:213
 msgid "Advanced Model Routing (Task-specific)"
 msgstr "Osobny model dla każdego zadania"
 
 #. Translators: Label for OCR model selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:211
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:220
 msgid "OCR / Vision Model:"
 msgstr "Model dla OCR / rozpoznawania obrazów:"
 
 #. Translators: Label for STT model selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:218
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:227
 msgid "Speech-to-Text (STT) Model:"
 msgstr "Model rozpoznawania mowy (STT):"
 
-#. Translators: Label for TTS model selection (Assigning to self to toggle
-#. visibility)
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:225
+#. Translators: Label for TTS model selection (Assigning to self to toggle visibility)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:234
 msgid "Text-to-Speech (TTS) Model:"
 msgstr "Model syntezy mowy (TTS):"
 
-#. Translators: Label for a dropdown menu in the "Advanced Model Routing"
-#. section of settings to choose a specific model for AI Operator tasks.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:232
+#. Translators: Label for a dropdown menu in the "Advanced Model Routing" section of settings to choose a specific model for AI Operator tasks.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:241
 msgid "AI Operator / CAPTCHA Model:"
 msgstr "Model Operatora AI i CAPTCHA:"
 
-#. Translators: Label for the Video Analysis model selection in the Advanced
-#. Model Routing section.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:238
+#. Translators: Label for the Video Analysis model selection in the Advanced Model Routing section.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:247
 msgid "Video Analysis Model (Gemini only):"
 msgstr "Model analizy wideo (tylko Gemini):"
 
-#. Translators: Label for the Live Assistant model selection in the Advanced
-#. Model Routing section (Gemini only).
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:245
+#. Translators: Label for the Live Assistant model selection in the Advanced Model Routing section (Gemini only).
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:254
 msgid "Live Assistant Model (Gemini only):"
 msgstr "Model asystenta głosowego (tylko Gemini):"
 
 #. Translators: Label for Proxy URL input
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:255
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:264
 msgid "Proxy URL:"
 msgstr "Adres URL serwera proxy:"
 
 #. Translators: Checkbox to enable/disable automatic update checks on startup
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:259
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:268
 msgid "Check for updates on startup"
 msgstr "Sprawdzaj aktualizacje przy uruchomieniu"
 
 #. Translators: Checkbox to toggle markdown cleaning in chat windows
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:262
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:271
 msgid "Clean Markdown in Chat"
 msgstr "Czyść Markdown w czacie"
 
 #. Translators: Checkbox to enable copying AI responses to clipboard
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:265
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:274
 msgid "Copy AI responses to clipboard"
 msgstr "Kopiuj odpowiedzi AI do schowka"
 
 #. Translators: Checkbox to skip chat window and only speak AI responses
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:268
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:277
 msgid "Direct Output (No Chat Window)"
 msgstr "Tryb bezpośredni (nie pokazuje okna czatu)"
 
-#. Translators: Checkbox to start the Live Assistant without its conversation
-#. window (open it later with the Show Last Result key).
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:271
+#. Translators: Checkbox to start the Live Assistant without its conversation window (open it later with the Show Last Result key).
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:290
 msgid "Live Assistant: Direct Output (No Window)"
 msgstr "Asystent głosowy: tryb bezpośredni (bez okna)"
 
+#. Translators: Checkbox to enable push-to-talk mode for the Live Assistant.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:294
+msgid "Push to Talk"
+msgstr "Naciśnij i mów"
+
+
+#. Translators: Label for the push-to-talk key field, instructing the user to press the keys to record it.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:299
+msgid ""
+"Push to Talk Key (press the keys to record, for example F12 or Ctrl+F12):"
+msgstr ""
+"Klawisz funkcji Naciśnij i mów (naciśnij klawisze, aby je zapisać, na przykład F12 lub Ctrl+F12):"
+
+
 #. --- AI Behavior Group ---
 #. Translators: Title of the settings group for AI behavior
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:278 addon\globalPlugins\visionAssistant\dialogs\settings.py:680
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:311
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:738
 msgid "AI Behavior"
 msgstr "Zachowanie AI"
 
 #. Translators: Label for AI Temperature setting
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:283
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:316
 msgid "Creativity (Temperature, does not affect OCR/Translation):"
 msgstr "Kreatywność (temperatura, nie wpływa na OCR/tłumaczenie):"
 
 #. --- Translation Languages Group ---
-#. Translators: Title of the settings group for translation languages
-#. configuration
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:295
+#. Translators: Title of the settings group for translation languages configuration
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:328
 msgid "Translation Languages"
 msgstr "Języki tłumaczenia"
 
 #. Translators: Checkbox for Smart Swap feature
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:314
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:347
 msgid "Smart Swap"
 msgstr "Zamiana"
 
 #. Translators: Label for OCR Engine selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:326
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:359
 msgid "OCR Engine:"
 msgstr "Silnik OCR:"
 
-#. Translators: Label for the OCR batch size setting. Set to 0 to process all
-#. pages in a single request.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:334
+#. Translators: Label for the OCR batch size setting. Set to 0 to process all pages in a single request.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:367
 msgid "OCR Batch Size (Pages per request, 0 to disable):"
 msgstr "Porcja OCR (stron na żądanie, 0 = wyłączone):"
 
-#. Translators: Label for the checkbox that enables image descriptions during
-#. OCR
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:340
+#. Translators: Label for the checkbox that enables image descriptions during OCR
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:373
 msgid "Describe images inline during document OCR"
 msgstr "Wplataj opisy obrazów w tekst podczas OCR dokumentu"
 
-#. Translators: Label for the checkbox that enables page numbers when
-#. exporting documents
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:345
+#. Translators: Label for the checkbox that enables page numbers when exporting documents
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:378
 msgid "Include page numbers when exporting documents"
 msgstr "Dołączaj numery stron przy eksporcie dokumentów"
 
-#. Translators: Label for Video Chunk Size setting. Explains the trade-off
-#. between chunk size, API requests, and description quality.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:365
+#. Translators: Label for Video Chunk Size setting. Explains the trade-off between chunk size, API requests, and description quality.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:398
 msgid ""
 "Video Chunk Size for Audio Description (Minutes, 0 to disable):\n"
-"Tip: Higher values use fewer API requests but rely on luck to succeed. Lower values guarantee highly detailed and precise descriptions."
+"Tip: Higher values use fewer API requests but rely on luck to succeed. Lower "
+"values guarantee highly detailed and precise descriptions."
 msgstr ""
 "Rozmiar fragmentu wideo dla audiodeskrypcji (minuty, 0 wyłącza):\n"
-"Wskazówka: wyższe wartości zużywają mniej zapytań API, ale ich powodzenie zależy od szczęścia. Niższe wartości gwarantują bardzo szczegółowe i precyzyjne opisy."
+"Wskazówka: wyższe wartości zużywają mniej zapytań API, ale ich powodzenie "
+"zależy od szczęścia. Niższe wartości gwarantują bardzo szczegółowe i "
+"precyzyjne opisy."
 
-#. Translators: Label for the checkbox that enables or disables the automated
-#. CAPTCHA solver feature.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:389
+#. Translators: Label for the checkbox that enables or disables the automated CAPTCHA solver feature.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:422
 msgid "Enable Visual CAPTCHA Solver"
 msgstr "Włącz rozwiązywanie CAPTCHA obrazkowej"
 
 #. Translators: Label for CAPTCHA capture method selection.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:393
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:426
 msgid "Text CAPTCHA Method:"
 msgstr "Metoda dla CAPTCHA tekstowej:"
 
-#. Translators: A choice for capture method. Captures only the specific object
-#. under the cursor.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:395 addon\globalPlugins\visionAssistant\features\quick_settings.py:51
+#. Translators: A choice for capture method. Captures only the specific object under the cursor.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:428
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:44
 msgid "Navigator Object"
 msgstr "Obiekt nawigatora"
 
-#. Translators: A choice for capture method. Captures the entire visible
-#. screen area.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:397 addon\globalPlugins\visionAssistant\features\quick_settings.py:51
+#. Translators: A choice for capture method. Captures the entire visible screen area.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:430
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:44
 msgid "Full Screen"
 msgstr "Cały ekran"
 
 #. --- Prompts Group ---
 #. Translators: Title of the settings group for prompt management.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:409
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:442
 msgid "Prompts"
 msgstr "Polecenia"
 
 #. Translators: Description for the prompt manager button.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:414
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:447
 msgid "Manage default and custom prompts."
 msgstr "Zarządzaj domyślnymi i niestandardowymi poleceniami."
 
 #. Translators: Button label to open prompt manager dialog.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:416
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:449
 msgid "Manage Prompts..."
 msgstr "Zarządzaj poleceniami..."
 
+#. Translators: Group box title for log management settings
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:466
+msgid "Log Management"
+msgstr "Zarządzanie dziennikiem"
+
 #. Translators: Checkbox label to enable dedicated add-on logging to file
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:433
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:471
 msgid "Enable dedicated log file"
 msgstr "Włącz osobny plik dziennika"
 
-#. Translators: Log level choice: Debug (Logs all detailed technical events,
-#. API calls, and raw responses)
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:438
+#. Translators: Log level choice: Debug (Logs all detailed technical events, API calls, and raw responses)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:476
 msgid "Debug (All Details)"
 msgstr "Diagnostyka (wszystkie szczegóły)"
 
-#. Translators: Log level choice: Info (Logs general operational events and
-#. task completions)
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:440
+#. Translators: Log level choice: Info (Logs general operational events and task completions)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:478
 msgid "Info (General Information)"
 msgstr "Informacje (ogólne)"
 
-#. Translators: Log level choice: Warning (Logs warnings and non-fatal
-#. retries)
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:442
+#. Translators: Log level choice: Warning (Logs warnings and non-fatal retries)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:480
 msgid "Warning (Warnings Only)"
 msgstr "Ostrzeżenia (tylko ostrzeżenia)"
 
-#. Translators: Log level choice: Error (Logs errors and critical exceptions
-#. only)
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:444
+#. Translators: Log level choice: Error (Logs errors and critical exceptions only)
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:482
 msgid "Error (Errors Only)"
 msgstr "Błędy (tylko błędy)"
 
 #. Translators: Label for Log Level selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:447
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:485
 msgid "Log Level:"
 msgstr "Poziom szczegółowości dziennika:"
 
 #. Translators: Label for Log Retention Duration selection
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:457
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:495
 msgid "Keep Logs For:"
 msgstr "Przechowuj dziennik przez:"
 
-#. Log management buttons
-#. Translators: Group box title for log management buttons
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:467
-msgid "Log Management"
-msgstr "Zarządzanie dziennikiem"
-
 #. Translators: Button to open log file
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:471
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:507
 msgid "Open Log File"
 msgstr "Otwórz plik dziennika"
 
 #. Translators: Button to open log folder
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:476
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:512
 msgid "Open Log Folder"
 msgstr "Otwórz folder dziennika"
 
 #. Translators: Button to clear log file
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:481
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:517
 msgid "Clear Log File"
 msgstr "Wyczyść plik dziennika"
 
+#. Translators: Group box title for the settings backup and restore buttons
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:526
+msgid "Backup and Restore"
+msgstr "Kopia zapasowa i przywracanie"
+
+
+#. Translators: Button to save add-on settings and data to a backup file
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:530
+msgid "Backup..."
+msgstr "Kopia zapasowa..."
+
+
+#. Translators: Button to restore add-on settings and data from a backup file
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:535
+msgid "Restore..."
+msgstr "Przywróć..."
+
+
 #. Translators: Summary text for prompt counts in settings.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:543
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:597
 #, python-brace-format
 msgid "Default prompts: {defaultCount}, Custom prompts: {customCount}"
 msgstr "Polecenia domyślne: {defaultCount}, niestandardowe: {customCount}"
 
 #. Translators: Prompt message to select local AI engine
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:740
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:810
 msgid "Select the local AI engine you are running:"
 msgstr "Wybierz uruchomiony silnik lokalnej AI:"
 
 #. Translators: Progress message shown when testing connection to local AI
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:761
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:831
 msgid "Connecting to Local AI..."
 msgstr "Łączenie z lokalną AI..."
 
 #. Translators: Error message when connection to local AI fails
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:792
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:862
 #, python-brace-format
-msgid "Could not connect to the selected local AI. Make sure it is running on {url}"
-msgstr "Nie udało się połączyć z wybraną lokalną AI. Upewnij się, że działa pod adresem {url}"
+msgid ""
+"Could not connect to the selected local AI. Make sure it is running on {url}"
+msgstr ""
+"Nie udało się połączyć z wybraną lokalną AI. Upewnij się, że działa pod "
+"adresem {url}"
 
 #. Translators: Announcement message when local AI setup succeeds
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:805
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:875
 msgid "Local AI configured successfully!"
 msgstr "Lokalna AI skonfigurowana pomyślnie!"
 
-#. Translators: Progress message shown while fetching AI models from the
-#. server
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:827
+#. Translators: Progress message shown while fetching AI models from the server
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:897
 msgid "Fetching models..."
 msgstr "Pobieranie modeli..."
 
-#. Translators: Option to follow the main model selected in the primary
-#. dropdown
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:847 addon\globalPlugins\visionAssistant\dialogs\settings.py:911
+#. Translators: Option to follow the main model selected in the primary dropdown
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:941
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:995
 msgid "Default (Main Model)"
 msgstr "Domyślny (model główny)"
 
-#. Translators: Option for the system to automatically choose the best model
-#. for this specific task
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:849 addon\globalPlugins\visionAssistant\dialogs\settings.py:912
+#. Translators: Option for the system to automatically choose the best model for this specific task
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:943
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:996
 msgid "Auto (Optimized)"
 msgstr "Auto (zoptymalizowane)"
 
-#. Translators: Status message when the AI models list is successfully
-#. refreshed.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:897
+#. Translators: Status message when the AI models list is successfully refreshed.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:981
 msgid "Models updated"
 msgstr "Modele zaktualizowane"
 
-#. Translators: Error message shown when the add-on cannot retrieve the list
-#. of models from the server.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:900
+#. Translators: Error message shown when the add-on cannot retrieve the list of models from the server.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:984
 msgid "Failed to fetch models"
 msgstr "Pobieranie modeli nie powiodło się"
 
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1220
+msgid ""
+"You have not assigned a Push to Talk key. Please press a key in the Push to "
+"Talk Key field, or disable Push to Talk."
+msgstr ""
+"Nie przypisano klawisza funkcji Naciśnij i mów. Naciśnij klawisz w polu klawisza tej funkcji albo ją wyłącz."
+
+
+#. Translators: Title of the warning dialog about the missing push-to-talk key.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1222
+msgid "Push to Talk Key"
+msgstr "Klawisz funkcji Naciśnij i mów"
+
+
 #. Translators: Message reported when log file is cleared.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1163
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1370
 msgid "Log file cleared."
 msgstr "Wyczyszczono plik dziennika."
 
-#. Translators: Notification showing the number of items found after filtering
-#. the model list.
-#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1211
+#. Translators: Title of the save file dialog for the add-on backup
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1382
+msgid "Save Backup"
+msgstr "Zapisz kopię zapasową"
+
+
+#. Translators: Options for what to include in the settings backup.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1395
+msgid "Everything (Settings, Labels, OCR Progress, History)"
+msgstr "Wszystko (ustawienia, etykiety, postęp OCR, historia)"
+
+
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1395
+msgid "Settings Only"
+msgstr "Tylko ustawienia"
+
+
+#. Translators: Message of the backup scope dialog asking what to include.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1399
+msgid "What would you like to back up?"
+msgstr "Co ma znaleźć się w kopii zapasowej?"
+
+
+#. Translators: Title of the backup scope dialog.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1401
+msgid "Backup Options"
+msgstr "Opcje kopii zapasowej"
+
+
+#. Translators: Message announced after a successful backup.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1434
+msgid "Backup saved."
+msgstr "Kopia zapasowa została zapisana."
+
+
+#. Translators: Error message when the settings backup fails.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1440
+#, python-brace-format
+msgid "Backup failed: {error}"
+msgstr "Tworzenie kopii zapasowej nie powiodło się: {error}"
+
+
+#. Translators: Title of the open file dialog for restoring a backup.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1450
+msgid "Choose a Backup File"
+msgstr "Wybierz plik kopii zapasowej"
+
+
+#. Translators: Error message when the chosen backup file cannot be read.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1462
+#, python-brace-format
+msgid "Could not read the backup file: {error}"
+msgstr "Nie udało się odczytać pliku kopii zapasowej: {error}"
+
+
+#. Translators: Error message when the chosen file is not a valid settings backup.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1466
+msgid "This file is not a valid Vision Assistant settings backup."
+msgstr "Ten plik nie jest prawidłową kopią zapasową ustawień Vision Assistant."
+
+
+#. Translators: Confirmation prompt shown before restoring a full backup, because it replaces all current settings and data.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1471
+msgid ""
+"Restoring will replace all current settings and data (labels, OCR progress, "
+"and history). Do you want to continue?"
+msgstr ""
+"Przywracanie zastąpi wszystkie bieżące ustawienia i dane (etykiety, postęp OCR oraz historię). Czy chcesz kontynuować?"
+
+
+#. Translators: Confirmation prompt shown before restoring, because it replaces all current settings.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1474
+msgid "Restoring will replace all current settings. Do you want to continue?"
+msgstr "Przywracanie zastąpi wszystkie bieżące ustawienia. Czy chcesz kontynuować?"
+
+
+#. Translators: Title of the confirmation dialog for restoring settings.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1478
+msgid "Restore Settings"
+msgstr "Przywróć ustawienia"
+
+
+#. Translators: Error message when applying the restored settings fails.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1491
+#, python-brace-format
+msgid "Restore failed: {error}"
+msgstr "Przywracanie nie powiodło się: {error}"
+
+
+#. Translators: Message announced after a successful restore.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1520
+msgid "Backup restored successfully."
+msgstr "Kopia zapasowa została przywrócona."
+
+
+#. Translators: Notification showing the number of items found after filtering the model list.
+#: addon\globalPlugins\visionAssistant\dialogs\settings.py:1652
 #, python-brace-format
 msgid "{count} items found"
 msgstr "Pozycje: {count}"
@@ -2969,8 +3456,15 @@ msgstr "&Dodaj etykietę"
 msgid "Could not find object at coordinates."
 msgstr "Nie znaleziono obiektu w tym miejscu."
 
-#. Translators: Error message shown when a unique signature cannot be created
-#. for a screen object.
+#. Translators: Message shown when a user tries to use AI labeling in a web browser.
+#: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:268
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:461
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:528
+msgid "AI Labeling is currently not supported in web browsers."
+msgstr ""
+"Etykietowanie AI nie jest obecnie obsługiwane w przeglądarkach internetowych."
+
+#. Translators: Error message shown when a unique signature cannot be created for a screen object.
 #: addon\globalPlugins\visionAssistant\dialogs\ui_elements.py:273
 msgid "Could not generate signature for this object."
 msgstr "Nie udało się utworzyć sygnatury tego obiektu."
@@ -2981,143 +3475,151 @@ msgstr "Nie udało się utworzyć sygnatury tego obiektu."
 msgid "Label added successfully: {name}"
 msgstr "Dodano etykietę: {name}"
 
-#. Translators: Message in an error dialog which can pop up while trying
-#. dictation.
-#. Translators: Message reported when dictation starts
-#: addon\globalPlugins\visionAssistant\features\audio.py:51 addon\globalPlugins\visionAssistant\features\audio.py:60 addon\globalPlugins\visionAssistant\features\audio.py:67 addon\globalPlugins\visionAssistant\features\audio.py:153 addon\globalPlugins\visionAssistant\features\audio.py:161
-#: addon\globalPlugins\visionAssistant\features\audio.py:168
+#. Translators: Message in an error dialog which can pop up while trying dictation.
+#: addon\globalPlugins\visionAssistant\features\audio.py:61
+#: addon\globalPlugins\visionAssistant\features\audio.py:69
+#: addon\globalPlugins\visionAssistant\features\audio.py:77
 #, python-brace-format
 msgid "Audio Hardware Error: {error}"
 msgstr "Błąd sprzętu audio: {error}"
 
-#: addon\globalPlugins\visionAssistant\features\audio.py:64 addon\globalPlugins\visionAssistant\features\audio.py:165
+#. Translators: Message reported when dictation or voice translation recording starts.
+#: addon\globalPlugins\visionAssistant\features\audio.py:74
 msgid "Listening..."
 msgstr "Nasłuchiwanie..."
 
-#. Translators: Message in an error dialog which can pop up while trying
-#. dictation.
-#: addon\globalPlugins\visionAssistant\features\audio.py:79 addon\globalPlugins\visionAssistant\features\audio.py:180
+#. Translators: Message in an error dialog which can pop up while trying dictation.
+#: addon\globalPlugins\visionAssistant\features\audio.py:89
 #, python-brace-format
 msgid "Save Recording Error: {error}"
 msgstr "Błąd zapisu nagrania: {error}"
 
 #. Translators: Message reported when the AI detects silence or empty speech
-#: addon\globalPlugins\visionAssistant\features\audio.py:94 addon\globalPlugins\visionAssistant\features\audio.py:121 addon\globalPlugins\visionAssistant\features\audio.py:194 addon\globalPlugins\visionAssistant\features\audio.py:235
+#: addon\globalPlugins\visionAssistant\features\audio.py:104
+#: addon\globalPlugins\visionAssistant\features\audio.py:157
 msgid "No speech detected."
 msgstr "Nie wykryto mowy."
 
 #. Translators: Message reported when processing dictation
-#: addon\globalPlugins\visionAssistant\features\audio.py:104
+#: addon\globalPlugins\visionAssistant\features\audio.py:115
 msgid "Typing..."
 msgstr "Wpisywanie..."
 
-#. Translators: Message reported while trying dictation.
-#: addon\globalPlugins\visionAssistant\features\audio.py:129 addon\globalPlugins\visionAssistant\features\audio.py:242
-msgid "No speech recognized or Error."
-msgstr "Nie rozpoznano mowy lub wystąpił błąd."
-
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\features\audio.py:204 addon\globalPlugins\visionAssistant\features\vision.py:1439
+#: addon\globalPlugins\visionAssistant\features\audio.py:118
+#: addon\globalPlugins\visionAssistant\features\vision.py:1502
 msgid "Translating..."
 msgstr "Tłumaczenie..."
 
+#. Translators: Message reported while trying dictation.
+#: addon\globalPlugins\visionAssistant\features\audio.py:165
+msgid "No speech recognized or Error."
+msgstr "Nie rozpoznano mowy lub wystąpił błąd."
+
 #. Translators: Message reported when dictation is complete
-#: addon\globalPlugins\visionAssistant\features\audio.py:262
+#: addon\globalPlugins\visionAssistant\features\audio.py:187
 #, python-brace-format
 msgid "Typed: {text}"
 msgstr "Wpisano: {text}"
 
 #. Translators: Options for the media file action menu
-#: addon\globalPlugins\visionAssistant\features\audio.py:290
+#: addon\globalPlugins\visionAssistant\features\audio.py:215
 msgid "Transcribe (Original Language)"
 msgstr "Transkrybuj (język oryginału)"
 
-#: addon\globalPlugins\visionAssistant\features\audio.py:290
+#: addon\globalPlugins\visionAssistant\features\audio.py:215
 msgid "Transcribe and Translate (Target Language)"
 msgstr "Transkrybuj i przetłumacz (język docelowy)"
 
 #. Translators: Option in media action menu to live translate/dub audio
-#: addon\globalPlugins\visionAssistant\features\audio.py:292
+#: addon\globalPlugins\visionAssistant\features\audio.py:217
 msgid "Dub and Translate (Target Language)"
 msgstr "Zdubbinguj i przetłumacz (język docelowy)"
 
 #. Translators: Title of the Refine dialog
 #. Translators: Title and prompt for the video action selection dialog.
 #. Translators: Title of the Refine dialog
-#: addon\globalPlugins\visionAssistant\features\audio.py:298 addon\globalPlugins\visionAssistant\features\video.py:91 addon\globalPlugins\visionAssistant\features\vision.py:73 addon\globalPlugins\visionAssistant\features\vision.py:393
+#: addon\globalPlugins\visionAssistant\features\audio.py:223
+#: addon\globalPlugins\visionAssistant\features\video.py:91
+#: addon\globalPlugins\visionAssistant\features\vision.py:74
+#: addon\globalPlugins\visionAssistant\features\vision.py:431
 msgid "Choose action:"
 msgstr "Wybierz czynność:"
 
-#: addon\globalPlugins\visionAssistant\features\audio.py:298
+#: addon\globalPlugins\visionAssistant\features\audio.py:223
 msgid "Media File"
 msgstr "Plik multimedialny"
 
 #. Translators: Message reported when calling the audio transcription command
-#: addon\globalPlugins\visionAssistant\features\audio.py:333
+#: addon\globalPlugins\visionAssistant\features\audio.py:259
 msgid "Uploading..."
 msgstr "Przesyłanie..."
 
-#. Translators: Status message when extracting audio and connecting to Gemini
-#. for dubbing
-#: addon\globalPlugins\visionAssistant\features\audio.py:372
+#. Translators: Progress message spoken when the add-on starts taking a screenshot of the current focused object.
+#: addon\globalPlugins\visionAssistant\features\audio.py:281
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:494
+#: addon\globalPlugins\visionAssistant\features\vision.py:1288
+msgid "Analyzing..."
+msgstr "Analizowanie..."
+
+#. Translators: Status message when extracting audio and connecting to Gemini for dubbing
+#: addon\globalPlugins\visionAssistant\features\audio.py:298
 msgid "Extracting audio and connecting to Gemini..."
 msgstr "Wyodrębnianie dźwięku i łączenie z Gemini..."
 
-#. Translators: Error message shown when Live Translate cannot connect to the
-#. server.
-#: addon\globalPlugins\visionAssistant\features\audio.py:458
+#. Translators: Error message shown when Live Translate cannot connect to the server.
+#: addon\globalPlugins\visionAssistant\features\audio.py:386
 msgid "WebSocket connection failed for all available API keys."
-msgstr "Połączenie WebSocket nie powiodło się dla żadnego z dostępnych kluczy API."
+msgstr ""
+"Połączenie WebSocket nie powiodło się dla żadnego z dostępnych kluczy API."
 
 #. Translators: Error message shown when the Live translation setup fails.
-#: addon\globalPlugins\visionAssistant\features\audio.py:489
+#: addon\globalPlugins\visionAssistant\features\audio.py:417
 #, python-brace-format
 msgid "Failed to setup Live translation session. Error: {error}"
 msgstr "Nie udało się rozpocząć sesji tłumaczenia Live. Błąd: {error}"
 
-#. Translators: Status message part showing estimated time remaining and
-#. completion time.
-#: addon\globalPlugins\visionAssistant\features\audio.py:502
+#. Translators: Status message part showing estimated time remaining and completion time.
+#: addon\globalPlugins\visionAssistant\features\audio.py:431
 #, python-brace-format
 msgid " (approx. {mins} min {secs} sec, finishing around {time})"
 msgstr " (około {mins} min {secs} s, koniec około {time})"
 
-#. Translators: Status message part showing estimated seconds remaining and
-#. completion time.
-#: addon\globalPlugins\visionAssistant\features\audio.py:504
+#. Translators: Status message part showing estimated seconds remaining and completion time.
+#: addon\globalPlugins\visionAssistant\features\audio.py:433
 #, python-brace-format
 msgid " (approx. {secs} sec, finishing around {time})"
 msgstr " (około {secs} s, koniec około {time})"
 
 #. Translators: Status message when live dubbing is actively streaming
-#: addon\globalPlugins\visionAssistant\features\audio.py:507
+#: addon\globalPlugins\visionAssistant\features\audio.py:436
 msgid "Dubbing in progress..."
 msgstr "Trwa dubbing..."
 
-#. Translators: Error message shown when live dubbing fails to return any
-#. audio
-#: addon\globalPlugins\visionAssistant\features\audio.py:598
+#. Translators: Error message shown when live dubbing fails to return any audio
+#: addon\globalPlugins\visionAssistant\features\audio.py:527
 msgid "Dubbing failed. No audio returned. Check NVDA log for details."
-msgstr "Dubbing nie powiódł się. Nie zwrócono dźwięku. Szczegóły w dzienniku NVDA."
+msgstr ""
+"Dubbing nie powiódł się. Nie zwrócono dźwięku. Szczegóły w dzienniku NVDA."
 
 #. Translators: Dialog title when saving a dubbed media file
-#: addon\globalPlugins\visionAssistant\features\audio.py:631
+#: addon\globalPlugins\visionAssistant\features\audio.py:560
 msgid "Save dubbed audio as"
 msgstr "Zapisz zdubbingowany dźwięk jako"
 
 #. Translators: Message reported when dubbed file is successfully saved
-#: addon\globalPlugins\visionAssistant\features\audio.py:643
+#: addon\globalPlugins\visionAssistant\features\audio.py:572
 #, python-brace-format
 msgid "Dubbed file saved: {path}"
 msgstr "Zapisano zdubbingowany plik: {path}"
 
 #. Translators: Status message when dubbing process finishes
-#: addon\globalPlugins\visionAssistant\features\audio.py:651
+#: addon\globalPlugins\visionAssistant\features\audio.py:580
 msgid "Dubbing finished."
 msgstr "Dubbing zakończony."
 
 #. Translators: Error message when live translate fails
-#: addon\globalPlugins\visionAssistant\features\audio.py:656
+#: addon\globalPlugins\visionAssistant\features\audio.py:586
 msgid "Dubbing failed."
 msgstr "Dubbing nie powiódł się."
 
@@ -3127,7 +3629,8 @@ msgid "UI Explorer Active"
 msgstr "Eksplorator interfejsu aktywny"
 
 #. Translators: Status message when UI Explorer stops
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:51 addon\globalPlugins\visionAssistant\features\operator_captcha.py:132
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:51
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:132
 msgid "UI Explorer Stopped"
 msgstr "Eksplorator interfejsu zatrzymany"
 
@@ -3152,7 +3655,8 @@ msgid "What should I do or what is your question?"
 msgstr "Co mam zrobić lub jakie jest twoje pytanie?"
 
 #. Translators: Message while processing request of the refine text command
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:162 addon\globalPlugins\visionAssistant\features\vision.py:436
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:162
+#: addon\globalPlugins\visionAssistant\features\vision.py:483
 msgid "Processing..."
 msgstr "Przetwarzanie..."
 
@@ -3161,123 +3665,188 @@ msgstr "Przetwarzanie..."
 msgid "Action performed. Checking result..."
 msgstr "Akcja wykonana. Sprawdzanie wyniku..."
 
-#. Translators: The title of the interactive chat dialog for the AI Operator
-#. feature.
+#. Translators: The title of the interactive chat dialog for the AI Operator feature.
 #: addon\globalPlugins\visionAssistant\features\operator_captcha.py:300
 #, python-brace-format
 msgid "{name} - AI Operator"
 msgstr "{name} – Operator AI"
 
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:312
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:314
 msgid "You"
 msgstr "Ty"
 
-#. Translators: Announcement when the visual CAPTCHA solver is manually
-#. aborted
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:659
+#. Translators: Message spoken by NVDA when the current object already has a custom or AI-generated label. {name} is replaced with the existing label text.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:480
+#, python-brace-format
+msgid "Already labeled as: {name}"
+msgstr "Już oznaczono jako: {name}"
+
+#. Translators: Progress message spoken when the add-on starts taking a screenshot of the current focused object.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:485
+msgid "Identifying object..."
+msgstr "Rozpoznawanie obiektu..."
+
+#. Translators: Success message spoken when the AI successfully assigns a new label to the object. {name} is replaced with the AI-generated label.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:512
+#, python-brace-format
+msgid "Labeled as: {name}"
+msgstr "Etykieta jako: {name}"
+
+#. Translators: Confirmation message shown after labels are deleted or renamed.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:548
+msgid "Labels updated."
+msgstr "Etykiety zaktualizowane."
+
+#. Translators: Progress message spoken when the add-on begins scanning the current application window to find UI elements (like buttons or icons) that do not have accessibility names.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:565
+msgid "Scanning application UI..."
+msgstr "Skanowanie interfejsu aplikacji..."
+
+#. Translators: Message spoken when the add-on finishes the UI scan but finds no unnamed elements to label (everything already has a name).
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:592
+msgid "No unnamed elements found."
+msgstr "Nie ma niezaetykietowanych elementów."
+
+#. Translators: Progress message spoken when the add-on has found unnamed elements and is now sending the full application screenshot to AI for batch labeling.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:596
+msgid "Analyzing application..."
+msgstr "Analizowanie aplikacji..."
+
+#. Translators: Success message spoken when the AI finishes analyzing the app and successfully names multiple elements in the background.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:646
+msgid "Application labeling complete."
+msgstr "Etykietowanie aplikacji zakończone."
+
+#. Translators: Error message spoken when the add-on fails to parse or map the labels returned by the AI (e.g., due to invalid AI response format).
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:651
+msgid "Batch labeling failed."
+msgstr "Zbiorcze etykietowanie nie powiodło się."
+
+#. Translators: Announcement when the visual CAPTCHA solver is manually aborted
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:667
 msgid "Visual CAPTCHA solver aborted."
 msgstr "Przerwano rozwiązywanie CAPTCHA z obrazu."
 
-#. Translators: Message reported by NVDA when the user triggers the CAPTCHA
-#. solving command.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:675
+#. Translators: Message reported by NVDA when the user triggers the CAPTCHA solving command.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:683
 msgid "Solving..."
 msgstr "Rozwiązywanie..."
 
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:682 addon\globalPlugins\visionAssistant\features\vision.py:1041
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:690
+#: addon\globalPlugins\visionAssistant\features\vision.py:1100
 msgid "Capture failed."
 msgstr "Przechwytywanie nie powiodło się."
 
-#. Translators: Message reported by NVDA when the AI cannot detect any CAPTCHA
-#. in the captured image.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:703
+#. Translators: Message reported by NVDA when the AI cannot detect any CAPTCHA in the captured image.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:711
 msgid "No CAPTCHA detected."
 msgstr "Nie wykryto kodu CAPTCHA."
 
-#. Translators: Message reported when a visual CAPTCHA (like reCAPTCHA) is
-#. detected.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:707
-msgid "Visual CAPTCHA detected. Entering solving mode... This may take a little while."
-msgstr "Wykryto CAPTCHA obrazkową. Rozpoczynam rozwiązywanie... To potrwa chwilę."
+#. Translators: Message reported when a visual CAPTCHA (like reCAPTCHA) is detected.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:715
+msgid ""
+"Visual CAPTCHA detected. Entering solving mode... This may take a little "
+"while."
+msgstr ""
+"Wykryto CAPTCHA obrazkową. Rozpoczynam rozwiązywanie... To potrwa chwilę."
 
-#. Translators: Message reported when a visual CAPTCHA is detected but the
-#. solver is disabled.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:711
+#. Translators: Message reported when a visual CAPTCHA is detected but the solver is disabled.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:719
 msgid "Visual CAPTCHA detected, but the solver is disabled in settings."
-msgstr "Wykryto CAPTCHA obrazkową, ale rozwiązywanie jest wyłączone w ustawieniach."
+msgstr ""
+"Wykryto CAPTCHA obrazkową, ale rozwiązywanie jest wyłączone w ustawieniach."
 
 #. Translators: Message reported when image capture fails or AI returns empty.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:714
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:722
 msgid "Capture failed or AI returned empty response."
 msgstr "Przechwytywanie nie powiodło się albo AI zwróciła pustą odpowiedź."
 
-#. Translators: Message reported by NVDA after successfully solving a text
-#. CAPTCHA, announcing the characters found.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:733
+#. Translators: Message reported by NVDA after successfully solving a text CAPTCHA, announcing the characters found.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:742
 #, python-brace-format
 msgid "Captcha: {text}"
 msgstr "Captcha: {text}"
 
 #. Translators: Message reported when a visual CAPTCHA is successfully solved.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:780
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:789
 msgid "Visual CAPTCHA solved!"
 msgstr "CAPTCHA obrazkowa rozwiązana!"
 
-#. Translators: Message reported when AI fails to solve the visual CAPTCHA
-#. after max attempts.
-#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:835
+#. Translators: Message reported when AI fails to solve the visual CAPTCHA after max attempts.
+#: addon\globalPlugins\visionAssistant\features\operator_captcha.py:844
 msgid "Failed to solve CAPTCHA after maximum attempts."
 msgstr "Nie udało się rozwiązać CAPTCHA po maksymalnej liczbie prób."
 
-#. Translators: Value representing the ON state for a toggle setting (e.g., in
-#. quick settings).
-#: addon\globalPlugins\visionAssistant\features\quick_settings.py:50 addon\globalPlugins\visionAssistant\features\quick_settings.py:52 addon\globalPlugins\visionAssistant\features\quick_settings.py:53
+#. Translators: Value representing the ON state for a toggle setting (e.g., in quick settings).
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:43
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:45
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:46
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:47
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:48
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:49
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:50
 msgid "On"
 msgstr "Włączone"
 
-#: addon\globalPlugins\visionAssistant\features\quick_settings.py:50 addon\globalPlugins\visionAssistant\features\quick_settings.py:52 addon\globalPlugins\visionAssistant\features\quick_settings.py:53
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:43
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:45
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:46
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:47
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:48
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:49
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:50
 msgid "Off"
 msgstr "Wyłączone"
 
 #. Translators: Announced when navigating to AI Model quick settings
-#: addon\globalPlugins\visionAssistant\features\quick_settings.py:68
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:65
 #, python-brace-format
 msgid "{setting}, Current: {val}. Use left and right arrows to change."
 msgstr "{setting}, obecnie: {val}. Zmieniaj strzałkami w lewo i w prawo."
 
 #. Translators: Warning when models list is not fetched
-#: addon\globalPlugins\visionAssistant\features\quick_settings.py:128
+#: addon\globalPlugins\visionAssistant\features\quick_settings.py:133
 #, python-brace-format
-msgid "No models fetched for {provider}. Please update models list from settings."
-msgstr "Nie pobrano modeli dla dostawcy {provider}. Zaktualizuj listę modeli w ustawieniach."
+msgid ""
+"No models fetched for {provider}. Please update models list from settings."
+msgstr ""
+"Nie pobrano modeli dla dostawcy {provider}. Zaktualizuj listę modeli w "
+"ustawieniach."
+
+#. Translators: Message of a dialog which may pop up while performing an AI call
+#: addon\globalPlugins\visionAssistant\features\upload.py:71
+#, python-brace-format
+msgid "File Upload Error: {error}"
+msgstr "Błąd przesyłania pliku: {error}"
 
 #: addon\globalPlugins\visionAssistant\features\video.py:91
 msgid "Video Action"
 msgstr "Akcja wideo"
 
-#. Translators: Prompt asking the user to manually input YouTube video
-#. duration.
-#: addon\globalPlugins\visionAssistant\features\video.py:107 addon\globalPlugins\visionAssistant\features\video.py:196
+#. Translators: Prompt asking the user to manually input YouTube video duration.
+#: addon\globalPlugins\visionAssistant\features\video.py:107
+#: addon\globalPlugins\visionAssistant\features\video.py:196
 msgid ""
 "Please enter the YouTube video duration in minutes (e.g., 10 or 10.5).\n"
-"If you enter an incorrect duration, the audio description may not be complete."
+"If you enter an incorrect duration, the audio description may not be "
+"complete."
 msgstr ""
 "Podaj długość filmu z YouTube w minutach (na przykład 10 albo 10.5).\n"
 "Przy błędnej długości audiodeskrypcja może być niepełna."
 
 #. Translators: Title for the YouTube duration input dialog.
-#: addon\globalPlugins\visionAssistant\features\video.py:109 addon\globalPlugins\visionAssistant\features\video.py:197
+#: addon\globalPlugins\visionAssistant\features\video.py:109
+#: addon\globalPlugins\visionAssistant\features\video.py:197
 msgid "YouTube Video Duration"
 msgstr "Długość filmu z YouTube"
 
-#. Translators: Error message shown when the entered YouTube duration is
-#. invalid.
-#: addon\globalPlugins\visionAssistant\features\video.py:126 addon\globalPlugins\visionAssistant\features\video.py:213
+#. Translators: Error message shown when the entered YouTube duration is invalid.
+#: addon\globalPlugins\visionAssistant\features\video.py:126
+#: addon\globalPlugins\visionAssistant\features\video.py:213
 msgid "Invalid duration entered. Video analysis cancelled."
 msgstr "Podano nieprawidłową długość. Anulowano analizę wideo."
 
-#. Translators: Error message when video analysis is attempted with a non-
-#. Gemini provider.
+#. Translators: Error message when video analysis is attempted with a non-Gemini provider.
 #: addon\globalPlugins\visionAssistant\features\video.py:154
 msgid "Video analysis is only supported by Gemini providers."
 msgstr "Analiza wideo jest obsługiwana wyłącznie przez dostawcę Gemini."
@@ -3287,253 +3856,314 @@ msgstr "Analiza wideo jest obsługiwana wyłącznie przez dostawcę Gemini."
 msgid "Error: Invalid URL."
 msgstr "Błąd: nieprawidłowy adres URL."
 
-#. Translators: Error message when the video URL is from an unsupported
-#. website.
+#. Translators: Error message when the video URL is from an unsupported website.
 #: addon\globalPlugins\visionAssistant\features\video.py:322
-msgid "Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok are supported."
-msgstr "Błąd: nieobsługiwana platforma. Obsługiwane są tylko YouTube, Instagram, Twitter i TikTok."
+msgid ""
+"Error: Unsupported platform. Only YouTube, Instagram, Twitter, and TikTok "
+"are supported."
+msgstr ""
+"Błąd: nieobsługiwana platforma. Obsługiwane są tylko YouTube, Instagram, "
+"Twitter i TikTok."
 
 #. Translators: Disclaimer added at the beginning of AI-generated SRT files.
-#: addon\globalPlugins\visionAssistant\features\video.py:345
-msgid "Disclaimer: This audio description was generated by AI. Some details, including character identities or events, may not be entirely accurate."
-msgstr "Zastrzeżenie: ta audiodeskrypcja została wygenerowana przez AI. Niektóre szczegóły, w tym tożsamość postaci lub przebieg zdarzeń, mogą nie być w pełni dokładne."
+#: addon\globalPlugins\visionAssistant\features\video.py:346
+msgid ""
+"Disclaimer: This audio description was generated by AI. Some details, "
+"including character identities or events, may not be entirely accurate."
+msgstr ""
+"Zastrzeżenie: ta audiodeskrypcja została wygenerowana przez AI. Niektóre "
+"szczegóły, w tym tożsamość postaci lub przebieg zdarzeń, mogą nie być w "
+"pełni dokładne."
 
-#. Translators: Status message when the AI is analyzing the whole video to
-#. extract character names and appearances.
+#. Translators: Status message when the AI is analyzing the whole video to extract character names and appearances.
 #: addon\globalPlugins\visionAssistant\features\video.py:445
 msgid "Extracting characters (First pass)..."
 msgstr "Wyodrębnianie postaci (pierwsze przejście)..."
 
-#. Translators: Header for the list of extracted characters in the generated
-#. subtitle.
+#. Translators: Header for the list of extracted characters in the generated subtitle.
 #: addon\globalPlugins\visionAssistant\features\video.py:495
 msgid "GLOBAL CHARACTER DICTIONARY:"
 msgstr "GLOBALNY SŁOWNIK POSTACI:"
 
-#. Translators: Status message shown when the add-on pauses briefly between
-#. API requests to prevent hitting server rate limits.
+#. Translators: Status message shown when the add-on pauses briefly between API requests to prevent hitting server rate limits.
 #: addon\globalPlugins\visionAssistant\features\video.py:512
 #, python-brace-format
 msgid "Cooling down to prevent rate limits ({seconds} seconds)..."
 msgstr "Przerwa, aby uniknąć limitów zapytań ({seconds} s)..."
 
-#. Translators: Header for the list of characters introduced up to the current
-#. video scene.
+#. Translators: Header for the list of characters introduced up to the current video scene.
 #: addon\globalPlugins\visionAssistant\features\video.py:546
 msgid "GLOBAL CHARACTER DICTIONARY (Active characters in this scene):"
 msgstr "GLOBALNY SPIS POSTACI (postacie obecne w tej scenie):"
 
-#. Translators: Status message reporting which segment of the video is
-#. currently being analyzed. {current} is the current segment number and
-#. {total} is the total segment count.
+#. Translators: Status message reporting which segment of the video is currently being analyzed. {current} is the current segment number and {total} is the total segment count.
 #: addon\globalPlugins\visionAssistant\features\video.py:562
 #, python-brace-format
 msgid "Analyzing video segment {current} of {total}..."
 msgstr "Analiza segmentu wideo {current} z {total}..."
 
 #. Translators: Message reported when AI is analyzing the video
-#: addon\globalPlugins\visionAssistant\features\video.py:564 addon\globalPlugins\visionAssistant\features\video.py:786
+#: addon\globalPlugins\visionAssistant\features\video.py:564
+#: addon\globalPlugins\visionAssistant\features\video.py:788
 msgid "Analyzing video..."
 msgstr "Analiza wideo..."
 
-#. Translators: Status message shown when a video segment finishes processing
-#. and the system is moving to the next one. {current} is the completed
-#. segment number.
-#: addon\globalPlugins\visionAssistant\features\video.py:613
+#. Translators: Status message shown when a video segment finishes processing and the system is moving to the next one. {current} is the completed segment number.
+#: addon\globalPlugins\visionAssistant\features\video.py:615
 #, python-brace-format
 msgid "Segment {current} finished. Preparing next..."
 msgstr "Segment {current} ukończony. Przygotowanie następnego..."
 
-#. Translators: Status message when all segments are done and it is
-#. finalizing.
-#: addon\globalPlugins\visionAssistant\features\video.py:616
+#. Translators: Status message when all segments are done and it is finalizing.
+#: addon\globalPlugins\visionAssistant\features\video.py:618
 msgid "Finalizing..."
 msgstr "Finalizowanie..."
 
-#. Translators: Error message shown when the AI output cannot be converted
-#. into a valid SRT subtitle file.
-#: addon\globalPlugins\visionAssistant\features\video.py:634
+#. Translators: Error message shown when the AI output cannot be converted into a valid SRT subtitle file.
+#: addon\globalPlugins\visionAssistant\features\video.py:636
 msgid "Failed to parse AI output into SRT."
 msgstr "Nie udało się przetworzyć wyniku AI na SRT."
 
-#. Translators: Error message reported when video segment analysis fails after
-#. multiple retries due to network issues.
-#: addon\globalPlugins\visionAssistant\features\video.py:645
+#. Translators: Error message reported when video segment analysis fails after multiple retries due to network issues.
+#: addon\globalPlugins\visionAssistant\features\video.py:647
 msgid "Connection failed after retries."
 msgstr "Połączenie nie powiodło się po ponownych próbach."
 
-#. Translators: Error message when video recording is attempted with a non-
-#. Gemini provider
-#: addon\globalPlugins\visionAssistant\features\video.py:668
+#. Translators: Error message when video recording is attempted with a non-Gemini provider
+#: addon\globalPlugins\visionAssistant\features\video.py:670
 msgid "Video recording is only supported by Gemini providers."
 msgstr "Nagrywanie wideo jest obsługiwane tylko przez dostawców Gemini."
 
 #. Translators: Status message reported when starting video recording
-#: addon\globalPlugins\visionAssistant\features\video.py:680
+#: addon\globalPlugins\visionAssistant\features\video.py:682
 msgid "Starting recording..."
 msgstr "Rozpoczynanie nagrywania..."
 
-#. Translators: Message when window capture fails and switches to full screen
-#. capture
-#: addon\globalPlugins\visionAssistant\features\video.py:722
+#. Translators: Message when window capture fails and switches to full screen capture
+#: addon\globalPlugins\visionAssistant\features\video.py:724
 msgid "Window capture failed. Trying full screen..."
 msgstr "Nie udało się przechwycić okna. Próba całego ekranu..."
 
 #. Translators: Error message when ffmpeg fails completely
-#: addon\globalPlugins\visionAssistant\features\video.py:726
+#: addon\globalPlugins\visionAssistant\features\video.py:728
 msgid "Recording failed to start. FFmpeg encountered a fatal error."
 msgstr "Nie udało się rozpocząć nagrywania. FFmpeg napotkał błąd krytyczny."
 
 #. Translators: Message when video recording starts
-#: addon\globalPlugins\visionAssistant\features\video.py:731
+#: addon\globalPlugins\visionAssistant\features\video.py:733
 msgid "Recording started. Press the same shortcut again to stop."
 msgstr "Rozpoczęto nagrywanie. Naciśnij ten sam skrót ponownie, aby zatrzymać."
 
 #. Translators: Error message when recording fails to start
-#: addon\globalPlugins\visionAssistant\features\video.py:742
+#: addon\globalPlugins\visionAssistant\features\video.py:744
 #, python-brace-format
 msgid "Failed to start recording: {error}"
 msgstr "Nie udało się rozpocząć nagrywania: {error}"
 
 #. Translators: Error when recorded video file is not found
-#: addon\globalPlugins\visionAssistant\features\video.py:758
+#: addon\globalPlugins\visionAssistant\features\video.py:760
 msgid "Recording file not found."
 msgstr "Nie znaleziono pliku nagrania."
 
 #. Translators: Error when recorded video file is too small/corrupted
-#: addon\globalPlugins\visionAssistant\features\video.py:766
-msgid "The recording was too short or the video file is corrupted. Please try recording for at least a few seconds."
-msgstr "Nagranie było za krótkie lub plik wideo jest uszkodzony. Spróbuj nagrywać przez co najmniej kilka sekund."
+#: addon\globalPlugins\visionAssistant\features\video.py:768
+msgid ""
+"The recording was too short or the video file is corrupted. Please try "
+"recording for at least a few seconds."
+msgstr ""
+"Nagranie było za krótkie lub plik wideo jest uszkodzony. Spróbuj nagrywać "
+"przez co najmniej kilka sekund."
 
-#. Translators: Status message showing recording info, {duration} is seconds,
-#. {size} is MB
-#: addon\globalPlugins\visionAssistant\features\video.py:770
+#. Translators: Status message showing recording info, {duration} is seconds, {size} is MB
+#: addon\globalPlugins\visionAssistant\features\video.py:772
 #, python-brace-format
 msgid "Recording stopped ({duration:.0f} seconds, {size:.1f} MB)"
 msgstr "Zatrzymano nagrywanie ({duration:.0f} s, {size:.1f} MB)"
 
 #. Translators: Error message when processing recorded video fails
-#: addon\globalPlugins\visionAssistant\features\video.py:800
+#: addon\globalPlugins\visionAssistant\features\video.py:802
 #, python-brace-format
 msgid "Failed to process recording: {error}"
 msgstr "Nie udało się przetworzyć nagrania: {error}"
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\features\vision.py:61
+#: addon\globalPlugins\visionAssistant\features\vision.py:62
 #, python-brace-format
 msgid "Translated: {text}"
 msgstr "Przetłumaczono: {text}"
 
 #. Translators: Options for the image file action menu
-#: addon\globalPlugins\visionAssistant\features\vision.py:70
+#: addon\globalPlugins\visionAssistant\features\vision.py:71
 msgid "Extract Text (OCR)"
 msgstr "Wyodrębnij tekst (OCR)"
 
-#: addon\globalPlugins\visionAssistant\features\vision.py:70
+#: addon\globalPlugins\visionAssistant\features\vision.py:71
 msgid "Describe Image"
 msgstr "Opisz obraz"
 
-#: addon\globalPlugins\visionAssistant\features\vision.py:73
+#: addon\globalPlugins\visionAssistant\features\vision.py:74
 msgid "Image File"
 msgstr "Plik obrazu"
 
 #. Translators: Status reported when an image file is being analyzed
-#: addon\globalPlugins\visionAssistant\features\vision.py:86
+#: addon\globalPlugins\visionAssistant\features\vision.py:87
 msgid "Analyzing Image File..."
 msgstr "Analizowanie pliku obrazu..."
 
+#. Translators: Line appended to the conversation when the live session has ended.
+#: addon\globalPlugins\visionAssistant\features\vision.py:125
+#: addon\globalPlugins\visionAssistant\features\vision.py:126
+msgid "--- Session ended ---"
+msgstr "--- Sesja zakończona ---"
+
+#. Translators: Message announced by NVDA when the live voice conversation ends.
+#: addon\globalPlugins\visionAssistant\features\vision.py:132
+msgid "Live conversation ended."
+msgstr "Rozmowa głosowa zakończona."
+
+#. Translators: Title of the dialog asking whether to resume an OCR operation that did not finish (for example after NVDA closed unexpectedly).
+#: addon\globalPlugins\visionAssistant\features\vision.py:171
+msgid "Unfinished Operation"
+msgstr "Niedokończona operacja"
+
+#. Translators: Message asking whether to continue an interrupted OCR extraction. {done} is the number of pages already processed, {total} is the total number of pages, and {files} is the number of files involved.
+#: addon\globalPlugins\visionAssistant\features\vision.py:173
+#, python-brace-format
+msgid ""
+"You have an unfinished operation: {done} of {total} pages processed across "
+"{files} file(s). Would you like to continue from where it stopped?"
+msgstr ""
+"Masz niedokończoną operację: przetworzono stron {done} z {total} w plikach: "
+"{files}. Kontynuować od miejsca zatrzymania?"
+
+#. Translators: Initial greeting message for the Direct Chat dialog.
+#: addon\globalPlugins\visionAssistant\features\vision.py:291
+msgid "Hello! I am Vision Assistant Pro. How can I help you today?"
+msgstr "Witaj! Tu Vision Assistant Pro. W czym mogę pomóc?"
+
+#. Translators: Dialog title for Direct Chat
+#: addon\globalPlugins\visionAssistant\features\vision.py:296
+#, python-brace-format
+msgid "{name} - Direct Chat"
+msgstr "{name} — czat"
+
 #. Translators: Dialog title for a Chat dialog
-#: addon\globalPlugins\visionAssistant\features\vision.py:352
+#: addon\globalPlugins\visionAssistant\features\vision.py:365
 #, python-brace-format
 msgid "{name} - Chat"
 msgstr "{name} - Czat"
 
+#. Translators: File dialog filter for supported files
+#: addon\globalPlugins\visionAssistant\features\vision.py:380
+msgid "Supported Files"
+msgstr "Obsługiwane pliki"
+
 #. Translators: Title of Refine Result dialog
-#: addon\globalPlugins\visionAssistant\features\vision.py:504
+#: addon\globalPlugins\visionAssistant\features\vision.py:548
 #, python-brace-format
 msgid "{name} - Refine Result"
 msgstr "{name} - Wynik poprawiania"
 
 #. Translators: Dialog title for Translation results
-#: addon\globalPlugins\visionAssistant\features\vision.py:544
+#: addon\globalPlugins\visionAssistant\features\vision.py:588
 #, python-brace-format
 msgid "{name} - Translation"
 msgstr "{name} - Tłumaczenie"
 
 #. Translators: Dialog title for Image Analysis
-#: addon\globalPlugins\visionAssistant\features\vision.py:627
+#: addon\globalPlugins\visionAssistant\features\vision.py:672
 #, python-brace-format
 msgid "{name} - Image Analysis"
 msgstr "{name} - Analiza obrazu"
 
-#. Translators: Error message shown when the OCR process fails to detect any
-#. text in the file or an unknown error occurs during extraction.
-#: addon\globalPlugins\visionAssistant\features\vision.py:829
+#. Translators: Title of the error dialog shown when the selected OCR engine cannot process the chosen image-based files.
+#: addon\globalPlugins\visionAssistant\features\vision.py:698
+#: addon\globalPlugins\visionAssistant\features\vision.py:992
+msgid "OCR Engine Error"
+msgstr "Błąd silnika OCR"
+
+#. Translators: Error when PyMuPDF is missing
+#: addon\globalPlugins\visionAssistant\features\vision.py:708
+#: addon\globalPlugins\visionAssistant\features\vision.py:981
+msgid "PyMuPDF library is missing."
+msgstr "Brak biblioteki PyMuPDF."
+
+#. Translators: Error when no pages found
+#: addon\globalPlugins\visionAssistant\features\vision.py:714
+#: addon\globalPlugins\visionAssistant\features\vision.py:999
+msgid "No readable pages found."
+msgstr "Nie znaleziono stron do odczytu."
+
+#. Translators: Error message shown when the OCR process fails to detect any text in the file or an unknown error occurs during extraction.
+#: addon\globalPlugins\visionAssistant\features\vision.py:870
 msgid "No text detected or error occurred."
 msgstr "Nie wykryto tekstu lub wystąpił błąd."
 
 #. Translators: Error message shown when the upload fails.
-#: addon\globalPlugins\visionAssistant\features\vision.py:899
+#: addon\globalPlugins\visionAssistant\features\vision.py:939
 #, python-brace-format
 msgid "Failed to process document batch {start}-{end} after multiple attempts."
-msgstr "Nie udało się przetworzyć wsadu dokumentów {start}-{end} po kilku próbach."
+msgstr ""
+"Nie udało się przetworzyć wsadu dokumentów {start}-{end} po kilku próbach."
 
-#. Translators: Error message shown when the connection to the server times
-#. out
-#: addon\globalPlugins\visionAssistant\features\vision.py:921
+#. Translators: Error message shown when the connection to the server times out
+#: addon\globalPlugins\visionAssistant\features\vision.py:961
 msgid "Connection Timeout"
 msgstr "Przekroczono czas połączenia"
 
-#: addon\globalPlugins\visionAssistant\features\vision.py:922
+#: addon\globalPlugins\visionAssistant\features\vision.py:962
 #, python-brace-format
 msgid "Failed to process document batch {start}-{end}: {error}"
 msgstr "Błąd przetwarzania wsadu dokumentów {start}-{end}: {error}"
 
 #. Translators: Message reported when calling an image analysis command
-#: addon\globalPlugins\visionAssistant\features\vision.py:1037
+#: addon\globalPlugins\visionAssistant\features\vision.py:1096
 msgid "Scanning..."
 msgstr "Skanowanie..."
 
+#. Translators: Announcement when an in-progress OCR extraction is stopped by the user.
+#: addon\globalPlugins\visionAssistant\features\vision.py:1109
+msgid "OCR operation stopped."
+msgstr "Zatrzymano operację OCR."
+
 #. Translators: Message reported when executing the refine command
-#: addon\globalPlugins\visionAssistant\features\vision.py:1153
+#: addon\globalPlugins\visionAssistant\features\vision.py:1215
 msgid "Uploading file..."
 msgstr "Przesyłanie pliku..."
 
-#. Translators: Status reported when an image found in the clipboard is being
-#. processed.
-#: addon\globalPlugins\visionAssistant\features\vision.py:1328 addon\globalPlugins\visionAssistant\features\vision.py:1405
+#. Translators: Status reported when an image found in the clipboard is being processed.
+#: addon\globalPlugins\visionAssistant\features\vision.py:1391
+#: addon\globalPlugins\visionAssistant\features\vision.py:1468
 msgid "Processing clipboard image..."
 msgstr "Przetwarzanie obrazu ze schowka..."
 
-#. Translators: Message reported when the user tries to show the last result
-#. but none is stored.
-#: addon\globalPlugins\visionAssistant\features\vision.py:1378
+#. Translators: Message reported when the user tries to show the last result but none is stored.
+#: addon\globalPlugins\visionAssistant\features\vision.py:1441
 msgid "No previous result to show."
 msgstr "Brak poprzedniego wyniku do wyświetlenia."
 
 #. Translators: Message when calling the command to translate from clipboard
-#: addon\globalPlugins\visionAssistant\features\vision.py:1420
+#: addon\globalPlugins\visionAssistant\features\vision.py:1483
 msgid "Translating Clipboard..."
 msgstr "Tłumaczenie schowka..."
 
 #. Translators: Message when the clipboard contains no text to translate
-#: addon\globalPlugins\visionAssistant\features\vision.py:1425
+#: addon\globalPlugins\visionAssistant\features\vision.py:1488
 msgid "Clipboard empty."
 msgstr "Schowek jest pusty."
 
 #. Translators: Message reported when calling translation command
-#: addon\globalPlugins\visionAssistant\features\vision.py:1435
+#: addon\globalPlugins\visionAssistant\features\vision.py:1498
 msgid "No text found."
 msgstr "Brak tekstu."
 
 #. Translators: Title of dialog asking user to download ffmpeg
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:106
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:107
 msgid "Download ffmpeg?"
 msgstr "Pobrać ffmpeg?"
 
-#. Translators: Message in dialog asking user to download ffmpeg for video
-#. processing
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:108
+#. Translators: Message in dialog asking user to download ffmpeg for video processing
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:109
 msgid ""
 "Video processing requires ffmpeg (approximately 70MB download).\n"
 "\n"
@@ -3547,202 +4177,189 @@ msgstr ""
 "\n"
 "Pobieranie jest jednorazowe."
 
-#. Translators: Message reported when user cancels downloading ffmpeg required
-#. for video processing
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:122 addon\globalPlugins\visionAssistant\utils\media_capture.py:156
+#. Translators: Message reported when user cancels downloading ffmpeg required for video processing
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:123
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:157
 msgid "Operation cancelled. ffmpeg is required for video processing."
 msgstr "Anulowano. Do przetwarzania wideo potrzebny jest ffmpeg."
 
 #. Translators: Status message when downloading ffmpeg
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:164
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:165
 msgid "Downloading ffmpeg, please wait..."
 msgstr "Pobieranie ffmpeg, proszę czekać..."
 
-#. Translators: Progress message during ffmpeg download, {percent} is download
-#. percentage
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:183
+#. Translators: Progress message during ffmpeg download, {percent} is download percentage
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:184
 #, python-brace-format
 msgid "Downloading ffmpeg: {percent}%"
 msgstr "Pobieranie ffmpeg: {percent}%"
 
 #. Translators: Status message when extracting ffmpeg
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:186
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:187
 msgid "Extracting ffmpeg..."
 msgstr "Wypakowywanie ffmpeg..."
 
 #. Translators: Success message after ffmpeg download completes
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:203
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:204
 msgid "ffmpeg downloaded successfully!"
 msgstr "Pobrano ffmpeg."
 
 #. Translators: Error message when ffmpeg download fails
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:211
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:212
 #, python-brace-format
 msgid "Failed to download ffmpeg: {error}"
 msgstr "Nie udało się pobrać ffmpeg: {error}"
 
 #. Translators: Error message shown when processing a local video file fails.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:389
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:390
 msgid "Error processing local video."
 msgstr "Błąd przetwarzania lokalnego wideo."
 
-#. Translators: Status message when compressing a local video file before
-#. uploading.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:400
+#. Translators: Status message when compressing a local video file before uploading.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:401
 msgid "Compressing video (this may take a moment)..."
 msgstr "Kompresja wideo (może chwilę potrwać)..."
 
-#. Translators: Error message shown when video compression fails or was
-#. cancelled by the user.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:404
+#. Translators: Error message shown when video compression fails or was cancelled by the user.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:405
 msgid "Error: Video compression failed or was cancelled."
 msgstr "Błąd: kompresja wideo nie powiodła się lub została anulowana."
 
 #. Translators: Error message shown when processing an online video fails.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:427 addon\globalPlugins\visionAssistant\utils\media_capture.py:490
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:428
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:491
 msgid "Error processing video."
 msgstr "Błąd przetwarzania wideo."
 
-#. Translators: Message reported when the add-on starts processing an online
-#. video link.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:434 addon\globalPlugins\visionAssistant\utils\media_capture.py:521
+#. Translators: Message reported when the add-on starts processing an online video link.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:435
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:522
 msgid "Processing Video..."
 msgstr "Przetwarzanie wideo..."
 
-#. Translators: Error message when the add-on fails to get a direct download
-#. link for an Instagram video.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:441
+#. Translators: Error message when the add-on fails to get a direct download link for an Instagram video.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:442
 msgid "Error: Could not extract Instagram video."
 msgstr "Błąd: nie udało się pobrać wideo z Instagrama."
 
-#. Translators: Error message when the add-on fails to get a direct download
-#. link for a Twitter/X video.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:445
+#. Translators: Error message when the add-on fails to get a direct download link for a Twitter/X video.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:446
 msgid "Error: Could not extract Twitter video."
 msgstr "Błąd: nie udało się pobrać wideo z Twittera."
 
-#. Translators: Error message when the add-on fails to get a direct download
-#. link for a TikTok video.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:449
+#. Translators: Error message when the add-on fails to get a direct download link for a TikTok video.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:450
 msgid "Error: Could not extract TikTok video."
 msgstr "Błąd: nie udało się pobrać wideo z TikToka."
 
-#. Translators: Message reported when the add-on is downloading the video from
-#. the extracted link.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:465
+#. Translators: Message reported when the add-on is downloading the video from the extracted link.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:466
 msgid "Downloading Video..."
 msgstr "Pobieranie wideo..."
 
 #. Translators: Error message when downloading the online video fails.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:470
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:471
 msgid "Error: Download failed."
 msgstr "Błąd: pobieranie nie powiodło się."
 
-#. Translators: Error message displayed when access to the Live voice service
-#. is blocked or forbidden (HTTP 403 Forbidden).
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1109
-msgid "Access denied (HTTP 403 Forbidden). Please check your Proxy/VPN or API key."
-msgstr "Odmowa dostępu (HTTP 403 Forbidden). Sprawdź proxy lub VPN albo klucz API."
+#. Translators: Error message displayed when access to the Live voice service is blocked or forbidden (HTTP 403 Forbidden).
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1153
+msgid ""
+"Access denied (HTTP 403 Forbidden). Please check your Proxy/VPN or API key."
+msgstr ""
+"Odmowa dostępu (HTTP 403 Forbidden). Sprawdź proxy lub VPN albo klucz API."
 
-#. Translators: Error message announced when connecting to the Live service
-#. fails. {error} is replaced with the technical connection error details.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1118
+#. Translators: Error message announced when connecting to the Live service fails. {error} is replaced with the technical connection error details.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1162
 #, python-brace-format
 msgid "Could not connect to the Live service: {error}"
 msgstr "Nie udało się połączyć z usługą asystenta głosowego: {error}"
 
-#. Translators: Error shown when the microphone cannot be opened for the live
-#. session.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1164
+#. Translators: Error shown when the microphone cannot be opened for the live session.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1209
 msgid "Could not open the microphone."
 msgstr "Nie udało się otworzyć mikrofonu."
 
-#. Translators: Line shown when the live server unexpectedly closes the
-#. connection. {reason} is the server's reason.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1220
+#. Translators: Line shown when the live server unexpectedly closes the connection. {reason} is the server's reason.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1305
 #, python-brace-format
 msgid "[Connection closed: {reason}]"
 msgstr "[Połączenie zamknięte: {reason}]"
 
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1220
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1305
 msgid "unknown"
 msgstr "nieznany"
 
-#. Translators: Message announced by NVDA when the live voice conversation
-#. starts.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1239
+#. Translators: Message announced by NVDA when the live voice conversation starts.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1324
 msgid "Live conversation started. You can speak now."
 msgstr "Rozmowa głosowa rozpoczęta. Możesz teraz mówić."
 
-#. Translators: Prefix for the user's transcribed speech line in the Live
-#. Assistant history.
-#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1286
+#. Translators: Prefix for the user's transcribed speech line in the Live Assistant history.
+#: addon\globalPlugins\visionAssistant\utils\media_capture.py:1371
 msgid "You: "
 msgstr "Ty: "
 
 #. Translators: Title of update confirmation dialog
-#: addon\globalPlugins\visionAssistant\utils\updater.py:30
+#: addon\globalPlugins\visionAssistant\utils\updater.py:28
 msgid "Update Available"
 msgstr "Dostępna jest aktualizacja"
 
 #. Translators: Message asking user to update. {version} is version number.
-#: addon\globalPlugins\visionAssistant\utils\updater.py:37
+#: addon\globalPlugins\visionAssistant\utils\updater.py:35
 #, python-brace-format
 msgid "A new version ({version}) of {name} is available."
 msgstr "Dostępna jest nowa wersja ({version}) dodatku {name}."
 
 #. Translators: Label for the changes text box
-#: addon\globalPlugins\visionAssistant\utils\updater.py:42
+#: addon\globalPlugins\visionAssistant\utils\updater.py:40
 msgid "Changes:"
 msgstr "Zmiany:"
 
 #. Translators: Question to download and install
-#: addon\globalPlugins\visionAssistant\utils\updater.py:49
+#: addon\globalPlugins\visionAssistant\utils\updater.py:47
 msgid "Download and Install?"
 msgstr "Pobrać i zainstalować?"
 
 #. Translators: Button to accept update
-#: addon\globalPlugins\visionAssistant\utils\updater.py:54
+#: addon\globalPlugins\visionAssistant\utils\updater.py:52
 msgid "&Yes"
 msgstr "&Tak"
 
 #. Translators: Button to reject update
-#: addon\globalPlugins\visionAssistant\utils\updater.py:56
+#: addon\globalPlugins\visionAssistant\utils\updater.py:54
 msgid "&No"
 msgstr "&Nie"
 
-#. Translators: Error message when an update is found but the addon file is
-#. missing from GitHub.
-#: addon\globalPlugins\visionAssistant\utils\updater.py:100
+#. Translators: Error message when an update is found but the addon file is missing from GitHub.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:98
 msgid "Update found but no .nvda-addon file in release."
 msgstr "Znaleziono aktualizację, ale brak pliku .nvda-addon w wydaniu."
 
-#. Translators: Status message informing the user they are already on the
-#. latest version.
-#: addon\globalPlugins\visionAssistant\utils\updater.py:104
+#. Translators: Status message informing the user they are already on the latest version.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:102
 msgid "You have the latest version."
 msgstr "Masz najnowszą wersję."
 
-#. Translators: Error message shown when the add-on fails to check for
-#. updates. The {error} placeholder is replaced with specific error details.
-#: addon\globalPlugins\visionAssistant\utils\updater.py:109
+#. Translators: Error message shown when the add-on fails to check for updates. The {error} placeholder is replaced with specific error details.
+#: addon\globalPlugins\visionAssistant\utils\updater.py:107
 #, python-brace-format
 msgid "Update check failed: {error}"
 msgstr "Sprawdzanie aktualizacji nie powiodło się: {error}"
 
 #. Translators: Message shown while downloading update
-#: addon\globalPlugins\visionAssistant\utils\updater.py:137
+#: addon\globalPlugins\visionAssistant\utils\updater.py:135
 msgid "Downloading update, please wait..."
 msgstr "Pobieranie aktualizacji, czekaj..."
 
 #. Translators: Progress message during update download
-#: addon\globalPlugins\visionAssistant\utils\updater.py:154
+#: addon\globalPlugins\visionAssistant\utils\updater.py:153
 #, python-brace-format
 msgid "Downloading update: {percent}%"
 msgstr "Pobieranie aktualizacji: {percent}%"
 
 #. Translators: Error message for download failure
-#: addon\globalPlugins\visionAssistant\utils\updater.py:161
+#: addon\globalPlugins\visionAssistant\utils\updater.py:160
 #, python-brace-format
 msgid "Download failed: {error}"
 msgstr "Pobieranie nie powiodło się: {error}"
@@ -3755,8 +4372,7 @@ msgid "Vision Assistant Pro"
 msgstr "Vision Assistant Pro"
 
 #. Add-on description
-#. Translators: Long description to be shown for this add-on on add-on
-#. information from add-on store
+#. Translators: Long description to be shown for this add-on on add-on information from add-on store
 #: buildVars.py:13
 msgid ""
 "An advanced AI assistant for NVDA using Gemini models.\n"
@@ -3814,66 +4430,273 @@ msgstr ""
 "- Szybkie ustawienia (strzałki góra/dół/lewo/prawo)"
 
 #. Brief changelog for this version
-#. Translators: what's new content for the add-on version to be shown in the
-#. add-on store
+#. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:42
 msgid ""
-"## Changes for 2026.08.06\n"
+"## Changes for 2026.09.01\n"
 "\n"
-"*   **UI Explorer Labeling**: You can now add labels directly to found elements inside the UI Explorer! A new \"Add Label\" button has been added, and the interface smartly stays open and preserves focus so you can rapidly label multiple objects without interruption.\n"
-"*   **Quick Settings Layer Enhancement**: The Vision Assistant layer (`Insert+Shift+V`) is now persistent and highly interactive! You can use `Up/Down` arrows to navigate between quick settings (Provider, Model, AI Response Language, TTS Model) and `Left/Right` arrows to instantly change their values with smart, concise voice "
-"feedback. Your selections take effect immediately (including auto-enabling advanced routing when necessary), and the layer stays alive while you configure.\n"
-"*   **Direct Chat (`Shift+C`)**: Added a new command to the layer! Press `Shift+C` to instantly open a \"Direct Chat\" window. This provides a clean, text-based conversational interface with the AI right away, without needing an image or document as a starting point.\n"
-"*   **Flawless Chat History Recall**: Fixed a major bug where pressing `Space` to recall the last result would lose your subsequent chat history. Now, the add-on globally tracks your conversation. If you chat, close the dialog, and press `Space` to recall it, your entire back-and-forth history is perfectly restored! Works for Direct "
-"Chat, Vision Analysis, Document Chat, and Translation.\n"
-"*   **Inline Image Descriptions in OCR**: Added an optional feature to describe images inline during document OCR. You can toggle this setting in the add-on's OCR settings, within the Document Reader options before extraction, and quickly on-the-fly via the Quick Settings layer.\n"
-"*   **Voice Translation (`Control+T`)**: Added a powerful new feature! Dictate speech and instantly translate and type it using AI based on your configured source and target languages.\n"
-"*   **Update Downloader Improvements**: The update download dialog now correctly displays download progress in percentages, and a bug where a phantom \"Downloading update\" message appeared upon canceling the installation has been fixed.\n"
-"*   **eSpeak-NG Downloader Improvements**: Added percentage progress tracking for eSpeak-NG downloads.\n"
-"*   **Batch OCR Resilience**: Fixed an issue in batch PDF OCR where the process would halt if the active API key reached its quota midway; it now automatically switches to the next available key and resumes the process.\n"
-"*   **Visual Captcha Support**: Added robust support for visual captcha solving. It attempts to automatically solve complex image challenges like hCaptcha and reCAPTCHA, significantly enhancing accessibility on challenging web forms.\n"
-"*   **Audio Transcriber Overhaul**: The Audio Transcriber module has been completely rebuilt and now supports both audio and video files. It features 3 distinct operation modes: \"Transcribe (Original Language)\", \"Transcribe and Translate (Target Language)\", and a new powerful \"Dub and Translate (Target Language)\" option "
-"(exclusive to Gemini) that generates a translated audio dub of the original speech.\n"
-"*   **Optional Page Numbers in Document Reader**: Added a new setting to toggle the inclusion of page numbers and separators in multi-page document outputs. You can easily manage this option from the main settings or toggle it on-the-fly via the Quick Settings layer. This feature applies to both text/HTML file exports and the inline "
-"\"View Formatted\" window, allowing you to read combined documents seamlessly.\n"
-"*   **Unlimited Gemini Live TTS for Video Descriptions**: You can now select \"Gemini Live TTS\" as the voice engine when generating Synchronized Audio Narration (MP3) for videos. This utilizes the Gemini Live API to synthesize high-quality audio descriptions without any character limits or length restrictions.\n"
-"*   **Codebase Modularization**: Refactored the add-on structure from a single file to a multi-file modular architecture for improved maintainability.\n"
-"*   **Settings UI Redesign**: Completely redesigned the Settings dialog to use a modern, tab-based interface instead of a grouped layout, providing better organization and easier navigation while keeping all existing options.\n"
-"*   **Global & Dedicated File Logging**: Added an optional global file logging system under the new \"Advanced\" settings tab. Automatically captures operational events, API traffic, and errors across all add-on modules into a dedicated file (`vision_assistant.log`). Supports configurable log verbosity levels (Debug, Info, Warning, "
-"Error), automated retention periods (1 hour to 90 days), and direct log opening or clearing from settings with zero performance impact or NVDA log interference.\n"
-"*   **Gemini Upload Progress Tracking**: Added real-time percentage progress announcements when uploading large files (video, audio, documents) to the Google Gemini API."
+"*   **History (Control + H)**: The Command Layer now includes a **History** "
+"dialog (`Control + H`) that lists your past chats and documents with filters "
+"for All, Chats, and Documents. Reopen any chat with its full conversation — "
+"attached files are re-attached automatically — or reopen a document and keep "
+"reading. Press **Delete** on any item to remove it, or clear everything at "
+"once.\n"
+"*   **Recent Documents in the Reader**: Pressing **D** in the Command Layer "
+"now shows your recently read documents first. Pick one to continue from the "
+"page you were on — even when the OCR already finished — or press **Open "
+"File...** (`Ctrl + O`) to browse as usual.\n"
+"*   **Push to Talk for Live Assistant**: Take full control of your live "
+"conversations! Enable **Push to Talk** in the new Live Assistant settings "
+"tab and assign any key — or even a lone modifier like `Left Ctrl` — to talk. "
+"Hold the key to speak and release it when you're done, with a short beep on "
+"each press and release. A matching toggle also appears right in the Live "
+"Assistant window, so you can switch between push-to-talk and open-mic mode "
+"without leaving the conversation.\n"
+"*   **Gemini 2.5 Flash Native Audio**: The Live Assistant now supports "
+"Gemini 2.5 Flash's native audio model (`gemini-2.5-flash-native-audio-"
+"preview-12-2025`) for low-latency, natural voice conversations. You can "
+"switch to it from **Settings → Advanced Model Routing → Live Assistant Model "
+"(Gemini only)**, or keep \"Auto\" to stay on the recommended model.\n"
+"*   **Settings Backup & Restore**: Added a powerful backup and restore "
+"system in the **Advanced** tab! You can now save all of your add-on settings "
+"— including API keys, models, custom prompts, and preferences — into a "
+"single JSON file, and restore them perfectly at any time, on any machine, or "
+"after reinstalling NVDA. When backing up, you choose what to include: "
+"**Everything** (settings, custom labels, OCR progress, and history) or "
+"**Settings Only**.\n"
+"*   **Direct Text & HTML Reading**: The Document Reader can now open plain "
+"text (`.txt`) and HTML (`.html`, `.htm`) files directly! It automatically "
+"detects the file encoding, strips scripts and formatting clutter, and "
+"intelligently splits the content into readable pages — even re-importing its "
+"own exported files while preserving page structure — so you can read them "
+"instantly with no OCR or AI processing!\n"
+"*   **Gemini Live TTS for the Document Reader**: The \"Generate Audio\" "
+"button now supports Gemini Live — a high-quality, natural-pace streaming "
+"text-to-speech engine! When Gemini is your active provider, you can choose "
+"between Standard TTS and Gemini Live right in the reader, and your selection "
+"is remembered for next time!\n"
+"*   **Custom Prompt Shortcuts**: You can now assign a shortcut key to any of "
+"your custom prompts right from the Prompt Manager! Give every prompt its own "
+"dedicated key or key combination to run it instantly, automatically "
+"capturing your current selection or context with zero extra steps!\n"
+"*   **Chat Message Navigation**: Review any conversation hands-free! Inside "
+"any chat window (Direct Chat, document chat, refine, and more), press `Alt + "
+"Down` to hear the next message and `Alt + Up` to hear the previous one — "
+"with clear \"You\" / \"AI\" prefixes and \"First message\" / \"Last "
+"message\" boundaries announced as you go.\n"
+"*   **Copy Chat Message (Alt + C)**: While reviewing a conversation with "
+"`Alt + Up/Down`, press `Alt + C` to copy the message you are currently on to "
+"the clipboard — respecting your Clean Markdown setting — with a spoken "
+"confirmation.\n"
+"*   **Direct Chat System Prompt**: The Direct Chat (`Shift+C`) now has its "
+"own editable system prompt — \"Direct Chat Instruction\" — that sets the "
+"assistant's persona and response language for every conversation. You can "
+"customize it from the Prompt Manager's Default Prompts tab.\n"
+"*   **Document Reader Cursor Page Navigation**: Reading multi-page documents "
+"just got smoother! In the Document Viewer, when your cursor reaches the last "
+"line of a page and you press `Down`, the reader automatically jumps to the "
+"next page. Pressing `Up` at the start of a page seamlessly takes you back to "
+"the previous one — no more manual page switching while reading!\n"
+"*   **New Quick Settings Toggles**: Copy AI responses to clipboard, Direct "
+"Output (no chat window), Clean Markdown in Chat, and Smart Swap can now be "
+"switched on and off instantly from the command layer's Quick Settings!\n"
+"*   **Live Assistant Settings Tab**: The Live Assistant now has its own "
+"dedicated settings tab! The \"Live Assistant: Direct Output (No Window)\" "
+"option moved here from the Connection tab, and the tab appears only when "
+"Google Gemini (or a Gemini-compatible Custom provider) is your active "
+"provider.\n"
 msgstr ""
-"## Zmiany w wersji 2026.08.06\n"
+"## Zmiany w wersji 2026.09.01\n"
 "\n"
-"*   **Etykietowanie w Eksploratorze interfejsu**: teraz można dodawać etykiety wprost do znalezionych elementów w Eksploratorze interfejsu. Doszedł przycisk „Dodaj etykietę\", a okno zostaje otwarte i utrzymuje fokus, więc kilka obiektów da się opisać jeden po drugim bez przerywania pracy.\n"
-"*   **Rozbudowana warstwa szybkich ustawień**: warstwa Vision Assistant (`Insert+Shift+V`) jest teraz trwała i w pełni interaktywna. Strzałkami góra i dół przechodzi się między szybkimi ustawieniami (dostawca, model, język odpowiedzi AI, model TTS), a strzałkami lewo i prawo od razu zmienia ich wartości, z krótkim komunikatem "
-"głosowym. Wybory działają natychmiast (łącznie z automatycznym włączeniem osobnego modelu dla zadania, jeśli jest potrzebny), a warstwa pozostaje aktywna przez cały czas konfiguracji.\n"
-"*   **Czat (`Shift+C`)**: nowe polecenie w warstwie. `Shift+C` otwiera okno czatu — czysty interfejs tekstowy do rozmowy z AI, bez potrzeby zaczynania od obrazu czy dokumentu.\n"
-"*   **Poprawne przywoływanie historii rozmowy**: naprawiony poważny błąd, przez który naciśnięcie `Spacji` w celu przywołania ostatniego wyniku gubiło dalszą historię rozmowy. Dodatek śledzi teraz całą rozmowę globalnie. Po zamknięciu okna i naciśnięciu `Spacji` wraca pełna historia wymiany. Działa dla czatu, analizy obrazu, rozmowy "
-"o dokumencie i tłumaczenia.\n"
-"*   **Opisy obrazów wplecione w tekst przy OCR**: doszła opcja, która przy OCR dokumentu wplata opis obrazu dokładnie tam, gdzie w dokumencie znajduje się ten obraz. Można ją przełączyć w ustawieniach OCR dodatku, w opcjach czytnika dokumentów przed wyodrębnieniem oraz na bieżąco w warstwie szybkich ustawień.\n"
-"*   **Tłumaczenie mowy (`Control+T`)**: nowa funkcja. Dyktujesz, a AI od razu tłumaczy wypowiedź i wpisuje ją jako tekst, zgodnie z ustawionym językiem źródłowym i docelowym.\n"
-"*   **Poprawki pobierania aktualizacji**: okno pobierania aktualizacji pokazuje teraz poprawnie postęp w procentach, a błąd, przez który po anulowaniu instalacji pojawiał się fantomowy komunikat „Pobieranie aktualizacji\", został naprawiony.\n"
-"*   **Poprawki pobierania eSpeak-NG**: doszedł postęp pobierania eSpeak-NG w procentach.\n"
-"*   **Odporność wsadowego OCR**: naprawiony błąd we wsadowym OCR plików PDF, przez który przetwarzanie zatrzymywało się, gdy aktywny klucz API wyczerpał limit w połowie pracy. Teraz dodatek sam przełącza się na kolejny dostępny klucz i kontynuuje.\n"
-"*   **Obsługa CAPTCHA obrazkowej**: doszła solidna obsługa rozwiązywania CAPTCHA z obrazu. Dodatek próbuje automatycznie rozwiązywać złożone zagadki obrazkowe w rodzaju hCaptcha i reCAPTCHA, co wyraźnie poprawia dostępność trudnych formularzy internetowych.\n"
-"*   **Przebudowana transkrypcja dźwięku**: moduł transkrypcji został napisany od nowa i obsługuje teraz zarówno pliki dźwiękowe, jak i wideo. Ma trzy tryby pracy: „Transkrybuj (język oryginału)\", „Transkrybuj i przetłumacz (język docelowy)\" oraz nowy „Zdubbinguj i przetłumacz (język docelowy)\" — ten ostatni dostępny wyłącznie w "
-"Gemini, tworzy przetłumaczoną ścieżkę głosową oryginalnej wypowiedzi.\n"
-"*   **Numery stron w czytniku dokumentów**: doszło ustawienie, które włącza i wyłącza numery stron oraz separatory w dokumentach wielostronicowych. Opcja jest w ustawieniach głównych i w warstwie szybkich ustawień. Działa zarówno przy eksporcie do pliku tekstowego i HTML, jak i w oknie „Pokaż sformatowane\", dzięki czemu połączone "
-"dokumenty czyta się bez przerw.\n"
-"*   **Gemini Live TTS bez limitu dla opisów wideo**: przy tworzeniu zsynchronizowanej narracji dźwiękowej (MP3) do filmów można teraz wybrać silnik głosu „Gemini Live TTS\". Korzysta on z Gemini Live API i tworzy wysokiej jakości audiodeskrypcję bez ograniczeń długości ani liczby znaków.\n"
-"*   **Modularyzacja kodu**: struktura dodatku została przebudowana z jednego pliku na architekturę wielomodułową, co ułatwia utrzymanie.\n"
-"*   **Przeprojektowane ustawienia**: okno ustawień zostało w całości przebudowane na nowoczesny układ z zakładkami zamiast grup. Porządek i nawigacja są wygodniejsze, a wszystkie dotychczasowe opcje zostają.\n"
-"*   **Globalny dziennik w osobnym pliku**: doszedł opcjonalny globalny dziennik pod nową zakładką ustawień „Zaawansowane\". Zapisuje zdarzenia, ruch do API i błędy ze wszystkich modułów dodatku do osobnego pliku (`vision_assistant.log`). Obsługuje poziomy szczegółowości (diagnostyka, informacje, ostrzeżenia, błędy) i automatyczne "
-"przechowywanie (od godziny do 90 dni), a plik można otworzyć lub wyczyścić wprost z ustawień. Bez wpływu na wydajność i bez zaśmiecania dziennika NVDA.\n"
-"*   **Postęp wysyłania do Gemini**: doszły komunikaty o postępie w procentach przy wysyłaniu dużych plików (wideo, dźwięk, dokumenty) do Google Gemini API."
+"*   **Historia (Control + H)**: warstwa poleceń zawiera teraz okno **Historii** (`Control + H`), które wypisuje wcześniejsze czaty i dokumenty, z filtrami Wszystko, Czaty i Dokumenty. Możesz otworzyć ponownie dowolny czat wraz z całą rozmową — załączone pliki dołączają się automatycznie — albo wrócić do dokumentu i czytać dalej. Naciśnij **Delete** na wybranej pozycji, aby ją usunąć, lub wyczyść wszystko naraz.\n"
+"*   **Ostatnie dokumenty w czytniku**: naciśnięcie **D** w warstwie poleceń pokazuje teraz najpierw ostatnio czytane dokumenty. Wybierz jeden, aby kontynuować od strony, na której skończyłeś — nawet gdy OCR już się zakończył — albo naciśnij **Otwórz plik...** (`Ctrl + O`), aby przeglądać jak dotąd.\n"
+"*   **Naciśnij i mów w asystencie na żywo**: przejmij pełną kontrolę nad rozmowami na żywo. Włącz opcję **Naciśnij i mów** w nowej karcie ustawień asystenta na żywo i przypisz dowolny klawisz — nawet sam modyfikator, taki jak `lewy Ctrl`. Przytrzymaj klawisz, aby mówić, i zwolnij go po zakończeniu; każdemu naciśnięciu i zwolnieniu towarzyszy krótki sygnał. Odpowiedni przełącznik pojawia się też w samym oknie asystenta, więc możesz przechodzić między trybem naciśnij i mów a otwartym mikrofonem bez opuszczania rozmowy.\n"
+"*   **Gemini 2.5 Flash z natywnym dźwiękiem**: asystent na żywo obsługuje teraz model natywnego dźwięku Gemini 2.5 Flash (`gemini-2.5-flash-native-audio-preview-12-2025`), zapewniający naturalne rozmowy głosowe o małym opóźnieniu. Możesz go wybrać w **Ustawieniach → Zaawansowane kierowanie modeli → Model asystenta na żywo (tylko Gemini)** albo zostawić \"Auto\", aby korzystać z modelu zalecanego.\n"
+"*   **Kopia zapasowa i przywracanie ustawień**: w karcie **Zaawansowane** pojawił się rozbudowany system kopii zapasowych. Możesz zapisać wszystkie ustawienia dodatku — w tym klucze API, modele, polecenia niestandardowe i preferencje — do jednego pliku JSON, a potem odtworzyć je w dowolnej chwili, na dowolnym komputerze albo po ponownej instalacji NVDA. Przy tworzeniu kopii wybierasz jej zakres: **Wszystko** (ustawienia, własne etykiety, postęp OCR i historia) albo **Tylko ustawienia**.\n"
+"*   **Bezpośrednie czytanie plików tekstowych i HTML**: czytnik dokumentów otwiera teraz wprost pliki tekstowe (`.txt`) oraz HTML (`.html`, `.htm`). Automatycznie rozpoznaje kodowanie pliku, usuwa skrypty i zbędne formatowanie oraz dzieli treść na czytelne strony — potrafi też ponownie wczytać własne wyeksportowane pliki z zachowaniem podziału na strony — więc przeczytasz je od razu, bez OCR i bez przetwarzania przez AI.\n"
+"*   **Gemini Live jako synteza mowy w czytniku**: przycisk \"Generuj dźwięk\" obsługuje teraz Gemini Live, czyli strumieniową syntezę mowy o wysokiej jakości i naturalnym tempie. Gdy aktywnym dostawcą jest Gemini, możesz wybrać w czytniku między standardową syntezą a Gemini Live, a wybór zostanie zapamiętany.\n"
+"*   **Skróty klawiszowe poleceń niestandardowych**: każdemu własnemu poleceniu możesz teraz przypisać skrót klawiszowy bezpośrednio w menedżerze poleceń. Nadaj poleceniu własny klawisz lub kombinację, aby uruchamiać je natychmiast, automatycznie przechwytując bieżące zaznaczenie lub kontekst, bez żadnych dodatkowych kroków.\n"
+"*   **Nawigacja po wiadomościach czatu**: przejrzyj każdą rozmowę bez użycia rąk. W dowolnym oknie czatu (czat bezpośredni, czat z dokumentem, dopracowywanie i inne) naciśnij `Alt + strzałka w dół`, aby usłyszeć następną wiadomość, a `Alt + strzałka w górę`, aby usłyszeć poprzednią — z wyraźnymi przedrostkami \"Ty\" i \"AI\" oraz zapowiedzią granic \"Pierwsza wiadomość\" i \"Ostatnia wiadomość\".\n"
+"*   **Kopiowanie wiadomości czatu (Alt + C)**: przeglądając rozmowę klawiszami `Alt + strzałki`, naciśnij `Alt + C`, aby skopiować bieżącą wiadomość do schowka — z uwzględnieniem ustawienia czyszczenia znaczników Markdown — wraz z potwierdzeniem głosowym.\n"
+"*   **Instrukcja czatu bezpośredniego**: czat bezpośredni (`Shift+C`) ma teraz własną, edytowalną instrukcję systemową — \"Instrukcja czatu bezpośredniego\" — która ustala osobowość asystenta i język odpowiedzi dla każdej rozmowy. Możesz ją zmienić w karcie poleceń domyślnych w menedżerze poleceń.\n"
+"*   **Przechodzenie między stronami kursorem w czytniku**: czytanie dokumentów wielostronicowych jest płynniejsze. Gdy w podglądzie dokumentu kursor dojdzie do ostatniego wiersza strony i naciśniesz `strzałkę w dół`, czytnik automatycznie przejdzie do następnej strony. Naciśnięcie `strzałki w górę` na początku strony wraca do poprzedniej — koniec z ręcznym przełączaniem stron podczas czytania.\n"
+"*   **Nowe przełączniki w szybkich ustawieniach**: kopiowanie odpowiedzi AI do schowka, wyjście bezpośrednie (bez okna czatu), czyszczenie znaczników Markdown w czacie oraz inteligentna zamiana dają się teraz włączać i wyłączać natychmiast z szybkich ustawień w warstwie poleceń.\n"
+"*   **Karta ustawień asystenta na żywo**: asystent na żywo ma teraz własną kartę ustawień. Opcja \"Asystent na żywo: wyjście bezpośrednie (bez okna)\" przeniosła się tu z karty połączenia, a sama karta pojawia się tylko wtedy, gdy aktywnym dostawcą jest Google Gemini lub zgodny z Gemini dostawca niestandardowy.\n"
+
+
+#~ msgid "Custom: "
+#~ msgstr "Niestandardowe: "
+
+#~ msgid ""
+#~ "## Changes for 2026.08.06\n"
+#~ "\n"
+#~ "*   **UI Explorer Labeling**: You can now add labels directly to found "
+#~ "elements inside the UI Explorer! A new \"Add Label\" button has been "
+#~ "added, and the interface smartly stays open and preserves focus so you "
+#~ "can rapidly label multiple objects without interruption.\n"
+#~ "*   **Quick Settings Layer Enhancement**: The Vision Assistant layer "
+#~ "(`Insert+Shift+V`) is now persistent and highly interactive! You can use "
+#~ "`Up/Down` arrows to navigate between quick settings (Provider, Model, AI "
+#~ "Response Language, TTS Model) and `Left/Right` arrows to instantly change "
+#~ "their values with smart, concise voice feedback. Your selections take "
+#~ "effect immediately (including auto-enabling advanced routing when "
+#~ "necessary), and the layer stays alive while you configure.\n"
+#~ "*   **Direct Chat (`Shift+C`)**: Added a new command to the layer! Press "
+#~ "`Shift+C` to instantly open a \"Direct Chat\" window. This provides a "
+#~ "clean, text-based conversational interface with the AI right away, "
+#~ "without needing an image or document as a starting point.\n"
+#~ "*   **Flawless Chat History Recall**: Fixed a major bug where pressing "
+#~ "`Space` to recall the last result would lose your subsequent chat "
+#~ "history. Now, the add-on globally tracks your conversation. If you chat, "
+#~ "close the dialog, and press `Space` to recall it, your entire back-and-"
+#~ "forth history is perfectly restored! Works for Direct Chat, Vision "
+#~ "Analysis, Document Chat, and Translation.\n"
+#~ "*   **Inline Image Descriptions in OCR**: Added an optional feature to "
+#~ "describe images inline during document OCR. You can toggle this setting "
+#~ "in the add-on's OCR settings, within the Document Reader options before "
+#~ "extraction, and quickly on-the-fly via the Quick Settings layer.\n"
+#~ "*   **Voice Translation (`Control+T`)**: Added a powerful new feature! "
+#~ "Dictate speech and instantly translate and type it using AI based on your "
+#~ "configured source and target languages.\n"
+#~ "*   **Update Downloader Improvements**: The update download dialog now "
+#~ "correctly displays download progress in percentages, and a bug where a "
+#~ "phantom \"Downloading update\" message appeared upon canceling the "
+#~ "installation has been fixed.\n"
+#~ "*   **eSpeak-NG Downloader Improvements**: Added percentage progress "
+#~ "tracking for eSpeak-NG downloads.\n"
+#~ "*   **Batch OCR Resilience**: Fixed an issue in batch PDF OCR where the "
+#~ "process would halt if the active API key reached its quota midway; it now "
+#~ "automatically switches to the next available key and resumes the "
+#~ "process.\n"
+#~ "*   **Visual Captcha Support**: Added robust support for visual captcha "
+#~ "solving. It attempts to automatically solve complex image challenges like "
+#~ "hCaptcha and reCAPTCHA, significantly enhancing accessibility on "
+#~ "challenging web forms.\n"
+#~ "*   **Audio Transcriber Overhaul**: The Audio Transcriber module has been "
+#~ "completely rebuilt and now supports both audio and video files. It "
+#~ "features 3 distinct operation modes: \"Transcribe (Original Language)\", "
+#~ "\"Transcribe and Translate (Target Language)\", and a new powerful \"Dub "
+#~ "and Translate (Target Language)\" option (exclusive to Gemini) that "
+#~ "generates a translated audio dub of the original speech.\n"
+#~ "*   **Optional Page Numbers in Document Reader**: Added a new setting to "
+#~ "toggle the inclusion of page numbers and separators in multi-page "
+#~ "document outputs. You can easily manage this option from the main "
+#~ "settings or toggle it on-the-fly via the Quick Settings layer. This "
+#~ "feature applies to both text/HTML file exports and the inline \"View "
+#~ "Formatted\" window, allowing you to read combined documents seamlessly.\n"
+#~ "*   **Unlimited Gemini Live TTS for Video Descriptions**: You can now "
+#~ "select \"Gemini Live TTS\" as the voice engine when generating "
+#~ "Synchronized Audio Narration (MP3) for videos. This utilizes the Gemini "
+#~ "Live API to synthesize high-quality audio descriptions without any "
+#~ "character limits or length restrictions.\n"
+#~ "*   **Codebase Modularization**: Refactored the add-on structure from a "
+#~ "single file to a multi-file modular architecture for improved "
+#~ "maintainability.\n"
+#~ "*   **Settings UI Redesign**: Completely redesigned the Settings dialog "
+#~ "to use a modern, tab-based interface instead of a grouped layout, "
+#~ "providing better organization and easier navigation while keeping all "
+#~ "existing options.\n"
+#~ "*   **Global & Dedicated File Logging**: Added an optional global file "
+#~ "logging system under the new \"Advanced\" settings tab. Automatically "
+#~ "captures operational events, API traffic, and errors across all add-on "
+#~ "modules into a dedicated file (`vision_assistant.log`). Supports "
+#~ "configurable log verbosity levels (Debug, Info, Warning, Error), "
+#~ "automated retention periods (1 hour to 90 days), and direct log opening "
+#~ "or clearing from settings with zero performance impact or NVDA log "
+#~ "interference.\n"
+#~ "*   **Gemini Upload Progress Tracking**: Added real-time percentage "
+#~ "progress announcements when uploading large files (video, audio, "
+#~ "documents) to the Google Gemini API."
+#~ msgstr ""
+#~ "## Zmiany w wersji 2026.08.06\n"
+#~ "\n"
+#~ "*   **Etykietowanie w Eksploratorze interfejsu**: teraz można dodawać "
+#~ "etykiety wprost do znalezionych elementów w Eksploratorze interfejsu. "
+#~ "Doszedł przycisk „Dodaj etykietę\", a okno zostaje otwarte i utrzymuje "
+#~ "fokus, więc kilka obiektów da się opisać jeden po drugim bez przerywania "
+#~ "pracy.\n"
+#~ "*   **Rozbudowana warstwa szybkich ustawień**: warstwa Vision Assistant "
+#~ "(`Insert+Shift+V`) jest teraz trwała i w pełni interaktywna. Strzałkami "
+#~ "góra i dół przechodzi się między szybkimi ustawieniami (dostawca, model, "
+#~ "język odpowiedzi AI, model TTS), a strzałkami lewo i prawo od razu "
+#~ "zmienia ich wartości, z krótkim komunikatem głosowym. Wybory działają "
+#~ "natychmiast (łącznie z automatycznym włączeniem osobnego modelu dla "
+#~ "zadania, jeśli jest potrzebny), a warstwa pozostaje aktywna przez cały "
+#~ "czas konfiguracji.\n"
+#~ "*   **Czat (`Shift+C`)**: nowe polecenie w warstwie. `Shift+C` otwiera "
+#~ "okno czatu — czysty interfejs tekstowy do rozmowy z AI, bez potrzeby "
+#~ "zaczynania od obrazu czy dokumentu.\n"
+#~ "*   **Poprawne przywoływanie historii rozmowy**: naprawiony poważny błąd, "
+#~ "przez który naciśnięcie `Spacji` w celu przywołania ostatniego wyniku "
+#~ "gubiło dalszą historię rozmowy. Dodatek śledzi teraz całą rozmowę "
+#~ "globalnie. Po zamknięciu okna i naciśnięciu `Spacji` wraca pełna historia "
+#~ "wymiany. Działa dla czatu, analizy obrazu, rozmowy o dokumencie i "
+#~ "tłumaczenia.\n"
+#~ "*   **Opisy obrazów wplecione w tekst przy OCR**: doszła opcja, która "
+#~ "przy OCR dokumentu wplata opis obrazu dokładnie tam, gdzie w dokumencie "
+#~ "znajduje się ten obraz. Można ją przełączyć w ustawieniach OCR dodatku, w "
+#~ "opcjach czytnika dokumentów przed wyodrębnieniem oraz na bieżąco w "
+#~ "warstwie szybkich ustawień.\n"
+#~ "*   **Tłumaczenie mowy (`Control+T`)**: nowa funkcja. Dyktujesz, a AI od "
+#~ "razu tłumaczy wypowiedź i wpisuje ją jako tekst, zgodnie z ustawionym "
+#~ "językiem źródłowym i docelowym.\n"
+#~ "*   **Poprawki pobierania aktualizacji**: okno pobierania aktualizacji "
+#~ "pokazuje teraz poprawnie postęp w procentach, a błąd, przez który po "
+#~ "anulowaniu instalacji pojawiał się fantomowy komunikat „Pobieranie "
+#~ "aktualizacji\", został naprawiony.\n"
+#~ "*   **Poprawki pobierania eSpeak-NG**: doszedł postęp pobierania eSpeak-"
+#~ "NG w procentach.\n"
+#~ "*   **Odporność wsadowego OCR**: naprawiony błąd we wsadowym OCR plików "
+#~ "PDF, przez który przetwarzanie zatrzymywało się, gdy aktywny klucz API "
+#~ "wyczerpał limit w połowie pracy. Teraz dodatek sam przełącza się na "
+#~ "kolejny dostępny klucz i kontynuuje.\n"
+#~ "*   **Obsługa CAPTCHA obrazkowej**: doszła solidna obsługa rozwiązywania "
+#~ "CAPTCHA z obrazu. Dodatek próbuje automatycznie rozwiązywać złożone "
+#~ "zagadki obrazkowe w rodzaju hCaptcha i reCAPTCHA, co wyraźnie poprawia "
+#~ "dostępność trudnych formularzy internetowych.\n"
+#~ "*   **Przebudowana transkrypcja dźwięku**: moduł transkrypcji został "
+#~ "napisany od nowa i obsługuje teraz zarówno pliki dźwiękowe, jak i wideo. "
+#~ "Ma trzy tryby pracy: „Transkrybuj (język oryginału)\", „Transkrybuj i "
+#~ "przetłumacz (język docelowy)\" oraz nowy „Zdubbinguj i przetłumacz (język "
+#~ "docelowy)\" — ten ostatni dostępny wyłącznie w Gemini, tworzy "
+#~ "przetłumaczoną ścieżkę głosową oryginalnej wypowiedzi.\n"
+#~ "*   **Numery stron w czytniku dokumentów**: doszło ustawienie, które "
+#~ "włącza i wyłącza numery stron oraz separatory w dokumentach "
+#~ "wielostronicowych. Opcja jest w ustawieniach głównych i w warstwie "
+#~ "szybkich ustawień. Działa zarówno przy eksporcie do pliku tekstowego i "
+#~ "HTML, jak i w oknie „Pokaż sformatowane\", dzięki czemu połączone "
+#~ "dokumenty czyta się bez przerw.\n"
+#~ "*   **Gemini Live TTS bez limitu dla opisów wideo**: przy tworzeniu "
+#~ "zsynchronizowanej narracji dźwiękowej (MP3) do filmów można teraz wybrać "
+#~ "silnik głosu „Gemini Live TTS\". Korzysta on z Gemini Live API i tworzy "
+#~ "wysokiej jakości audiodeskrypcję bez ograniczeń długości ani liczby "
+#~ "znaków.\n"
+#~ "*   **Modularyzacja kodu**: struktura dodatku została przebudowana z "
+#~ "jednego pliku na architekturę wielomodułową, co ułatwia utrzymanie.\n"
+#~ "*   **Przeprojektowane ustawienia**: okno ustawień zostało w całości "
+#~ "przebudowane na nowoczesny układ z zakładkami zamiast grup. Porządek i "
+#~ "nawigacja są wygodniejsze, a wszystkie dotychczasowe opcje zostają.\n"
+#~ "*   **Globalny dziennik w osobnym pliku**: doszedł opcjonalny globalny "
+#~ "dziennik pod nową zakładką ustawień „Zaawansowane\". Zapisuje zdarzenia, "
+#~ "ruch do API i błędy ze wszystkich modułów dodatku do osobnego pliku "
+#~ "(`vision_assistant.log`). Obsługuje poziomy szczegółowości (diagnostyka, "
+#~ "informacje, ostrzeżenia, błędy) i automatyczne przechowywanie (od godziny "
+#~ "do 90 dni), a plik można otworzyć lub wyczyścić wprost z ustawień. Bez "
+#~ "wpływu na wydajność i bez zaśmiecania dziennika NVDA.\n"
+#~ "*   **Postęp wysyłania do Gemini**: doszły komunikaty o postępie w "
+#~ "procentach przy wysyłaniu dużych plików (wideo, dźwięk, dokumenty) do "
+#~ "Google Gemini API."
 
 #, python-brace-format
 #~ msgid "{name} Error"
 #~ msgstr "Błąd {name}"
 
-#~ msgid "The Screen Curtain is currently enabled. Please disable it (NVDA+Control+Escape) before using visual recognition features."
-#~ msgstr "Kurtyna ekranowa jest obecnie włączona. Wyłącz ją (NVDA+Control+Escape) przed użyciem funkcji rozpoznawania obrazu."
+#~ msgid ""
+#~ "The Screen Curtain is currently enabled. Please disable it "
+#~ "(NVDA+Control+Escape) before using visual recognition features."
+#~ msgstr ""
+#~ "Kurtyna ekranowa jest obecnie włączona. Wyłącz ją (NVDA+Control+Escape) "
+#~ "przed użyciem funkcji rozpoznawania obrazu."
 
 #~ msgid "Downloading update..."
 #~ msgstr "Pobieranie aktualizacji..."
@@ -3897,14 +4720,20 @@ msgstr ""
 #~ msgstr "Transkrybuje wybrany plik audio."
 
 #~ msgid "Analyzes a YouTube, Instagram, Twitter or TikTok video URL."
-#~ msgstr "Analizuje adres URL wideo z YouTube, Instagrama, Twittera lub TikToka."
+#~ msgstr ""
+#~ "Analizuje adres URL wideo z YouTube, Instagrama, Twittera lub TikToka."
 
 #~ msgid "Reports the number of banned Gemini API keys and their unban time."
-#~ msgstr "Podaje liczbę zablokowanych kluczy API Gemini i czas ich odblokowania."
+#~ msgstr ""
+#~ "Podaje liczbę zablokowanych kluczy API Gemini i czas ich odblokowania."
 
 #, python-brace-format
-#~ msgid "{count} key(s) exceeded daily quota for model {model} (resets around {time_str})"
-#~ msgstr "Klucze, które przekroczyły dzienny limit dla modelu {model}: {count} (reset około {time_str})"
+#~ msgid ""
+#~ "{count} key(s) exceeded daily quota for model {model} (resets around "
+#~ "{time_str})"
+#~ msgstr ""
+#~ "Klucze, które przekroczyły dzienny limit dla modelu {model}: {count} "
+#~ "(reset około {time_str})"
 
 #~ msgid "Performs smart actions on a selected image or PDF file."
 #~ msgstr "Wykonuje inteligentne akcje na wybranym pliku obrazu lub PDF."
@@ -3914,8 +4743,10 @@ msgstr ""
 #~ msgstr "Analizowanie porcji {start}–{end}..."
 
 #, python-brace-format
-#~ msgid "Failed to upload document batch {start}-{end} after multiple attempts."
-#~ msgstr "Nie udało się przesłać wsadu dokumentów {start}-{end} po kilku próbach."
+#~ msgid ""
+#~ "Failed to upload document batch {start}-{end} after multiple attempts."
+#~ msgstr ""
+#~ "Nie udało się przesłać wsadu dokumentów {start}-{end} po kilku próbach."
 
 #~ msgid ""
 #~ "Screen recording requires ffmpeg (approximately 70MB download).\n"
@@ -3994,43 +4825,119 @@ msgstr ""
 #~ msgid ""
 #~ "## Changes for 2026.07.15\n"
 #~ "\n"
-#~ "*   **Intelligent API Model Filtering**: Complete overhaul of the model filtering system to use a pure blacklist approach instead of whitelists. Added stronger filtering keywords (`embedding`, `bison`, `gecko`, `audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, `computer`) to ensure the main chat model dropdown "
-#~ "remains perfectly clean and future-proof, while keeping all specialized models accessible in the Advanced Routing section.\n"
-#~ "*   **Advanced Routing Search**: All Advanced Model Routing dropdowns (OCR, STT, TTS, Operator, Video, Live) and the eSpeak Variant selector are now fully searchable. You can quickly type to filter and find your desired model or variant.\n"
+#~ "*   **Intelligent API Model Filtering**: Complete overhaul of the model "
+#~ "filtering system to use a pure blacklist approach instead of whitelists. "
+#~ "Added stronger filtering keywords (`embedding`, `bison`, `gecko`, "
+#~ "`audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, "
+#~ "`computer`) to ensure the main chat model dropdown remains perfectly "
+#~ "clean and future-proof, while keeping all specialized models accessible "
+#~ "in the Advanced Routing section.\n"
+#~ "*   **Advanced Routing Search**: All Advanced Model Routing dropdowns "
+#~ "(OCR, STT, TTS, Operator, Video, Live) and the eSpeak Variant selector "
+#~ "are now fully searchable. You can quickly type to filter and find your "
+#~ "desired model or variant.\n"
 #~ "*   **New Command Layer Shortcuts**:\n"
-#~ "    *   **Settings (`Alt + S`)**: Instantly opens the Vision Assistant Pro settings dialog.\n"
-#~ "    *   **Quota Exhausted Keys Report (`Alt + Q`)**: Reports the exact number of Gemini API keys that have exceeded their daily quota, identifying which specific model they are exhausted on, and announces their exact reset time.\n"
-#~ "    *   **Routing Audit (`Alt + M`)**: Audits and announces your current Advanced Routing configuration, reading out which models are actively selected for specialized tasks (skipping default settings).\n"
-#~ "*   **Video Analyzer Complete Overhaul**: The Video Analyzer has been completely transformed! Previously, it only provided a basic description of online videos. Now, it is a comprehensive video processing suite tailored for blind users:\n"
-#~ "    *   **Local Screen Recording (`Control+V`)**: You can now record silent videos directly from your screen. The AI will analyze the recorded segment and provide a highly detailed description of the scene, layout, and actions.\n"
-#~ "    *   **Audio Description Generation (SRT)**: The add-on can now generate highly detailed Audio Description scripts (in standard SRT format) for videos, complete with smart gap-timing to intelligently anchor descriptions to natural pauses in the audio track, and verbatim OCR for any on-screen text.\n"
-#~ "    *   **Synchronized Audio Narration (MP3 Export)**: Beyond text-based subtitles, the add-on can synthesize the Audio Description into speech, automatically mix it with the video's original audio track, apply audio ducking (lowering background volume during descriptions), and export the final synchronized result as an MP3 "
-#~ "file!\n"
-#~ "    *   **Smart Video File Action**: If you focus on a local video file and press the video shortcut, the add-on will automatically detect it and process the file directly.\n"
-#~ "    *   **Advanced Character Tracking**: The AI now performs a character extraction pre-pass. It builds a global character dictionary and tracks characters accurately segment-by-segment without confusing identities.\n"
-#~ "    *   **Video Analysis Configuration**: Added new settings to control SRT chunk sizes, character subtitling, and disclaimers.\n"
-#~ "    *   **Extended Model Routing**: You can now explicitly select specialized video models (`gemini_video_model`, `custom_video_model`) in the Advanced Model Routing settings.\n"
-#~ "*   **Smart API Quota Management**: Enhanced handling of 429 (Daily Limit) errors by tracking quotas per-model. If a key hits its daily limit on one model, it is intelligently quarantined for that specific model only, leaving the key available for use with other models."
+#~ "    *   **Settings (`Alt + S`)**: Instantly opens the Vision Assistant "
+#~ "Pro settings dialog.\n"
+#~ "    *   **Quota Exhausted Keys Report (`Alt + Q`)**: Reports the exact "
+#~ "number of Gemini API keys that have exceeded their daily quota, "
+#~ "identifying which specific model they are exhausted on, and announces "
+#~ "their exact reset time.\n"
+#~ "    *   **Routing Audit (`Alt + M`)**: Audits and announces your current "
+#~ "Advanced Routing configuration, reading out which models are actively "
+#~ "selected for specialized tasks (skipping default settings).\n"
+#~ "*   **Video Analyzer Complete Overhaul**: The Video Analyzer has been "
+#~ "completely transformed! Previously, it only provided a basic description "
+#~ "of online videos. Now, it is a comprehensive video processing suite "
+#~ "tailored for blind users:\n"
+#~ "    *   **Local Screen Recording (`Control+V`)**: You can now record "
+#~ "silent videos directly from your screen. The AI will analyze the recorded "
+#~ "segment and provide a highly detailed description of the scene, layout, "
+#~ "and actions.\n"
+#~ "    *   **Audio Description Generation (SRT)**: The add-on can now "
+#~ "generate highly detailed Audio Description scripts (in standard SRT "
+#~ "format) for videos, complete with smart gap-timing to intelligently "
+#~ "anchor descriptions to natural pauses in the audio track, and verbatim "
+#~ "OCR for any on-screen text.\n"
+#~ "    *   **Synchronized Audio Narration (MP3 Export)**: Beyond text-based "
+#~ "subtitles, the add-on can synthesize the Audio Description into speech, "
+#~ "automatically mix it with the video's original audio track, apply audio "
+#~ "ducking (lowering background volume during descriptions), and export the "
+#~ "final synchronized result as an MP3 file!\n"
+#~ "    *   **Smart Video File Action**: If you focus on a local video file "
+#~ "and press the video shortcut, the add-on will automatically detect it and "
+#~ "process the file directly.\n"
+#~ "    *   **Advanced Character Tracking**: The AI now performs a character "
+#~ "extraction pre-pass. It builds a global character dictionary and tracks "
+#~ "characters accurately segment-by-segment without confusing identities.\n"
+#~ "    *   **Video Analysis Configuration**: Added new settings to control "
+#~ "SRT chunk sizes, character subtitling, and disclaimers.\n"
+#~ "    *   **Extended Model Routing**: You can now explicitly select "
+#~ "specialized video models (`gemini_video_model`, `custom_video_model`) in "
+#~ "the Advanced Model Routing settings.\n"
+#~ "*   **Smart API Quota Management**: Enhanced handling of 429 (Daily "
+#~ "Limit) errors by tracking quotas per-model. If a key hits its daily limit "
+#~ "on one model, it is intelligently quarantined for that specific model "
+#~ "only, leaving the key available for use with other models."
 #~ msgstr ""
 #~ "## Zmiany w wersji 2026.07.15\n"
 #~ "\n"
-#~ "*   **Filtrowanie modeli API**: Całkowita przebudowa systemu filtrowania modeli na podejście czystej czarnej listy zamiast białych list. Dodano mocniejsze słowa kluczowe filtrowania (`embedding`, `bison`, `gecko`, `audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, `computer`), aby lista rozwijana głównego modelu "
-#~ "czatu pozostawała czysta i odporna na przyszłe zmiany, przy jednoczesnym zachowaniu dostępu do wszystkich wyspecjalizowanych modeli w sekcji osobnego modelu dla każdego zadania.\n"
-#~ "*   **Wyszukiwanie w przydziale modeli**: Wszystkie listy rozwijane osobnego modelu dla każdego zadania (OCR, STT, TTS, Operator, Wideo, Asystent głosowy) oraz selektor wariantu eSpeak są teraz w pełni przeszukiwalne. Można szybko wpisać frazę, aby przefiltrować i znaleźć żądany model lub wariant.\n"
+#~ "*   **Filtrowanie modeli API**: Całkowita przebudowa systemu filtrowania "
+#~ "modeli na podejście czystej czarnej listy zamiast białych list. Dodano "
+#~ "mocniejsze słowa kluczowe filtrowania (`embedding`, `bison`, `gecko`, "
+#~ "`audio`, `realtime`, `babbage`, `moderation`, `deep`, `antigravity`, "
+#~ "`computer`), aby lista rozwijana głównego modelu czatu pozostawała czysta "
+#~ "i odporna na przyszłe zmiany, przy jednoczesnym zachowaniu dostępu do "
+#~ "wszystkich wyspecjalizowanych modeli w sekcji osobnego modelu dla każdego "
+#~ "zadania.\n"
+#~ "*   **Wyszukiwanie w przydziale modeli**: Wszystkie listy rozwijane "
+#~ "osobnego modelu dla każdego zadania (OCR, STT, TTS, Operator, Wideo, "
+#~ "Asystent głosowy) oraz selektor wariantu eSpeak są teraz w pełni "
+#~ "przeszukiwalne. Można szybko wpisać frazę, aby przefiltrować i znaleźć "
+#~ "żądany model lub wariant.\n"
 #~ "*   **Nowe skróty warstwy poleceń**:\n"
-#~ "    *   **Ustawienia (`Alt + S`)**: Natychmiast otwiera okno ustawień Vision Assistant Pro.\n"
-#~ "    *   **Raport kluczy z wyczerpanym limitem (`Alt + Q`)**: Podaje dokładną liczbę kluczy API Gemini, które przekroczyły dzienny limit, wskazuje, na którym modelu się wyczerpały, i ogłasza dokładny czas ich zresetowania.\n"
-#~ "    *   **Audyt przydziału (`Alt + M`)**: Sprawdza i ogłasza bieżącą konfigurację osobnego modelu dla każdego zadania, odczytując, które modele są aktywnie wybrane do wyspecjalizowanych zadań (pomijając ustawienia domyślne).\n"
-#~ "*   **Całkowita przebudowa analizatora wideo**: Analizator wideo, który wcześniej udostępniał tylko podstawowy opis filmów online, robi teraz znacznie więcej:\n"
-#~ "    *   **Lokalne nagrywanie ekranu (`Control+V`)**: Można teraz nagrywać bezgłośne filmy bezpośrednio z ekranu. AI przeanalizuje nagrany fragment i poda szczegółowy opis sceny, układu i akcji.\n"
-#~ "    *   **Generowanie audiodeskrypcji (SRT)**: Dodatek potrafi teraz generować szczegółowe skrypty audiodeskrypcji (w standardowym formacie SRT) dla filmów, wraz z dopasowaniem czasu do przerw, aby zakotwiczyć opisy w naturalnych pauzach ścieżki dźwiękowej, oraz dosłownym OCR tekstu na ekranie.\n"
-#~ "    *   **Zsynchronizowana narracja dźwiękowa (eksport MP3)**: Poza napisami tekstowymi dodatek potrafi zsyntetyzować audiodeskrypcję na mowę, automatycznie zmiksować ją z oryginalną ścieżką dźwiękową filmu, zastosować przyciszanie tła (obniżenie głośności tła podczas opisów) i wyeksportować gotowy zsynchronizowany wynik jako "
-#~ "plik MP3!\n"
-#~ "    *   **Akcja na pliku wideo**: Jeśli ustawisz fokus na lokalnym pliku wideo i naciśniesz skrót wideo, dodatek automatycznie go wykryje i przetworzy plik bezpośrednio.\n"
-#~ "    *   **Śledzenie postaci**: AI wykonuje teraz wstępne przejście wyodrębniające postacie. Buduje globalny słownik postaci i śledzi je dokładnie segment po segmencie, nie myląc tożsamości.\n"
-#~ "    *   **Konfiguracja analizy wideo**: Dodano nowe ustawienia sterujące rozmiarem fragmentów SRT, napisami postaci i zastrzeżeniami.\n"
-#~ "    *   **Rozszerzony przydział modeli**: Można teraz jawnie wybrać wyspecjalizowane modele wideo (`gemini_video_model`, `custom_video_model`) w ustawieniach osobnego modelu dla każdego zadania.\n"
-#~ "*   **Zarządzanie limitami API**: Ulepszona obsługa błędów 429 (dzienny limit) przez śledzenie limitów per model. Jeśli klucz osiągnie dzienny limit na jednym modelu, zostaje odizolowany tylko dla tego konkretnego modelu, pozostając dostępny dla innych modeli."
+#~ "    *   **Ustawienia (`Alt + S`)**: Natychmiast otwiera okno ustawień "
+#~ "Vision Assistant Pro.\n"
+#~ "    *   **Raport kluczy z wyczerpanym limitem (`Alt + Q`)**: Podaje "
+#~ "dokładną liczbę kluczy API Gemini, które przekroczyły dzienny limit, "
+#~ "wskazuje, na którym modelu się wyczerpały, i ogłasza dokładny czas ich "
+#~ "zresetowania.\n"
+#~ "    *   **Audyt przydziału (`Alt + M`)**: Sprawdza i ogłasza bieżącą "
+#~ "konfigurację osobnego modelu dla każdego zadania, odczytując, które "
+#~ "modele są aktywnie wybrane do wyspecjalizowanych zadań (pomijając "
+#~ "ustawienia domyślne).\n"
+#~ "*   **Całkowita przebudowa analizatora wideo**: Analizator wideo, który "
+#~ "wcześniej udostępniał tylko podstawowy opis filmów online, robi teraz "
+#~ "znacznie więcej:\n"
+#~ "    *   **Lokalne nagrywanie ekranu (`Control+V`)**: Można teraz nagrywać "
+#~ "bezgłośne filmy bezpośrednio z ekranu. AI przeanalizuje nagrany fragment "
+#~ "i poda szczegółowy opis sceny, układu i akcji.\n"
+#~ "    *   **Generowanie audiodeskrypcji (SRT)**: Dodatek potrafi teraz "
+#~ "generować szczegółowe skrypty audiodeskrypcji (w standardowym formacie "
+#~ "SRT) dla filmów, wraz z dopasowaniem czasu do przerw, aby zakotwiczyć "
+#~ "opisy w naturalnych pauzach ścieżki dźwiękowej, oraz dosłownym OCR tekstu "
+#~ "na ekranie.\n"
+#~ "    *   **Zsynchronizowana narracja dźwiękowa (eksport MP3)**: Poza "
+#~ "napisami tekstowymi dodatek potrafi zsyntetyzować audiodeskrypcję na "
+#~ "mowę, automatycznie zmiksować ją z oryginalną ścieżką dźwiękową filmu, "
+#~ "zastosować przyciszanie tła (obniżenie głośności tła podczas opisów) i "
+#~ "wyeksportować gotowy zsynchronizowany wynik jako plik MP3!\n"
+#~ "    *   **Akcja na pliku wideo**: Jeśli ustawisz fokus na lokalnym pliku "
+#~ "wideo i naciśniesz skrót wideo, dodatek automatycznie go wykryje i "
+#~ "przetworzy plik bezpośrednio.\n"
+#~ "    *   **Śledzenie postaci**: AI wykonuje teraz wstępne przejście "
+#~ "wyodrębniające postacie. Buduje globalny słownik postaci i śledzi je "
+#~ "dokładnie segment po segmencie, nie myląc tożsamości.\n"
+#~ "    *   **Konfiguracja analizy wideo**: Dodano nowe ustawienia sterujące "
+#~ "rozmiarem fragmentów SRT, napisami postaci i zastrzeżeniami.\n"
+#~ "    *   **Rozszerzony przydział modeli**: Można teraz jawnie wybrać "
+#~ "wyspecjalizowane modele wideo (`gemini_video_model`, "
+#~ "`custom_video_model`) w ustawieniach osobnego modelu dla każdego "
+#~ "zadania.\n"
+#~ "*   **Zarządzanie limitami API**: Ulepszona obsługa błędów 429 (dzienny "
+#~ "limit) przez śledzenie limitów per model. Jeśli klucz osiągnie dzienny "
+#~ "limit na jednym modelu, zostaje odizolowany tylko dla tego konkretnego "
+#~ "modelu, pozostając dostępny dla innych modeli."
 
 #~ msgid "YouTube / Instagram / Twitter / TikTok Analysis"
 #~ msgstr "Analiza YouTube / Instagram / Twitter / TikTok"
@@ -4041,22 +4948,56 @@ msgstr ""
 #~ msgid ""
 #~ "## Changes for 6.5.0\n"
 #~ "\n"
-#~ "*   **Live Assistant**: Added a real-time voice and screen assistant feature, available exclusively for the Google Gemini provider (or Gemini-compatible custom providers). Includes interactive voice and thinking depth customization directly inside the dialog, with automatic reconnection upon changing settings.\n"
-#~ "*   **MiniMax AI Provider**: Integrated MiniMax as a peer provider with full multimodal support (chat, vision, OCR), custom TTS using over 300+ dynamic voices, and automatic stripping of reasoning blocks (e.g., `<think>...</think>`) from outputs.\n"
-#~ "*   **Document Viewer Translation**: Corrected a silent translation failure for non-English NVDA users by ensuring the standard 2-letter language code is sent to Google Translate instead of the localized language name.\n"
-#~ "*   **PDF Batch Scan Retry**: Implemented a highly optimized, separate, and silent retry logic for PDF document batch scanning to prevent redundant uploads and avoid disruptive error popups during retries.\n"
-#~ "*   **Document Viewer Status**: Fixed a bug where the plugin's overall status (checked via `I`) remained stuck on \"Batch Processing Started\" during long document scans.\n"
-#~ "*   **Resolved Threading Crash**: Fixed a severe `IsMain() failed in wxTimerImpl` thread assertion crash when opening documents from a background thread by transitioning the GUI callback queue to `wx.CallAfter`."
+#~ "*   **Live Assistant**: Added a real-time voice and screen assistant "
+#~ "feature, available exclusively for the Google Gemini provider (or Gemini-"
+#~ "compatible custom providers). Includes interactive voice and thinking "
+#~ "depth customization directly inside the dialog, with automatic "
+#~ "reconnection upon changing settings.\n"
+#~ "*   **MiniMax AI Provider**: Integrated MiniMax as a peer provider with "
+#~ "full multimodal support (chat, vision, OCR), custom TTS using over 300+ "
+#~ "dynamic voices, and automatic stripping of reasoning blocks (e.g., "
+#~ "`<think>...</think>`) from outputs.\n"
+#~ "*   **Document Viewer Translation**: Corrected a silent translation "
+#~ "failure for non-English NVDA users by ensuring the standard 2-letter "
+#~ "language code is sent to Google Translate instead of the localized "
+#~ "language name.\n"
+#~ "*   **PDF Batch Scan Retry**: Implemented a highly optimized, separate, "
+#~ "and silent retry logic for PDF document batch scanning to prevent "
+#~ "redundant uploads and avoid disruptive error popups during retries.\n"
+#~ "*   **Document Viewer Status**: Fixed a bug where the plugin's overall "
+#~ "status (checked via `I`) remained stuck on \"Batch Processing Started\" "
+#~ "during long document scans.\n"
+#~ "*   **Resolved Threading Crash**: Fixed a severe `IsMain() failed in "
+#~ "wxTimerImpl` thread assertion crash when opening documents from a "
+#~ "background thread by transitioning the GUI callback queue to "
+#~ "`wx.CallAfter`."
 #~ msgstr ""
 #~ "## Zmiany w wersji 6.5.0\n"
 #~ "\n"
-#~ "*   **Asystent głosowy**: Dodano funkcję asystenta głosowego i ekranowego w czasie rzeczywistym, dostępną wyłącznie dla dostawcy Google Gemini (lub zgodnych z Gemini dostawców niestandardowych). Obejmuje interaktywną zmianę głosu i głębi myślenia bezpośrednio w oknie dialogowym, z automatycznym ponownym połączeniem po zmianie "
-#~ "ustawień.\n"
-#~ "*   **Dostawca MiniMax**: Zintegrowano MiniMax jako równorzędnego dostawcę z pełną obsługą multimodalną (czat, obraz, OCR), własnym TTS z ponad 300 dynamicznymi głosami oraz automatycznym usuwaniem bloków rozumowania (np. `<think>...</think>`) z odpowiedzi.\n"
-#~ "*   **Tłumaczenie w czytniku dokumentów**: Naprawiono ciche niepowodzenie tłumaczenia u osób korzystających z NVDA w językach innych niż angielski, dbając o to, by do Google Translate trafiał standardowy dwuliterowy kod języka zamiast zlokalizowanej nazwy.\n"
-#~ "*   **Ponawianie skanowania wsadowego PDF**: Wprowadzono zoptymalizowaną, osobną i cichą logikę ponawiania przy skanowaniu wsadowym dokumentów PDF, aby zapobiec zbędnym przesłaniom i uniknąć uciążliwych okienek z błędami podczas ponawiania.\n"
-#~ "*   **Status czytnika dokumentów**: Naprawiono błąd, przez który ogólny status dodatku (sprawdzany przez `I`) pozostawał zatrzymany na „Rozpoczęto przetwarzanie wsadowe” podczas długiego skanowania dokumentów.\n"
-#~ "*   **Naprawiona awaria wątkowania**: Naprawiono poważną awarię (`IsMain() failed in wxTimerImpl`) przy otwieraniu dokumentów z wątku działającego w tle, przenosząc kolejkę wywołań GUI na `wx.CallAfter`."
+#~ "*   **Asystent głosowy**: Dodano funkcję asystenta głosowego i ekranowego "
+#~ "w czasie rzeczywistym, dostępną wyłącznie dla dostawcy Google Gemini (lub "
+#~ "zgodnych z Gemini dostawców niestandardowych). Obejmuje interaktywną "
+#~ "zmianę głosu i głębi myślenia bezpośrednio w oknie dialogowym, z "
+#~ "automatycznym ponownym połączeniem po zmianie ustawień.\n"
+#~ "*   **Dostawca MiniMax**: Zintegrowano MiniMax jako równorzędnego "
+#~ "dostawcę z pełną obsługą multimodalną (czat, obraz, OCR), własnym TTS z "
+#~ "ponad 300 dynamicznymi głosami oraz automatycznym usuwaniem bloków "
+#~ "rozumowania (np. `<think>...</think>`) z odpowiedzi.\n"
+#~ "*   **Tłumaczenie w czytniku dokumentów**: Naprawiono ciche niepowodzenie "
+#~ "tłumaczenia u osób korzystających z NVDA w językach innych niż angielski, "
+#~ "dbając o to, by do Google Translate trafiał standardowy dwuliterowy kod "
+#~ "języka zamiast zlokalizowanej nazwy.\n"
+#~ "*   **Ponawianie skanowania wsadowego PDF**: Wprowadzono zoptymalizowaną, "
+#~ "osobną i cichą logikę ponawiania przy skanowaniu wsadowym dokumentów PDF, "
+#~ "aby zapobiec zbędnym przesłaniom i uniknąć uciążliwych okienek z błędami "
+#~ "podczas ponawiania.\n"
+#~ "*   **Status czytnika dokumentów**: Naprawiono błąd, przez który ogólny "
+#~ "status dodatku (sprawdzany przez `I`) pozostawał zatrzymany na "
+#~ "„Rozpoczęto przetwarzanie wsadowe” podczas długiego skanowania "
+#~ "dokumentów.\n"
+#~ "*   **Naprawiona awaria wątkowania**: Naprawiono poważną awarię "
+#~ "(`IsMain() failed in wxTimerImpl`) przy otwieraniu dokumentów z wątku "
+#~ "działającego w tle, przenosząc kolejkę wywołań GUI na `wx.CallAfter`."
 
 #~ msgid "Please configure Gemini API Key."
 #~ msgstr "Skonfiguruj klucz API Gemini."
@@ -4064,21 +5005,56 @@ msgstr ""
 #~ msgid ""
 #~ "## Changes for 6.1.0\n"
 #~ "\n"
-#~ "*   **Universal Local AI Integration (Setup Local AI)**: Added a new **\"Setup Local AI\"** button in Custom Provider Settings. Users can now automatically configure local AI engines, including **Ollama**, **LM Studio**, **Jan.ai**, and **KoboldCPP** instantly.\n"
-#~ "*   **Intelligent Local Proxy Bypass**: Rebuilt the connection logic with an advanced proxy bypass mechanism. The add-on is now smart enough to completely bypass Windows system proxies for local loopback connections, ensuring stable local AI connections even when your VPN/TUN-mode is active.\n"
-#~ "*   **AI Operator Emergency Cancel (Shift+A)**: Added a highly requested stop/cancel safety trigger. Pressing the AI Operator command (**Shift+A** inside the command layer) while an autonomous operation is running will instantly abort the loop and announce *\"AI Operator stopped.\"*\n"
-#~ "*   **Ultra-Stable AI Labeling (v2)**: Replaced absolute screen coordinate keys with an advanced, hybrid **Object Signature** system. Labels now rely on programmatic identifiers (UIA **AutomationId** or Win32 **ControlID**) and window-relative coordinates, making your custom labels completely resistant to window resizing, moving, "
-#~ "monitor switching, or scaling.\n"
-#~ "*   **Seamless Automatic Label Migration**: Upgrading is completely transparent. The add-on will automatically migrate your older legacy coordinate-based labels to the new stable fingerprint format in the background upon first focus, with zero data loss."
+#~ "*   **Universal Local AI Integration (Setup Local AI)**: Added a new "
+#~ "**\"Setup Local AI\"** button in Custom Provider Settings. Users can now "
+#~ "automatically configure local AI engines, including **Ollama**, **LM "
+#~ "Studio**, **Jan.ai**, and **KoboldCPP** instantly.\n"
+#~ "*   **Intelligent Local Proxy Bypass**: Rebuilt the connection logic with "
+#~ "an advanced proxy bypass mechanism. The add-on is now smart enough to "
+#~ "completely bypass Windows system proxies for local loopback connections, "
+#~ "ensuring stable local AI connections even when your VPN/TUN-mode is "
+#~ "active.\n"
+#~ "*   **AI Operator Emergency Cancel (Shift+A)**: Added a highly requested "
+#~ "stop/cancel safety trigger. Pressing the AI Operator command (**Shift+A** "
+#~ "inside the command layer) while an autonomous operation is running will "
+#~ "instantly abort the loop and announce *\"AI Operator stopped.\"*\n"
+#~ "*   **Ultra-Stable AI Labeling (v2)**: Replaced absolute screen "
+#~ "coordinate keys with an advanced, hybrid **Object Signature** system. "
+#~ "Labels now rely on programmatic identifiers (UIA **AutomationId** or "
+#~ "Win32 **ControlID**) and window-relative coordinates, making your custom "
+#~ "labels completely resistant to window resizing, moving, monitor "
+#~ "switching, or scaling.\n"
+#~ "*   **Seamless Automatic Label Migration**: Upgrading is completely "
+#~ "transparent. The add-on will automatically migrate your older legacy "
+#~ "coordinate-based labels to the new stable fingerprint format in the "
+#~ "background upon first focus, with zero data loss."
 #~ msgstr ""
 #~ "## Zmiany w wersji 6.1.0\n"
 #~ "\n"
-#~ "*   **Uniwersalna integracja lokalnej AI (Konfiguracja lokalnej AI)**: Dodano nowy przycisk **„Konfiguracja lokalnej AI”** w ustawieniach niestandardowego dostawcy. Teraz można od razu automatycznie skonfigurować lokalne silniki AI, w tym **Ollama**, **LM Studio**, **Jan.ai** i **KoboldCPP**.\n"
-#~ "*   **Ominięcie lokalnego proxy**: Przebudowano logikę połączenia z zaawansowanym mechanizmem omijania proxy. Dodatek całkowicie omija systemowe proxy Windows przy połączeniach lokalnych, dzięki czemu połączenie z lokalną AI jest stabilne nawet przy aktywnym VPN lub trybie TUN.\n"
-#~ "*   **Awaryjne zatrzymanie Operatora AI (Shift+A)**: Dodano często wyczekiwany wyzwalacz zatrzymania. Naciśnięcie polecenia Operatora AI (**Shift+A** w warstwie poleceń) podczas trwającej operacji autonomicznej natychmiast przerywa pętlę i ogłasza *„Operator AI zatrzymany.”*\n"
-#~ "*   **Bardzo stabilne etykietowanie AI (v2)**: Zastąpiono klucze oparte na bezwzględnych współrzędnych ekranu zaawansowanym, hybrydowym systemem **sygnatur obiektów**. Etykiety opierają się teraz na identyfikatorach programowych (UIA **AutomationId** lub Win32 **ControlID**) oraz współrzędnych względem okna, dzięki czemu są "
-#~ "całkowicie odporne na zmianę rozmiaru, przesuwanie, zmianę monitora czy skalowanie okna.\n"
-#~ "*   **Płynna automatyczna migracja etykiet**: Aktualizacja jest całkowicie przezroczysta. Dodatek automatycznie przeniesie starsze etykiety oparte na współrzędnych do nowego, stabilnego formatu sygnatur w tle przy pierwszym ustawieniu fokusu, bez utraty danych."
+#~ "*   **Uniwersalna integracja lokalnej AI (Konfiguracja lokalnej AI)**: "
+#~ "Dodano nowy przycisk **„Konfiguracja lokalnej AI”** w ustawieniach "
+#~ "niestandardowego dostawcy. Teraz można od razu automatycznie "
+#~ "skonfigurować lokalne silniki AI, w tym **Ollama**, **LM Studio**, "
+#~ "**Jan.ai** i **KoboldCPP**.\n"
+#~ "*   **Ominięcie lokalnego proxy**: Przebudowano logikę połączenia z "
+#~ "zaawansowanym mechanizmem omijania proxy. Dodatek całkowicie omija "
+#~ "systemowe proxy Windows przy połączeniach lokalnych, dzięki czemu "
+#~ "połączenie z lokalną AI jest stabilne nawet przy aktywnym VPN lub trybie "
+#~ "TUN.\n"
+#~ "*   **Awaryjne zatrzymanie Operatora AI (Shift+A)**: Dodano często "
+#~ "wyczekiwany wyzwalacz zatrzymania. Naciśnięcie polecenia Operatora AI "
+#~ "(**Shift+A** w warstwie poleceń) podczas trwającej operacji autonomicznej "
+#~ "natychmiast przerywa pętlę i ogłasza *„Operator AI zatrzymany.”*\n"
+#~ "*   **Bardzo stabilne etykietowanie AI (v2)**: Zastąpiono klucze oparte "
+#~ "na bezwzględnych współrzędnych ekranu zaawansowanym, hybrydowym systemem "
+#~ "**sygnatur obiektów**. Etykiety opierają się teraz na identyfikatorach "
+#~ "programowych (UIA **AutomationId** lub Win32 **ControlID**) oraz "
+#~ "współrzędnych względem okna, dzięki czemu są całkowicie odporne na zmianę "
+#~ "rozmiaru, przesuwanie, zmianę monitora czy skalowanie okna.\n"
+#~ "*   **Płynna automatyczna migracja etykiet**: Aktualizacja jest "
+#~ "całkowicie przezroczysta. Dodatek automatycznie przeniesie starsze "
+#~ "etykiety oparte na współrzędnych do nowego, stabilnego formatu sygnatur w "
+#~ "tle przy pierwszym ustawieniu fokusu, bez utraty danych."
 
 #~ msgid "Copy USDT (TRC20) Address"
 #~ msgstr "Kopiuj adres USDT (TRC20)"
@@ -4108,80 +5084,191 @@ msgstr ""
 #~ msgid ""
 #~ "## Changes for 5.6\n"
 #~ "\n"
-#~ "*   **Added \"None (Extract Text Layer)\" OCR Engine**: Users can now extract text directly from searchable PDFs without using AI credits, significantly improving speed and privacy for text-based documents.\n"
-#~ "*   **Refined UI Explorer Accuracy**: Improved the UI Explorer prompt to better identify element types (like List Items) and accurately report states such as \"(Checked)\", \"(Selected)\", or \"(Expanded)\" while ignoring Windows system components like the Taskbar and Clock.\n"
-#~ "*   **Installation Setup Reminder**: Added a notification after installation to guide users to the settings menu for configuring their API keys and preferences."
+#~ "*   **Added \"None (Extract Text Layer)\" OCR Engine**: Users can now "
+#~ "extract text directly from searchable PDFs without using AI credits, "
+#~ "significantly improving speed and privacy for text-based documents.\n"
+#~ "*   **Refined UI Explorer Accuracy**: Improved the UI Explorer prompt to "
+#~ "better identify element types (like List Items) and accurately report "
+#~ "states such as \"(Checked)\", \"(Selected)\", or \"(Expanded)\" while "
+#~ "ignoring Windows system components like the Taskbar and Clock.\n"
+#~ "*   **Installation Setup Reminder**: Added a notification after "
+#~ "installation to guide users to the settings menu for configuring their "
+#~ "API keys and preferences."
 #~ msgstr ""
 #~ "## Zmiany w wersji 5.6\n"
 #~ "\n"
-#~ "*   **Dodano silnik OCR „Wyodrębnij tekst (offline)”**: Teraz można wyodrębniać tekst bezpośrednio z plików PDF z warstwą tekstową, bez zużywania kredytów AI, co daje znaczne przyspieszenie i większą prywatność dokumentów tekstowych.\n"
-#~ "*   **Lepsza dokładność Eksploratora interfejsu**: Ulepszono prompt eksploratora, by trafniej rozpoznawał typy elementów (np. element listy) i precyzyjnie raportował stany takie jak „(zaznaczony)”, „(wybrany)” albo „(rozwinięty)”, pomijając jednocześnie komponenty systemu Windows jak pasek zadań i zegar.\n"
-#~ "*   **Przypomnienie o konfiguracji po instalacji**: Dodano powiadomienie po instalacji, które prowadzi do menu ustawień, by skonfigurować klucze API i preferencje."
+#~ "*   **Dodano silnik OCR „Wyodrębnij tekst (offline)”**: Teraz można "
+#~ "wyodrębniać tekst bezpośrednio z plików PDF z warstwą tekstową, bez "
+#~ "zużywania kredytów AI, co daje znaczne przyspieszenie i większą "
+#~ "prywatność dokumentów tekstowych.\n"
+#~ "*   **Lepsza dokładność Eksploratora interfejsu**: Ulepszono prompt "
+#~ "eksploratora, by trafniej rozpoznawał typy elementów (np. element listy) "
+#~ "i precyzyjnie raportował stany takie jak „(zaznaczony)”, „(wybrany)” albo "
+#~ "„(rozwinięty)”, pomijając jednocześnie komponenty systemu Windows jak "
+#~ "pasek zadań i zegar.\n"
+#~ "*   **Przypomnienie o konfiguracji po instalacji**: Dodano powiadomienie "
+#~ "po instalacji, które prowadzi do menu ustawień, by skonfigurować klucze "
+#~ "API i preferencje."
 
 #~ msgid ""
 #~ "## Changes for 6.0\n"
 #~ "\n"
-#~ "*   **Introducing Semantic AI Labeling**: Users can now permanently label unnamed buttons and icons using AI. Press **L** to label the current navigator object (supporting both Tab focus and object navigation) or **Shift+L** to scan and label the entire application at once.\n"
-#~ "*   **Intelligent Label Management**: Added a new, fully accessible Label Manager dialog (via **Shift+L** if labels exist) to view, rename, or batch-delete custom labels.\n"
-#~ "*   **Direct File Analysis (Bypass File Dialog)**: The add-on is now smart enough to detect if you are currently focusing on a PDF or image file in Windows File Explorer. Pressing **F (Smart File Action)** or **D (Document Reader)** on a highlighted file will immediately process it, bypassing the standard \"Open\" dialog entirely."
+#~ "*   **Introducing Semantic AI Labeling**: Users can now permanently label "
+#~ "unnamed buttons and icons using AI. Press **L** to label the current "
+#~ "navigator object (supporting both Tab focus and object navigation) or "
+#~ "**Shift+L** to scan and label the entire application at once.\n"
+#~ "*   **Intelligent Label Management**: Added a new, fully accessible Label "
+#~ "Manager dialog (via **Shift+L** if labels exist) to view, rename, or "
+#~ "batch-delete custom labels.\n"
+#~ "*   **Direct File Analysis (Bypass File Dialog)**: The add-on is now "
+#~ "smart enough to detect if you are currently focusing on a PDF or image "
+#~ "file in Windows File Explorer. Pressing **F (Smart File Action)** or **D "
+#~ "(Document Reader)** on a highlighted file will immediately process it, "
+#~ "bypassing the standard \"Open\" dialog entirely."
 #~ msgstr ""
 #~ "## Lista zmian w wersji 6.0\n"
 #~ "\n"
-#~ "*   **etykietowanie AI**: Teraz można trwale nadawać etykiety nienazwanym przyciskom i ikonom za pomocą AI. Naciśnij **L**, by oznaczyć bieżący obiekt nawigatora (obsługa zarówno fokusu Tab, jak i nawigacji obiektowej), lub **Shift+L**, by przeskanować i oznaczyć całą aplikację naraz.\n"
-#~ "*   **Zarządzanie etykietami**: Nowe, w pełni dostępne okno Menedżera etykiet (przez **Shift+L**, jeśli etykiety istnieją) pozwala przeglądać, zmieniać nazwy i zbiorczo usuwać etykiety.\n"
-#~ "*   **Bezpośrednia analiza pliku (z pominięciem okna dialogowego)**: Dodatek wykrywa, czy fokus znajduje się na pliku PDF lub graficznym w Eksploratorze Windows. Naciśnięcie **F (Akcja na pliku)** lub **D (Czytnik dokumentów)** na zaznaczonym pliku natychmiast go przetworzy, pomijając standardowe okno „Otwórz\"."
+#~ "*   **etykietowanie AI**: Teraz można trwale nadawać etykiety nienazwanym "
+#~ "przyciskom i ikonom za pomocą AI. Naciśnij **L**, by oznaczyć bieżący "
+#~ "obiekt nawigatora (obsługa zarówno fokusu Tab, jak i nawigacji "
+#~ "obiektowej), lub **Shift+L**, by przeskanować i oznaczyć całą aplikację "
+#~ "naraz.\n"
+#~ "*   **Zarządzanie etykietami**: Nowe, w pełni dostępne okno Menedżera "
+#~ "etykiet (przez **Shift+L**, jeśli etykiety istnieją) pozwala przeglądać, "
+#~ "zmieniać nazwy i zbiorczo usuwać etykiety.\n"
+#~ "*   **Bezpośrednia analiza pliku (z pominięciem okna dialogowego)**: "
+#~ "Dodatek wykrywa, czy fokus znajduje się na pliku PDF lub graficznym w "
+#~ "Eksploratorze Windows. Naciśnięcie **F (Akcja na pliku)** lub **D "
+#~ "(Czytnik dokumentów)** na zaznaczonym pliku natychmiast go przetworzy, "
+#~ "pomijając standardowe okno „Otwórz\"."
 
 #~ msgid ""
 #~ "## Changes for 5.5.2\n"
 #~ "\n"
-#~ "*   **Fixed AI Operator Typing Issue:** Resolved a bug where the letter 'v' was typed instead of pasting text on certain systems. This fix addresses timing conflicts that occurred during high system load.\n"
-#~ "*   **Enhanced Stability:** Added robust error handling for clipboard operations to prevent addon crashes when the system clipboard is temporarily locked by other applications.\n"
-#~ "*   **Timing Optimization:** Adjusted internal delays for keyboard events to ensure higher reliability across different system speeds and better compatibility with third-party Clipboard Managers."
+#~ "*   **Fixed AI Operator Typing Issue:** Resolved a bug where the letter "
+#~ "'v' was typed instead of pasting text on certain systems. This fix "
+#~ "addresses timing conflicts that occurred during high system load.\n"
+#~ "*   **Enhanced Stability:** Added robust error handling for clipboard "
+#~ "operations to prevent addon crashes when the system clipboard is "
+#~ "temporarily locked by other applications.\n"
+#~ "*   **Timing Optimization:** Adjusted internal delays for keyboard events "
+#~ "to ensure higher reliability across different system speeds and better "
+#~ "compatibility with third-party Clipboard Managers."
 #~ msgstr ""
 #~ "## Zmiany w 5.5.2\n"
 #~ "\n"
-#~ "*   **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w którym litera „v\" była wpisywana zamiast wklejania tekstu na niektórych systemach. Poprawka usuwa konflikty czasowe występujące przy dużym obciążeniu systemu.\n"
-#~ "*   **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest tymczasowo zablokowany przez inne aplikacje.\n"
-#~ "*   **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami schowka."
+#~ "*   **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w "
+#~ "którym litera „v\" była wpisywana zamiast wklejania tekstu na niektórych "
+#~ "systemach. Poprawka usuwa konflikty czasowe występujące przy dużym "
+#~ "obciążeniu systemu.\n"
+#~ "*   **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na "
+#~ "schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest "
+#~ "tymczasowo zablokowany przez inne aplikacje.\n"
+#~ "*   **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia "
+#~ "zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych "
+#~ "prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami "
+#~ "schowka."
 
 #~ msgid ""
 #~ "## Changes for 5.5.2\n"
 #~ "\n"
-#~ "*   **Fixed AI Operator Typing Issue:** Resolved a bug where the letter 'v' was typed instead of pasting text on certain systems. This fix addresses timing conflicts that occurred during high system load.\n"
-#~ "*   **Enhanced Stability:** Added robust error handling for clipboard operations to prevent addon crashes when the system clipboard is temporarily locked by other applications.\n"
-#~ "*   **Timing Optimization:** Adjusted internal delays for keyboard events to ensure higher reliability across different system speeds and better compatibility with third-party Clipboard Managers.\n"
+#~ "*   **Fixed AI Operator Typing Issue:** Resolved a bug where the letter "
+#~ "'v' was typed instead of pasting text on certain systems. This fix "
+#~ "addresses timing conflicts that occurred during high system load.\n"
+#~ "*   **Enhanced Stability:** Added robust error handling for clipboard "
+#~ "operations to prevent addon crashes when the system clipboard is "
+#~ "temporarily locked by other applications.\n"
+#~ "*   **Timing Optimization:** Adjusted internal delays for keyboard events "
+#~ "to ensure higher reliability across different system speeds and better "
+#~ "compatibility with third-party Clipboard Managers.\n"
 #~ "\n"
 #~ "## Changes for 5.5 (The Automation Update)\n"
 #~ "\n"
-#~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown jewel of v5.5. Vision Assistant Pro has graduated from being a passive assistant to becoming your personal **AI Operator**. It doesn't just describe the screen—it takes command.\n"
-#~ "    *   *How it works:* You can now give verbal instructions to operate your PC. For example, in a completely inaccessible application where your screen reader stays silent, you can press **Shift+A** and type: *\"Click on the Settings button\"* or *\"Find the search field, type 'Latest News' and press enter.\"* The AI visually "
-#~ "identifies the elements, moves the mouse, and executes the task for you.\n"
-#~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 Flash (Preview)**, delivering incredibly fast and intelligent responses that can handle even the most complex UI layouts.\n"
-#~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" exactly what's happening to be accurate, it sends a high-resolution screenshot with every step. Please note that frequent use will consume your API quota much faster than standard text-based tasks.\n"
-#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled buttons\"? Press **E** to activate the UI Explorer. The AI will scan the entire window and generate a list of every clickable element it sees—including icons, graphics, and menus. Simply pick an item from the list, and the AI Operator will click it for you. "
-#~ "It's like having an \"accessible layer\" on top of any app.\n"
-#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been completely overhauled. It no longer assumes you only want OCR. When you select a single image, it now intelligently asks for your intent: you can choose a **Detailed Visual Description** to understand the scene or a **Structured Text Extraction (OCR)** for "
-#~ "reading. The menu adapts dynamically based on the file type and your active AI engine.\n"
-#~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on's internal logic, removing unused legacy functions and redundant code. This results in a leaner, faster, and more reliable experience for all users."
+#~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown "
+#~ "jewel of v5.5. Vision Assistant Pro has graduated from being a passive "
+#~ "assistant to becoming your personal **AI Operator**. It doesn't just "
+#~ "describe the screen—it takes command.\n"
+#~ "    *   *How it works:* You can now give verbal instructions to operate "
+#~ "your PC. For example, in a completely inaccessible application where your "
+#~ "screen reader stays silent, you can press **Shift+A** and type: *\"Click "
+#~ "on the Settings button\"* or *\"Find the search field, type 'Latest News' "
+#~ "and press enter.\"* The AI visually identifies the elements, moves the "
+#~ "mouse, and executes the task for you.\n"
+#~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 "
+#~ "Flash (Preview)**, delivering incredibly fast and intelligent responses "
+#~ "that can handle even the most complex UI layouts.\n"
+#~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" "
+#~ "exactly what's happening to be accurate, it sends a high-resolution "
+#~ "screenshot with every step. Please note that frequent use will consume "
+#~ "your API quota much faster than standard text-based tasks.\n"
+#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled "
+#~ "buttons\"? Press **E** to activate the UI Explorer. The AI will scan the "
+#~ "entire window and generate a list of every clickable element it sees—"
+#~ "including icons, graphics, and menus. Simply pick an item from the list, "
+#~ "and the AI Operator will click it for you. It's like having an "
+#~ "\"accessible layer\" on top of any app.\n"
+#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been "
+#~ "completely overhauled. It no longer assumes you only want OCR. When you "
+#~ "select a single image, it now intelligently asks for your intent: you can "
+#~ "choose a **Detailed Visual Description** to understand the scene or a "
+#~ "**Structured Text Extraction (OCR)** for reading. The menu adapts "
+#~ "dynamically based on the file type and your active AI engine.\n"
+#~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on's "
+#~ "internal logic, removing unused legacy functions and redundant code. This "
+#~ "results in a leaner, faster, and more reliable experience for all users."
 #~ msgstr ""
 #~ "## Zmiany w 5.5.2\n"
 #~ "\n"
-#~ "*   **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w którym litera „v\" była wpisywana zamiast wklejania tekstu na niektórych systemach. Poprawka usuwa konflikty czasowe występujące przy dużym obciążeniu systemu.\n"
-#~ "*   **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest tymczasowo zablokowany przez inne aplikacje.\n"
-#~ "*   **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami schowka.\n"
+#~ "*   **Naprawa błędu wpisywania w Operatorze AI:** Rozwiązano błąd, w "
+#~ "którym litera „v\" była wpisywana zamiast wklejania tekstu na niektórych "
+#~ "systemach. Poprawka usuwa konflikty czasowe występujące przy dużym "
+#~ "obciążeniu systemu.\n"
+#~ "*   **Większa stabilność:** Dodano solidną obsługę błędów dla operacji na "
+#~ "schowku, aby zapobiec awariom dodatku, gdy schowek systemowy jest "
+#~ "tymczasowo zablokowany przez inne aplikacje.\n"
+#~ "*   **Optymalizacja czasu reakcji:** Dostosowano wewnętrzne opóźnienia "
+#~ "zdarzeń klawiatury w celu zapewnienia większej niezawodności na różnych "
+#~ "prędkościach systemowych i lepszej zgodności z zewnętrznymi menedżerami "
+#~ "schowka.\n"
 #~ "\n"
 #~ "## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
 #~ "\n"
-#~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.\n"
-#~ "    *   *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* "
-#~ "AI wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
-#~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.\n"
-#~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi „widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.\n"
-#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po „nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak "
-#~ "„warstwa dostępności\" nałożona na dowolną aplikację.\n"
-#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz „F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** "
-#~ "do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
-#~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla wszystkich użytkowników."
+#~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w "
+#~ "koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w "
+#~ "Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz "
+#~ "przejmuje sterowanie.\n"
+#~ "    *   *Jak to działa:* Możesz teraz wydawać AI instrukcje słowne, aby "
+#~ "obsługiwała Twój komputer. Na przykład w całkowicie niedostępnej "
+#~ "aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i "
+#~ "wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole "
+#~ "wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI "
+#~ "wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za "
+#~ "Ciebie.\n"
+#~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini "
+#~ "3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych "
+#~ "odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami "
+#~ "interfejsu.\n"
+#~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi "
+#~ "„widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła "
+#~ "zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie "
+#~ "znacznie szybciej zużyje Twój limit API niż standardowe zadania "
+#~ "tekstowe.\n"
+#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po "
+#~ "„nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator "
+#~ "interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego "
+#~ "klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z "
+#~ "listy, a Operator AI kliknie go za Ciebie. To jak „warstwa dostępności\" "
+#~ "nałożona na dowolną aplikację.\n"
+#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz "
+#~ "„F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko "
+#~ "OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją "
+#~ "intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć "
+#~ "scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu "
+#~ "dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
+#~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie "
+#~ "wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny "
+#~ "kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla "
+#~ "wszystkich użytkowników."
 
 #~ msgid "Default (Auto)"
 #~ msgstr "Domyślny (auto)"
@@ -4195,29 +5282,77 @@ msgstr ""
 #~ msgid ""
 #~ "## Changes for 5.5 (The Automation Update)\n"
 #~ "\n"
-#~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown jewel of v5.5. Vision Assistant Pro has graduated from being a passive assistant to becoming your personal **AI Operator**. It doesn't just describe the screen—it takes command.\n"
-#~ "    *   *How it works:* You can now give verbal instructions to operate your PC. For example, in a completely inaccessible application where your screen reader stays silent, you can press **Shift+A** and type: *\"Click on the Settings button\"* or *\"Find the search field, type 'Latest News' and press enter.\"* The AI visually "
-#~ "identifies the elements, moves the mouse, and executes the task for you.\n"
-#~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 Flash (Preview)**, delivering incredibly fast and intelligent responses that can handle even the most complex UI layouts.\n"
-#~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" exactly what's happening to be accurate, it sends a high-resolution screenshot with every step. Please note that frequent use will consume your API quota much faster than standard text-based tasks.\n"
-#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled buttons\"? Press **E** to activate the UI Explorer. The AI will scan the entire window and generate a list of every clickable element it sees—including icons, graphics, and menus. Simply pick an item from the list, and the AI Operator will click it for you. "
-#~ "It’s like having an \"accessible layer\" on top of any app.\n"
-#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been completely overhauled. It no longer assumes you only want OCR. When you select a single image, it now intelligently asks for your intent: you can choose a **Detailed Visual Description** to understand the scene or a **Structured Text Extraction (OCR)** for "
-#~ "reading. The menu adapts dynamically based on the file type and your active AI engine.\n"
-#~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on’s internal logic, removing unused legacy functions and redundant code. This results in a leaner, faster, and more reliable experience for all users."
+#~ "*   **AI Operator (Autonomous Control - Shift+A):** This is the crown "
+#~ "jewel of v5.5. Vision Assistant Pro has graduated from being a passive "
+#~ "assistant to becoming your personal **AI Operator**. It doesn't just "
+#~ "describe the screen—it takes command.\n"
+#~ "    *   *How it works:* You can now give verbal instructions to operate "
+#~ "your PC. For example, in a completely inaccessible application where your "
+#~ "screen reader stays silent, you can press **Shift+A** and type: *\"Click "
+#~ "on the Settings button\"* or *\"Find the search field, type 'Latest News' "
+#~ "and press enter.\"* The AI visually identifies the elements, moves the "
+#~ "mouse, and executes the task for you.\n"
+#~ "    *   *Performance Note:* This feature is optimized for **Gemini 3.0 "
+#~ "Flash (Preview)**, delivering incredibly fast and intelligent responses "
+#~ "that can handle even the most complex UI layouts.\n"
+#~ "    *   **⚠️ API Usage Warning:** Because the AI Operator needs to \"see\" "
+#~ "exactly what's happening to be accurate, it sends a high-resolution "
+#~ "screenshot with every step. Please note that frequent use will consume "
+#~ "your API quota much faster than standard text-based tasks.\n"
+#~ "*   **Visual UI Explorer (E):** Tired of navigating through \"unlabeled "
+#~ "buttons\"? Press **E** to activate the UI Explorer. The AI will scan the "
+#~ "entire window and generate a list of every clickable element it sees—"
+#~ "including icons, graphics, and menus. Simply pick an item from the list, "
+#~ "and the AI Operator will click it for you. It’s like having an "
+#~ "\"accessible layer\" on top of any app.\n"
+#~ "*   **Context-Aware Smart File Action (F):** The \"F\" key has been "
+#~ "completely overhauled. It no longer assumes you only want OCR. When you "
+#~ "select a single image, it now intelligently asks for your intent: you can "
+#~ "choose a **Detailed Visual Description** to understand the scene or a "
+#~ "**Structured Text Extraction (OCR)** for reading. The menu adapts "
+#~ "dynamically based on the file type and your active AI engine.\n"
+#~ "*   **Core Optimization:** We've performed a deep cleanup of the add-on’s "
+#~ "internal logic, removing unused legacy functions and redundant code. This "
+#~ "results in a leaner, faster, and more reliable experience for all users."
 #~ msgstr ""
 #~ "## Zmiany w 5.5 (Aktualizacja automatyzacji)\n"
 #~ "\n"
-#~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz przejmuje sterowanie.\n"
-#~ "    *   *Jak to działa:* Możesz teraz wydawać polecenia głosowe dla obsługi swojego komputera. Na przykład w całkowicie niedostępnej aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI "
-#~ "wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za Ciebie.\n"
-#~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini 3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami interfejsu.\n"
-#~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi \"widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie znacznie szybciej zużyje Twój limit API niż standardowe zadania tekstowe.\n"
-#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po \"nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z listy, a Operator AI kliknie go za Ciebie. To jak "
-#~ "\"warstwa dostępności\" nałożona na dowolną aplikację.\n"
-#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz \"F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** "
-#~ "do czytania. Menu dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
-#~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla wszystkich użytkowników."
+#~ "*   **Operator AI (Sterowanie autonomiczne - Shift+A):** To perła w "
+#~ "koronie wersji 5.5. Vision Assistant Pro przeszedł z biernego asystenta w "
+#~ "Twojego osobistego **Operatora AI**. Nie tylko opisuje ekran, lecz "
+#~ "przejmuje sterowanie.\n"
+#~ "    *   *Jak to działa:* Możesz teraz wydawać polecenia głosowe dla "
+#~ "obsługi swojego komputera. Na przykład w całkowicie niedostępnej "
+#~ "aplikacji, gdzie czytnik ekranu milczy, możesz nacisnąć **Shift+A** i "
+#~ "wpisać: *\"Kliknij przycisk Ustawienia\"* lub *\"Znajdź pole "
+#~ "wyszukiwania, wpisz 'Najnowsze wiadomości' i naciśnij enter.\"* AI "
+#~ "wizualnie identyfikuje elementy, przesuwa kursor i wykonuje zadanie za "
+#~ "Ciebie.\n"
+#~ "    *   *Uwaga o wydajności:* Funkcja jest zoptymalizowana dla **Gemini "
+#~ "3.0 Flash (Preview)**, dostarczając niezwykle szybkich i inteligentnych "
+#~ "odpowiedzi, które poradzą sobie nawet z najbardziej złożonymi układami "
+#~ "interfejsu.\n"
+#~ "    *   **⚠️ Ostrzeżenie o zużyciu API:** Ponieważ Operator AI musi "
+#~ "\"widzieć\" dokładnie to, co się dzieje, aby działać precyzyjnie, wysyła "
+#~ "zrzut ekranu w wysokiej rozdzielczości na każdym kroku. Częste używanie "
+#~ "znacznie szybciej zużyje Twój limit API niż standardowe zadania "
+#~ "tekstowe.\n"
+#~ "*   **Wizualny Eksplorator interfejsu (E):** Zmęczony nawigacją po "
+#~ "\"nieoznaczonych przyciskach\"? Naciśnij **E**, aby uruchomić Eksplorator "
+#~ "interfejsu. AI przeskanuje całe okno i wygeneruje listę każdego "
+#~ "klikalnego elementu, jaki widzi: ikon, grafik i menu. Wybierz element z "
+#~ "listy, a Operator AI kliknie go za Ciebie. To jak \"warstwa dostępności\" "
+#~ "nałożona na dowolną aplikację.\n"
+#~ "*   **Inteligentna akcja na pliku zależna od kontekstu (F):** Klawisz "
+#~ "\"F\" został gruntownie przebudowany. Nie zakłada już, że chcesz tylko "
+#~ "OCR. Gdy wybierzesz pojedynczy obraz, inteligentnie zapyta o Twoją "
+#~ "intencję: możesz wybrać **Szczegółowy opis wizualny**, aby zrozumieć "
+#~ "scenę, lub **Strukturalne wyodrębnienie tekstu (OCR)** do czytania. Menu "
+#~ "dostosowuje się dynamicznie do typu pliku i aktywnego silnika AI.\n"
+#~ "*   **Optymalizacja rdzenia:** Wykonaliśmy głębokie czyszczenie "
+#~ "wewnętrznej logiki dodatku, usuwając nieużywane funkcje legacy i zbędny "
+#~ "kod. Daje to lżejsze, szybsze i bardziej niezawodne działanie dla "
+#~ "wszystkich użytkowników."
 
 #~ msgid "Action performed"
 #~ msgstr "Akcja wykonana"


### PR DESCRIPTION
Polish (pl) translation updated for version 2026.09.01, per the call for translations in #287.

**addon/locale/pl/LC_MESSAGES/nvda.po**
- 65 entries translated: 41 new strings and 24 that arrived fuzzy.
- All fuzzy suggestions were reviewed individually and rejected where msgmerge had carried over the translation of a different string.
- Verified: msgfmt --check passes, 0 fuzzy, 0 untranslated, no existing translation altered.

**addon/doc/pl/readme.md**
- New sections translated: Live Assistant tab, Settings Backup & Restore, Chat & History (with chat window shortcuts and the History dialog), Recent Documents, Custom Prompt Shortcuts, and the rewritten Document Reader intro with its How It Works steps.
- Section 7.3 completed: the Buttons & Controls list and cursor page navigation were missing.
- Section 9: Push to Talk entry added.
- Whole document renumbered to match the English structure (main sections 3-12 shifted to 4-13, and subsections accordingly). No in-text cross-references to section numbers exist, so nothing was broken by this.
- Changelog for 2026.09.01 translated.

Thank you for the detailed call and the ready-made template.